### PR TITLE
add tutorial to install apache2 with letsencrypt

### DIFF
--- a/tutorials/install-apache2-and-letsencrpt/01.en.md
+++ b/tutorials/install-apache2-and-letsencrpt/01.en.md
@@ -1,0 +1,132 @@
+---
+SPDX-License-Identifier: MIT
+path: "/tutorials/install-apache2-and-letsancrypt"
+slug: "install-apache2-and-letsancrypt"
+date: "2019-03-21"
+title: "Install Apache2 with LetsEncrypt SSL:"
+short_description: "Install Apache2 with an LetsEncrpy Cert on a new Server"
+tags: ["Development", "Lang:Bash"]
+author: "Stefan Dunkel"
+author_link: "https://github.com/sap-dev"
+language: "en"
+available_languages: [""]
+header_img: ""
+---
+
+<!-- This where the actual tutorial begins, with the title: -->
+
+# Install Apache2 with LetsEncrypt 
+
+## Introduction
+
+In this Tutorial we will install on a blank Server an Apache2 Webserver, change the Servername and install on it an fresh LetsEncrypt Certificate
+
+**Prerequisites**
+
+Operating System can be an Debian 9.0, Ubuntu 16.04 or 18.04. Other distributions not tested
+
+## Step 1 - Install Apache2
+
+In the first step we will update the system with apt and install needed software:
+
+```bash
+apt-get update
+apt-get upgrade
+apt-get dist-upgrade
+apt-get install apache2
+```
+The Server will ask you, that packages should be install. Answer with "y".
+
+
+## Step 2 - Install LetsEncrpt
+
+In this step we install the basically LetsEncrypt Module for Apache2, that generate the Certificate.
+```bash
+apt install python-certbot-apache
+```
+
+## Step 3 - Change Servername Vhost
+
+The Apache 2 configuration files are located in ```/etc/apache2```. That LetsEncrpt can set the SSL Settings in the right configuration file, we must change the servername.
+In this Example, the server called ```test1.test.de```.
+
+Edit the configuration file ```/etc/apache2/sites-available/000-default.conf``` and uncomment the line
+
+```bash
+#ServerName www.example.com
+```
+
+and change to
+
+```bash
+ServerName test1.test.de
+```
+
+After that, save the file.
+
+## Step 4 - Create LetsEncrypt Certificate
+To create the Certificate, enter the following command
+
+```bash
+certbot --apache -d test1.test.de
+```
+
+LetsEncrpt generate the certficate now for you.
+
+```bash
+Saving debug log to /var/log/letsencrypt/letsencrypt.log
+Plugins selected: Authenticator apache, Installer apache
+Obtaining a new certificate
+Performing the following challenges:
+http-01 challenge for test1.test.de
+Waiting for verification...
+Cleaning up challenges
+```
+
+The CertBot ask you, what method you will use:
+
+```bash
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+1: No redirect - Make no further changes to the webserver configuration.
+2: Redirect - Make all requests redirect to secure HTTPS access. Choose this for
+new sites, or if you're confident your site works on HTTPS. You can undo this
+change by editing your web server's configuration.
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+```
+We enter 2, then all HTTP connections will be redirect to HTTPS.
+
+Congratulation, your SSL Certificate is working. The Certbot restart the Webserver for you.
+
+
+## Conclusion
+
+##### License: MIT
+
+<!---
+
+Contributors's Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it under the license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate license and I have the
+    right under that license to submit that work with modifications,
+    whether created in whole or in part by me, under the same license
+    (unless I am permitted to submit under a different license), as
+    indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are
+    public and that a record of the contribution (including all personal
+    information I submit with it, including my sign-off) is maintained
+    indefinitely and may be redistributed consistent with this project
+    or the license(s) involved.
+
+Signed-off-by: [submitter's name and email address here]
+
+-->


### PR DESCRIPTION
I have read and understood the Contributor's Certificate of Origin available at the end of 
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Stefan Dunkel <stefan@stefan6.de>

Please use stefan@stefan6.de for communication, i dont can change the github email. Thanks.