### PR TITLE
Add konsoleH SSH access tutorial

### DIFF
--- a/tutorials/konsoleh-ssh-access/01.en.md
+++ b/tutorials/konsoleh-ssh-access/01.en.md
@@ -1,0 +1,79 @@
+# konsoleH: SSH access
+
+## Introduction - What is SSH?
+
+SSH stands for Secure Shell.
+
+With SSH you can access a server via command line on which you are able to execute commands.
+
+**Prerequisites**
+- konsoleH customer login
+- An account with SSH access (e.g. [Level 19](https://www.hetzner.com/webhosting/level-19))
+
+## SSH programs
+
+There are countless SSH applications available for download from the internet. Recommended programs are, for example:
+
+- OpenSSH (pre-installed on Linux, Windows, Mac)
+- [PuTTY](https://www.putty.org/)
+- [mRemoteNG](https://mremoteng.org/)
+
+## Access details
+
+In konsoleH you can find the SSH access details under `Contract` -> `View Account Details` -> `SSH access`.
+
+There you will find something similar to the following:
+
+Host name: wwwXXX.your-server.de (Server IP: 10.0.0.1)
+SSH-Port: 222
+Login: holu
+Password: *********
+Connection identifier: ssh holu@wwwXXX.your-server.de -p222
+
+Note: If you have a [Managed Server](https://www.hetzner.com/managed-server) you have to replace `www` with `dedi`.
+
+## Selecting your own password
+
+Your SSH password is the same as your FTP password. You can change it under `Services` -> `Login data` -> `Edit`.
+
+An SSH password should fulfill some requirements for increased security. Please find these rules when changing the password.
+
+To change the SSH/FTP password, simply enter your new password in the relevant text box and click `Save`.
+
+## Connection via SSH
+
+In order to ensure a proper SSH connection you should always use the servername and the port 222.
+
+### OpenSSH
+
+OpenSSH is a command line application which has no GUI. We can execute the following command to connect to the server:
+
+```bash
+ssh holu@wwwXXX.your-server.de -p222
+```
+
+### PuTTY
+
+1. Start PuTTY
+2. Enter the hostname in the text box and change the `Port` from `22` to `222` behind the `Host Name` text box.
+3. Enter a name under `Saved Sessions`
+4. Click on `Save`
+
+We now have saved the SSH connection details and can always use it in the future.
+
+5. Click on `Open` in the bottom right.
+6. Click on `Accept` to accept the SSH server key
+7. Enter your username (in this tutorial it is `holu`)
+8. Enter the password you have selected (or the one you found pre-configured in konsoleH)
+
+We are now connected to the server and can look around and execute commands via SSH.
+
+**Known errors with PuTTY:**
+- Server refused to start a shell/command
+        - Solution: Set port to `222`
+
+- Server refused to allocate pty
+        - Solution: Set port to 222
+
+- PuTTY closes without any error
+        - Solution: You probably do not have an account with enabled SSH access


### PR DESCRIPTION
We do not have any dedicated guide for SSH access for konsoleH in the [Hetzner Wiki](https://wiki.hetzner.de).
There only was a dedicated [FTP Tutorial](https://wiki.hetzner.de/index.php/KonsoleH:Accountverwaltung#SSH-Zugang/en) and some very small notices about SSH here and there.

I asked about this already some weeks ago in the managed server department and got positive feedback as we do not have anything yet to which we can link our customers for SSH access.