### PR TITLE
Add tutorial about docker-compose services via systemd service templates

### DIFF
--- a/tutorials/DockerComposeAsSystemdService.md
+++ b/tutorials/DockerComposeAsSystemdService.md
@@ -96,7 +96,8 @@ Since in the service template we configured it to pull and build our images on a
 echo '0  4    * * *   root    /bin/systemctl reload docker-compose@*.service' >> /etc/crontab
 ```
 
-Please note that this only works as intended in combination with 'watchtower' as shown above as new images will not automatically be used.
+Please note that this only works as intended in combination with watchtower as shown above in step 1 as new images will not automatically be used.
+When the systemd service is reloaded Docker Compose will pull and build new images. Watchtower will then automatically pick up those new images and restart the according containers with the new images.  
 
 ## Step 4 - Start Docker services
 

--- a/tutorials/DockerComposeAsSystemdService.md
+++ b/tutorials/DockerComposeAsSystemdService.md
@@ -1,3 +1,16 @@
+---
+path: "/community/tutorials/DockerComposeAsSystemdService"
+date: "2019-03-07"
+title: "Run multiple Docker Compose services on Debian/Ubuntu"
+short_description: "This tutorial will show you how you can run multiple Docker Compose services via a systemd service template."
+tags: ["Hetzner Official", "Docker"]
+views: "100"
+author: "Bernd Stellwag"
+author_img: "https://avatars0.githubusercontent.com/u/16883833?s=400&v=4"
+author_description: ""
+header_img: ""
+---
+
 # Run multiple Docker Compose services on Debian/Ubuntu
 
 ## Introduction

--- a/tutorials/DockerComposeAsSystemdService.md
+++ b/tutorials/DockerComposeAsSystemdService.md
@@ -42,7 +42,7 @@ services:
 ```
 
 For more info about the options specified under `command` take a look at [watchtower](https://hub.docker.com/r/v2tec/watchtower/).
-Here we specify that old images should new removed after updating to a new image (`--cleanup`).
+Here we specify that old images should be removed after updating to a new image (`--cleanup`).
 We also tell watchtower that it should not check for newer images itself (`--no-pull`). That is because it's actually recommended to use this option if you are building your own images (without pushing them to the Docker Registry). We will take care of pulling new images regularly later. If you don't plan on building your own images then you can just omit `--no-pull` and also skip step 3.
 
 ## Step 2 - Create the systemd service template

--- a/tutorials/DockerComposeAsSystemdService.md
+++ b/tutorials/DockerComposeAsSystemdService.md
@@ -1,0 +1,111 @@
+# Run multiple docker-compose services on Debian/Ubuntu
+
+## Introduction
+This tutorial will show you how you can run multiple docker-compose services via a systemd service template.
+
+### Prerequisites
+* Server with Debian/Ubuntu
+* Docker already installed and running
+  * [Tutorial for Debian](https://docs.docker.com/install/linux/docker-ce/debian/)
+  * [Tutorial for Ubuntu](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
+* `docker-compose` installed at `/usr/local/bin/docker-compose` as instructed in the [official tutorial](https://docs.docker.com/compose/install/) (otherwise you may need to adapt the path in the examples)
+
+## Steps
+
+### Create docker-compose files
+
+For this tutorial we will store our docker-compose service configurations under `/etc/docker-compose`.
+
+```bash
+mkdir /etc/docker-compose
+```
+
+Just as an example, let's say we want to run [watchtower](https://hub.docker.com/r/v2tec/watchtower/) to keep our running containers up to date. We have to create a directory for that service in `/etc/docker-compose`:
+
+```bash
+mkdir /etc/docker-compose/watchtower
+```
+
+And we need the according docker-compose file at `/etc/docker-compose/watchtower/docker-compose.yml`:
+
+```
+version: "3"
+
+services:
+  watchtower:
+    image: v2tec/watchtower
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --cleanup --no-pull
+```
+
+### Create the systemd service template
+
+Now we create the [systemd service template](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Service%20Templates) at `/etc/systemd/system/docker-compose@.service`:
+
+```
+[Unit]
+Description=docker-compose %i service
+Requires=docker.service network-online.target
+After=docker.service network-online.target
+
+[Service]
+WorkingDirectory=/etc/docker-compose/%i
+Type=simple
+TimeoutStartSec=15min
+Restart=always
+
+ExecStartPre=/usr/local/bin/docker-compose pull --quiet --ignore-pull-failures
+ExecStartPre=/usr/local/bin/docker-compose build --pull
+
+ExecStart=/usr/local/bin/docker-compose up --remove-orphans
+
+ExecStop=/usr/local/bin/docker-compose down --remove-orphans
+
+ExecReload=/usr/local/bin/docker-compose pull --quiet --ignore-pull-failures
+ExecReload=/usr/local/bin/docker-compose build --pull
+
+[Install]
+WantedBy=multi-user.target
+```
+
+This service template will:
+* try to pull new versions of the used docker images on startup and reload of the systemd service
+* try to build the images if it's configured this way in the `docker-compose.yml` on startup and reload of the systemd service
+* remove orphan containers (e.g. after you changed a containers name or removed a container from the `docker-compose.yml`)
+
+If you wonder why the start timeout is a bit long, some docker images may need some time to be built which is done when starting the service.
+
+Now we make systemd reload the service files:
+
+```bash
+systemctl daemon-reload
+```
+
+Since in the service template we configured it to pull and build our images on a reload of the systemd service we can also create a cronjob for this so we will regularly pull/build new images:
+
+```bash
+echo '0  4    * * *   root    /bin/systemctl reload docker-compose@*.service' >> /etc/crontab
+```
+
+Please note that this only works as intended in combination with 'watchtower' as shown above as new images will not automatically be used. 
+
+With this setup we can now start a docker-compose service (in this case 'watchtower'):
+
+```bash
+systemctl start docker-compose@watchtower
+```
+
+And enable it to start on boot:
+
+```bash
+systemctl enable docker-compose@watchtower
+```
+
+## Conclusion
+You have now setup an environment where you can easily start different docker-compose services as systemd services. For each additional service you just need to:
+* create the according `/etc/docker-compose/servicename` directory
+* create at least a `/etc/docker-compose/servicename/docker-compose.yml` file (and whatever else you need for the service)
+* start the service via `systemctl start docker-compose@servicename`
+* (optional) start the service on boot with `systemctl enable docker-compose@servicename`

--- a/tutorials/DockerComposeAsSystemdService.md
+++ b/tutorials/DockerComposeAsSystemdService.md
@@ -6,6 +6,8 @@ This tutorial will show you how you can run multiple Docker Compose services via
 
 **Prerequisites**
 * Server with Debian/Ubuntu
+  * [Tutorial for Debian](https://www.debian.org/releases/stable/amd64/)
+  * [Tutorial for Ubuntu](https://help.ubuntu.com/lts/installation-guide/amd64/index.html)
 * Docker already installed and running
   * [Tutorial for Debian](https://docs.docker.com/install/linux/docker-ce/debian/)
   * [Tutorial for Ubuntu](https://docs.docker.com/install/linux/docker-ce/ubuntu/)

--- a/tutorials/DockerComposeAsSystemdService.md
+++ b/tutorials/DockerComposeAsSystemdService.md
@@ -41,6 +41,10 @@ services:
     command: --cleanup --no-pull
 ```
 
+For more info about the options specified under `command` take a look at [watchtower](https://hub.docker.com/r/v2tec/watchtower/).
+Here we specify that old images should new removed after updating to a new image (`--cleanup`).
+We also tell watchtower that it should not check for newer images itself (`--no-pull`). That is because it's actually recommended to use this option if you are building your own images (without pushing them to the Docker Registry). We will take care of pulling new images regularly later. If you don't plan on building your own images then you can just omit `--no-pull` and also skip step 3.
+
 ## Step 2 - Create the systemd service template
 
 Now we create the [systemd service template](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Service%20Templates) at `/etc/systemd/system/docker-compose@.service`:

--- a/tutorials/DockerComposeAsSystemdService.md
+++ b/tutorials/DockerComposeAsSystemdService.md
@@ -1,18 +1,17 @@
 # Run multiple Docker Compose services on Debian/Ubuntu
 
 ## Introduction
+
 This tutorial will show you how you can run multiple Docker Compose services via a systemd service template.
 
-### Prerequisites
+**Prerequisites**
 * Server with Debian/Ubuntu
 * Docker already installed and running
   * [Tutorial for Debian](https://docs.docker.com/install/linux/docker-ce/debian/)
   * [Tutorial for Ubuntu](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
 * Docker Compose installed at `/usr/local/bin/docker-compose` as instructed in the [official tutorial](https://docs.docker.com/compose/install/) (otherwise you may need to adapt the path in the examples)
 
-## Steps
-
-### Create Docker Compose files
+## Step 1 - Create Docker Compose files
 
 For this tutorial we will store our Docker Compose service configurations under `/etc/docker-compose`.
 
@@ -40,7 +39,7 @@ services:
     command: --cleanup --no-pull
 ```
 
-### Create the systemd service template
+## Step 2 - Create the systemd service template
 
 Now we create the [systemd service template](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Service%20Templates) at `/etc/systemd/system/docker-compose@.service`:
 
@@ -83,13 +82,17 @@ Now we make systemd reload the service files:
 systemctl daemon-reload
 ```
 
+## Step 3 - Regularly pull and build new Docker images (optional)
+
 Since in the service template we configured it to pull and build our images on a reload of the systemd service we can also create a cronjob for this so we will regularly pull/build new images:
 
 ```bash
 echo '0  4    * * *   root    /bin/systemctl reload docker-compose@*.service' >> /etc/crontab
 ```
 
-Please note that this only works as intended in combination with 'watchtower' as shown above as new images will not automatically be used. 
+Please note that this only works as intended in combination with 'watchtower' as shown above as new images will not automatically be used.
+
+## Step 4 - Start Docker services
 
 With this setup we can now start a Docker Compose service (in this case 'watchtower'):
 
@@ -104,6 +107,7 @@ systemctl enable docker-compose@watchtower
 ```
 
 ## Conclusion
+
 You have now setup an environment where you can easily start different Docker Compose services as systemd services. For each additional service you just need to:
 * create the according `/etc/docker-compose/servicename` directory
 * create at least a `/etc/docker-compose/servicename/docker-compose.yml` file (and whatever else you need for the service)

--- a/tutorials/DockerComposeAsSystemdService.md
+++ b/tutorials/DockerComposeAsSystemdService.md
@@ -1,20 +1,20 @@
-# Run multiple docker-compose services on Debian/Ubuntu
+# Run multiple Docker Compose services on Debian/Ubuntu
 
 ## Introduction
-This tutorial will show you how you can run multiple docker-compose services via a systemd service template.
+This tutorial will show you how you can run multiple Docker Compose services via a systemd service template.
 
 ### Prerequisites
 * Server with Debian/Ubuntu
 * Docker already installed and running
   * [Tutorial for Debian](https://docs.docker.com/install/linux/docker-ce/debian/)
   * [Tutorial for Ubuntu](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
-* `docker-compose` installed at `/usr/local/bin/docker-compose` as instructed in the [official tutorial](https://docs.docker.com/compose/install/) (otherwise you may need to adapt the path in the examples)
+* Docker Compose installed at `/usr/local/bin/docker-compose` as instructed in the [official tutorial](https://docs.docker.com/compose/install/) (otherwise you may need to adapt the path in the examples)
 
 ## Steps
 
-### Create docker-compose files
+### Create Docker Compose files
 
-For this tutorial we will store our docker-compose service configurations under `/etc/docker-compose`.
+For this tutorial we will store our Docker Compose service configurations under `/etc/docker-compose`.
 
 ```bash
 mkdir /etc/docker-compose
@@ -26,7 +26,7 @@ Just as an example, let's say we want to run [watchtower](https://hub.docker.com
 mkdir /etc/docker-compose/watchtower
 ```
 
-And we need the according docker-compose file at `/etc/docker-compose/watchtower/docker-compose.yml`:
+And we need the according Docker Compose file at `/etc/docker-compose/watchtower/docker-compose.yml`:
 
 ```
 version: "3"
@@ -71,11 +71,11 @@ WantedBy=multi-user.target
 ```
 
 This service template will:
-* try to pull new versions of the used docker images on startup and reload of the systemd service
+* try to pull new versions of the used Docker images on startup and reload of the systemd service
 * try to build the images if it's configured this way in the `docker-compose.yml` on startup and reload of the systemd service
 * remove orphan containers (e.g. after you changed a containers name or removed a container from the `docker-compose.yml`)
 
-If you wonder why the start timeout is a bit long, some docker images may need some time to be built which is done when starting the service.
+If you wonder why the start timeout is a bit long, some Docker images may need some time to be built which is done when starting the service.
 
 Now we make systemd reload the service files:
 
@@ -91,7 +91,7 @@ echo '0  4    * * *   root    /bin/systemctl reload docker-compose@*.service' >>
 
 Please note that this only works as intended in combination with 'watchtower' as shown above as new images will not automatically be used. 
 
-With this setup we can now start a docker-compose service (in this case 'watchtower'):
+With this setup we can now start a Docker Compose service (in this case 'watchtower'):
 
 ```bash
 systemctl start docker-compose@watchtower
@@ -104,7 +104,7 @@ systemctl enable docker-compose@watchtower
 ```
 
 ## Conclusion
-You have now setup an environment where you can easily start different docker-compose services as systemd services. For each additional service you just need to:
+You have now setup an environment where you can easily start different Docker Compose services as systemd services. For each additional service you just need to:
 * create the according `/etc/docker-compose/servicename` directory
 * create at least a `/etc/docker-compose/servicename/docker-compose.yml` file (and whatever else you need for the service)
 * start the service via `systemctl start docker-compose@servicename`

--- a/tutorials/DockerComposeAsSystemdService.md
+++ b/tutorials/DockerComposeAsSystemdService.md
@@ -76,13 +76,13 @@ WantedBy=multi-user.target
 ```
 
 This service template will:
-* try to pull new versions of the used Docker images on startup and reload of the systemd service
-* try to build the images if it's configured this way in the `docker-compose.yml` on startup and reload of the systemd service
-* remove orphan containers (e.g. after you changed a containers name or removed a container from the `docker-compose.yml`)
+* Try to pull new versions of the used Docker images on startup and reload of the systemd service
+* Try to build the images if it's configured this way in the `docker-compose.yml` on startup and reload of the systemd service
+* Remove orphan containers (e.g. after you changed a containers name or removed a container from the `docker-compose.yml`)
 
 If you wonder why the start timeout is a bit long, some Docker images may need some time to be built which is done when starting the service.
 
-Now we make systemd reload the service files:
+Now we make systemd reload the service files so we can actually use it:
 
 ```bash
 systemctl daemon-reload
@@ -90,7 +90,7 @@ systemctl daemon-reload
 
 ## Step 3 - Regularly pull and build new Docker images (optional)
 
-Since in the service template we configured it to pull and build our images on a reload of the systemd service we can also create a cronjob for this so we will regularly pull/build new images:
+Since we configured the service template to pull and build our images on a reload of the systemd service we can also create a cronjob for that so we can benefit from regularly pulled/built images:
 
 ```bash
 echo '0  4    * * *   root    /bin/systemctl reload docker-compose@*.service' >> /etc/crontab
@@ -115,8 +115,8 @@ systemctl enable docker-compose@watchtower
 
 ## Conclusion
 
-You have now setup an environment where you can easily start different Docker Compose services as systemd services. For each additional service you just need to:
-* create the according `/etc/docker-compose/servicename` directory
-* create at least a `/etc/docker-compose/servicename/docker-compose.yml` file (and whatever else you need for the service)
-* start the service via `systemctl start docker-compose@servicename`
-* (optional) start the service on boot with `systemctl enable docker-compose@servicename`
+You have now set up an environment where you can easily start different Docker Compose services as systemd services. For each additional service you just need to:
+* Create the according `/etc/docker-compose/servicename` directory
+* Create at least a `/etc/docker-compose/servicename/docker-compose.yml` file (and whatever else you need for the service)
+* Start the service via `systemctl start docker-compose@servicename`
+* (Optional) Start the service on boot with `systemctl enable docker-compose@servicename`


### PR DESCRIPTION
I thought this might be useful for somebody. This tutorial describes how you can setup multiple docker-compose services using a systemd service template. I hope this is somehow as you expect the tutorials to look like :)