### PR TITLE
Cronjob email reports via ssmtp

### DIFF
--- a/tutorials/cron-email-notifications/01.en.md
+++ b/tutorials/cron-email-notifications/01.en.md
@@ -3,9 +3,9 @@ SPDX-License-Identifier: MIT
 path: "/tutorials/cron-email-notifications"
 slug: "cron-email-notifications"
 date: "2019-03-15"
-title: "Cronjob email notifications"
-short_description: "This tutorial will walk you trough the process on how to setup ssmtp to get cron email notifications"
-tags: ["cron", "Linux", "ssmtp"]
+title: "Cronjob email notifications with sSMTP"
+short_description: "This tutorial will walk you through the process of setting up sSMTP to get cron email notifications."
+tags: ["cron", "ssmtp"]
 author: "ntimo"
 author_link: "https://github.com/ntimo"
 author_img: "https://avatars3.githubusercontent.com/u/6145026"
@@ -15,31 +15,27 @@ available_languages: ["en"]
 header_img: ""
 ---
 
-# Cronjob e-mail notifications with ssmtp
 
 ## Introduction
 
-In this tutorial you will learn how to setup ssmtp in order to receive email notifications from your server. This makes it possible to get the output of a cronjob via email.  
+In this tutorial you will learn how to setup sSMTP in order to receive email notifications from your server. This makes it possible to get the output of a cronjob via email.  
 
 **Prerequisites**
 
-* A email account that will send the emails
+* An email account that will send the emails.
 
-## Step 1 - Connect to your server
+## Step 1 - Install sSMTP
 
-If you already have a server you should connect to it via SSH.  
-
-## Step 2- Install ssmtp
-
-Now you should install ssmtp. You can do that by running:
+Connect to your server via SSH, and install sSMTP. You can do that by running:
 `apt update && apt install -y ssmtp`
 
-## Step 3 - Update the ssmtp configuration
+## Step 2 - Update the sSMTP Configuration
 
-Now you need to update the ssmtp configuration. The configuration files can be found under `/etc/ssmtp`.  
-Use `nano /etc/ssmtp/ssmtp.conf` to open the config in an editor.  
+The configuration files of sSMTP can be found under `/etc/ssmtp`.
 
-Now you have to add some lines the final config, when you are done it should look like this:  
+Use `nano /etc/ssmtp/ssmtp.conf` to open the config in an editor.
+
+Now you have to add some lines to the final config. When you are done it should look like this:  
 
 ```
 root=yourownemail@example.com
@@ -53,8 +49,8 @@ rewriteDomain=yourdomain.com
 hostname=senderemail@example.com
 ```
 
-Once that is done you will need to edit `/etc/ssmtp/revaliases` you can use `nano /etc/ssmtp/revaliases` to edit the file.  
-The config should look like this when you are done editing:  
+Once that is done you will need to edit `/etc/ssmtp/revaliases`. You can use `nano /etc/ssmtp/revaliases` to edit the file.  
+The config should look like this when you are done editing:
 
 ```
 # sSMTP aliases
@@ -67,19 +63,19 @@ The config should look like this when you are done editing:
 root:senderemail@example.com:mail.example.com:465
 ```
 
-## Step 4 - Setup the a cronjob
+## Step 3 - Setup a cronjob
 
-Now you can setup an cronjob with `crontab -e` then choose the editor you like (for example nano).  
-Before your cronjobs you have to add `MAILTO=yourownemail@example.com`.  
-Now you will get an email when ever a cronjob runs.
+Now you can setup a cronjob with `crontab -e` then choose the editor you like (for example nano).  
+Before your cronjobs you have to add `MAILTO=yourownemail@example.com`.
+Now you will get an email whenever a cronjob runs.
 
-## Step 5 - Exclude a cronjob from email sending
+## Step 4 - Exclude a cronjob from sending email
 
-If you don't want one cron job to send emails you can simply add a `>/dev/null 2>&1` to its end. This will redirect the output of that job to `/dev/null` and no email will be send.
+If you don't want a cronjob to send emails you can simply add a `>/dev/null 2>&1` to its end. This will redirect the output of that job to `/dev/null` and no email will be sent.
 
 ## Conclusion
 
-With ssmtp configured on your server, you will now get emails for every cronjob. This can be super helpful for example if you are auto upgrading some services on your machine. But it can also be annoying. If you for example have a cronjob that runs very minute you will get a email every minute which is definitely going to be annoying at some point. So before you start using this feature you should carefully consider if you need it.  
+With sSMTP configured on your server, you will now get emails for every cronjob. This can be super helpful for example if you are auto upgrading some services on your machine. However, it can also be annoying. If you for example have a cronjob that runs every minute you will also get an email every minute, so make sure you carefully select which cronjobs will send emails.
 
 ##### License: MIT
 

--- a/tutorials/cron-email-notifications/01.en.md
+++ b/tutorials/cron-email-notifications/01.en.md
@@ -1,0 +1,72 @@
+---
+SPDX-License-Identifier: MIT
+path: "/tutorials/cron-email-notifications"
+slug: "cron-email-notifications"
+date: "2019-03-15"
+title: "Cronjob email notifications"
+short_description: "This tutorial will walk you trough the process on how to setup ssmtp to get cron email notifications"
+tags: ["cron", "Linux", "ssmtp"]
+author: "ntimo"
+author_img: "https://avatars3.githubusercontent.com/u/6145026"
+author_description: ""
+header_img: ""
+---
+
+# Cronjob e-mail notifications with ssmtp
+
+## Introduction
+
+In this tutorial you will learn how to setup ssmtp in order to receive email notifications from your server. This makes it possible to get the output of a cronjob via email.  
+
+**Prerequisites**
+
+* A email account that will send the emails
+
+## Step 1 - Connect to your server
+
+If you already have a server you should connect to it via SSH.  
+
+## Step 2- Install ssmtp
+
+Now you should install ssmtp. You can do that by running:
+`apt update && apt install -y ssmtp`
+
+## Step 3 - Update the ssmtp configuration
+
+Now you need to update the ssmtp configuration. The configuration files can be found under `/etc/ssmtp`.  
+Use `nano /etc/ssmtp/ssmtp.conf` to open the config in a editor.  
+
+Now you have to add some lines the final config should then look like this:
+
+```
+root=yourownemail@example.com
+mailhub=mail.example.com:465
+FromLineOverride=NO
+UseSTARTTLS=YES                    # Does your email server support start tls if no simply change this to NO
+UseTLS=YES                         # Does your email server support tls if no simply change this to NO
+AuthUser=senderemail@example.com
+AuthPass=password
+rewriteDomain=yourdomain.com
+hostname=senderemail@example.com
+```
+
+When that is done you will have to edit use `nano /etc/ssmtp/revaliases` to edit the `revaliases` config. The config should look like this when you are done:
+
+```
+# sSMTP aliases
+#
+# Format:       local_account:outgoing_address:mailhub
+#
+# Example: root:your_login@your.domain:mailhub.your.domain[:port]
+# where [:port] is an optional port number that defaults to 25.
+
+root:senderemail@example.com:mail.example.com:465
+```
+
+## Step 4 - Setup the a cronjob
+
+Now you can setup a cronjob with `crontab -e` then choose the editor you like (for example nano). There you have to add `MAILTO=yourownemail@example.com` above your cron jobs. Now you will get a email when ever a cronjob runs.
+
+## Step 5 - Exclude a cronjob from email sending
+
+If you don't want one cron job to send you emails you can simply add a `>/dev/null 2>&1` to its end. This will redirect the output of that job to `/dev/null` and no email will be send.

--- a/tutorials/cron-email-notifications/01.en.md
+++ b/tutorials/cron-email-notifications/01.en.md
@@ -10,6 +10,9 @@ author: "ntimo"
 author_img: "https://avatars3.githubusercontent.com/u/6145026"
 author_description: ""
 header_img: ""
+language: "en"
+available_languages: ["en"]
+author_link: "https://github.com/ntimo"
 ---
 
 # Cronjob e-mail notifications with ssmtp
@@ -70,3 +73,35 @@ Now you can setup a cronjob with `crontab -e` then choose the editor you like (f
 ## Step 5 - Exclude a cronjob from email sending
 
 If you don't want one cron job to send you emails you can simply add a `>/dev/null 2>&1` to its end. This will redirect the output of that job to `/dev/null` and no email will be send.
+
+##### License: MIT
+
+<!---
+
+Contributors's Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it under the license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate license and I have the
+    right under that license to submit that work with modifications,
+    whether created in whole or in part by me, under the same license
+    (unless I am permitted to submit under a different license), as
+    indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are
+    public and that a record of the contribution (including all personal
+    information I submit with it, including my sign-off) is maintained
+    indefinitely and may be redistributed consistent with this project
+    or the license(s) involved.
+
+Signed-off-by: 0mfhniozkb9s4q7e6ap8yvlt@nowitzki.me
+
+-->
+

--- a/tutorials/cron-email-notifications/01.en.md
+++ b/tutorials/cron-email-notifications/01.en.md
@@ -7,12 +7,12 @@ title: "Cronjob email notifications"
 short_description: "This tutorial will walk you trough the process on how to setup ssmtp to get cron email notifications"
 tags: ["cron", "Linux", "ssmtp"]
 author: "ntimo"
+author_link: "https://github.com/ntimo"
 author_img: "https://avatars3.githubusercontent.com/u/6145026"
 author_description: ""
-header_img: ""
 language: "en"
 available_languages: ["en"]
-author_link: "https://github.com/ntimo"
+header_img: ""
 ---
 
 # Cronjob e-mail notifications with ssmtp
@@ -37,9 +37,9 @@ Now you should install ssmtp. You can do that by running:
 ## Step 3 - Update the ssmtp configuration
 
 Now you need to update the ssmtp configuration. The configuration files can be found under `/etc/ssmtp`.  
-Use `nano /etc/ssmtp/ssmtp.conf` to open the config in a editor.  
+Use `nano /etc/ssmtp/ssmtp.conf` to open the config in an editor.  
 
-Now you have to add some lines the final config should then look like this:
+Now you have to add some lines the final config, when you are done it should look like this:  
 
 ```
 root=yourownemail@example.com
@@ -53,7 +53,8 @@ rewriteDomain=yourdomain.com
 hostname=senderemail@example.com
 ```
 
-When that is done you will have to edit use `nano /etc/ssmtp/revaliases` to edit the `revaliases` config. The config should look like this when you are done:
+Once that is done you will need to edit `/etc/ssmtp/revaliases` you can use `nano /etc/ssmtp/revaliases` to edit the file.  
+The config should look like this when you are done editing:  
 
 ```
 # sSMTP aliases
@@ -68,11 +69,17 @@ root:senderemail@example.com:mail.example.com:465
 
 ## Step 4 - Setup the a cronjob
 
-Now you can setup a cronjob with `crontab -e` then choose the editor you like (for example nano). There you have to add `MAILTO=yourownemail@example.com` above your cron jobs. Now you will get a email when ever a cronjob runs.
+Now you can setup an cronjob with `crontab -e` then choose the editor you like (for example nano).  
+Before your cronjobs you have to add `MAILTO=yourownemail@example.com`.  
+Now you will get an email when ever a cronjob runs.
 
 ## Step 5 - Exclude a cronjob from email sending
 
-If you don't want one cron job to send you emails you can simply add a `>/dev/null 2>&1` to its end. This will redirect the output of that job to `/dev/null` and no email will be send.
+If you don't want one cron job to send emails you can simply add a `>/dev/null 2>&1` to its end. This will redirect the output of that job to `/dev/null` and no email will be send.
+
+## Conclusion
+
+With ssmtp configured on your server, you will now get emails for every cronjob. This can be super helpful for example if you are auto upgrading some services on your machine. But it can also be annoying. If you for example have a cronjob that runs very minute you will get a email every minute which is definitely going to be annoying at some point. So before you start using this feature you should carefully consider if you need it.  
 
 ##### License: MIT
 
@@ -104,4 +111,3 @@ By making a contribution to this project, I certify that:
 Signed-off-by: 0mfhniozkb9s4q7e6ap8yvlt@nowitzki.me
 
 -->
-


### PR DESCRIPTION
This tutorials explains how you an setup ssmtp to receive cron job logs via email. 

I have read and understood the Contributor's Certificate of Origin available at the end of https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md and I hereby certify that I meet the contribution criteria described in it. Signed-off-by: Timo 0mfhniozkb9s4q7e6ap8yvlt@nowitzki.me



