### PR TITLE
Hetzner Cloud CLI - wrong title and metadata

### DIFF
--- a/tutorials/howto-hcloud-cli/01.en.md
+++ b/tutorials/howto-hcloud-cli/01.en.md
@@ -1,9 +1,9 @@
 ---
 path: "/community/tutorials/howto-hcloud-cli/01.en"
 date: "2019-03-11"
-title: "How-to: hcloud-cli"
+title: "How-to: Hetzner Cloud CLI"
 short_description: "How to use the hcloud-cli, including how to create, list and delete servers and how to do more complex scenarios like attaching a volume to a server."
-tags: ["hcloud"]
+tags: ["Hetzner Cloud", "hcloud", "cli"]
 author: "Lukas Kämmerling"
 author_img: "https://avatars1.githubusercontent.com/u/4281581?s=400&v=4"
 author_description: ""


### PR DESCRIPTION
The Hetzner Cloud CLI Tutorial contained wrong metadata and a "not so good" title. This PR changes this. 