### PR TITLE
Hetzner Cloud Terraform Provider - wrong metadata

### DIFF
--- a/tutorials/howto-hcloud-terraform/01.en.md
+++ b/tutorials/howto-hcloud-terraform/01.en.md
@@ -1,9 +1,9 @@
 ---
 path: "/community/tutorials/howto-hcloud-terraform/01.en"
 date: "2019-03-11"
-title: "How-to: hcloud Terraform Provider"
-short_description: "How to use the hcloud-cli, including how to create and delete resources and how to do more complex scenarios like attaching a volume to a server."
-tags: ["hcloud", "Terraform"]
+title: "How-to: Hetzner Cloud Terraform Provider"
+short_description: "How to use the Hetzner Cloud Terraform provider for creating and managing resources on the Hetzner Cloud."
+tags: ["Hetzner Cloud", "hcloud", "Terraform"]
 author: "Lukas Kämmerling"
 author_img: "https://avatars1.githubusercontent.com/u/4281581?s=400&v=4"
 author_description: ""
@@ -13,7 +13,7 @@ header_img: ""
 
 ## Introduction
 
-In this how-to you will learn to use the hcloud Terraform Provider. This includes how to create and delete resources and how to do more complex scenarios like attaching a volume to a server.
+In this how-to you will learn to use the hcloud Terraform provider. This includes how to create and delete resources and how to do more complex scenarios like attaching a volume to a server.
 
  **Prerequisites**
 


### PR DESCRIPTION
The Metadata for the Hetzner Cloud Terraform provider contained the description of the hcloud-cli Tutorial and it should contain the tag "Hetzner Cloud".