### PR TITLE
Fix issues with Prosody on Debian 9

### DIFF
--- a/tutorials/prosody-on-debian9/01.en.md
+++ b/tutorials/prosody-on-debian9/01.en.md
@@ -108,7 +108,9 @@ Prosody needs to be able to access the modules folder, therefore we need to chan
 `chown root:prosody -R /opt/prosody-modules/`
 
 Now we add a cronjob to update the repository periodically:
-`(echo "0 18 * * 2 cd /opt/prosody-modules && hg pull --update && chown root:prosody -R /opt/prosody-modules/") | crontab -`
+First run `crontab -e` and go down to the bottom of the file and create a new line. Paste the following line:
+
+`0 18 * * 2 cd /opt/prosody-modules && hg pull --update && chown root:prosody -R /opt/prosody-modules/`
 
 As we do not need all community modules and also some official modules still have old versions in the community repository we symlink all needed modules.
 

--- a/tutorials/prosody-on-debian9/01.en.md
+++ b/tutorials/prosody-on-debian9/01.en.md
@@ -107,7 +107,7 @@ After that we will download the so called "community modules" which will add mor
 Prosody needs to be able to access the modules folder, therefore we need to change the owner of the directory.
 `chown root:prosody -R /opt/prosody-modules/`
 
-Now the we add a cronjob to update the repository periodically
+Now we add a cronjob to update the repository periodically:
 `(echo "0 18 * * 2 cd /opt/prosody-modules && hg pull --update && chown root:prosody -R /opt/prosody-modules/") | crontab -`
 
 As we do not need all community modules and also some official modules still have old versions in the community repository we symlink all needed modules.

--- a/tutorials/prosody-on-debian9/01.en.md
+++ b/tutorials/prosody-on-debian9/01.en.md
@@ -314,7 +314,6 @@ disco_items = {
 Component "conference.example.com" "muc"
   name = "example.com chatrooms"
   restrict_room_creation = false
-  max_history_messages = 30
   
    ssl = {
      key = "/usr/lib/prosody/cert/conference.example.com/privkey.pem";

--- a/tutorials/prosody-on-debian9/01.en.md
+++ b/tutorials/prosody-on-debian9/01.en.md
@@ -110,7 +110,9 @@ Prosody needs to be able to access the modules folder, therefore we need to chan
 Now we add a cronjob to update the repository periodically:
 First run `crontab -e` and go down to the bottom of the file and create a new line. Paste the following line:
 
-`0 18 * * 2 cd /opt/prosody-modules && hg pull --update && chown root:prosody -R /opt/prosody-modules/`
+```cron
+0 18 * * 2 cd /opt/prosody-modules && hg pull --update && chown root:prosody -R /opt/prosody-modules/
+```
 
 As we do not need all community modules and also some official modules still have old versions in the community repository we symlink all needed modules.
 

--- a/tutorials/prosody-on-debian9/01.it.md
+++ b/tutorials/prosody-on-debian9/01.it.md
@@ -318,7 +318,6 @@ disco_items = {
 Component "conference.example.com" "muc"
   name = "example.com chatrooms"
   restrict_room_creation = false
-  max_history_messages = 30
 
    ssl = {
      key = "/usr/lib/prosody/cert/conference.example.com/privkey.pem";

--- a/tutorials/prosody-on-debian9/01.it.md
+++ b/tutorials/prosody-on-debian9/01.it.md
@@ -111,8 +111,12 @@ Dopo di che scaricheremo i cosiddetti "moduli della comunità" che aggiungeranno
 Prosody deve essere in grado di accedere alla cartella dei moduli, quindi dobbiamo cambiare il proprietario della directory.
 `chown root:prosody -R /opt/prosody-modules/`
 
-Ora aggiungiamo un cronjob per aggiornare periodicamente il repository
-`(echo "0 18 * * 2 cd /opt/prosody-modules && hg pull --update && chown root:prosody -R /opt/prosody-modules/") | crontab -`
+Ora aggiungiamo un cronjob per aggiornare periodicamente il repository:
+Prima eseguiamo `crontab -e` e scendiamo in fondo al file e creiamo una nuova linea. Incollare la seguente linea:
+
+```cron
+0 18 * * 2 cd /opt/prosody-modules && hg pull --update && chown root:prosody -R /opt/prosody-modules/
+```
 
 Poiché non abbiamo bisogno di tutti i moduli della comunità e anche alcuni moduli ufficiali hanno ancora vecchie versioni nel repository della comunità, colleghiamo tutti i moduli necessari.
 


### PR DESCRIPTION
This PR fixes issues with the prosody on debian 9 tutorial:

1. When you copy the config file and run prosodyctl checkit will warn with

```
startup             warn        Configuration warning: /etc/prosody/prosody.cfg.lua:167: Duplicate option 'max_history_messages'
```

This PR Removes the first of the two duplicates

2. If you run the proposed command for adding the cronjob, it will overwrite all of your existing cronjobs. This PR implements directions to do it manually via crontab -e. The Italian translation of it was only done trough an online translation service, **somebody who is fluent in Italian probably should check this translation.**