### PR TITLE
pfSense Private Network Tutorial: Upload/Performance fix

### DIFF
--- a/tutorials/how-to-route-cloudserver-over-private-network-using-pfsense-and-hcnetworks/01.en.md
+++ b/tutorials/how-to-route-cloudserver-over-private-network-using-pfsense-and-hcnetworks/01.en.md
@@ -122,7 +122,9 @@ Description: Make private network reachable for pfSense
 
 Apply the changes and go back to `Interfaces -> LAN` and also apply the changes. 
 
-Go to `Firewall -> NAT -> Outbound` and set the Outbound NAT Mode to `Hybrid Outbound NAT rule generation`.
+Go to `System -> Advanced -> Networking` and enable `Disable hardware checksum offload` under `Network Interfaces` and click `Save`.
+
+Then, go to `Firewall -> NAT -> Outbound` and set the Outbound NAT Mode to `Hybrid Outbound NAT rule generation`.
 
 Create the following mapping rule:
 
@@ -130,7 +132,7 @@ Create the following mapping rule:
 Interface: WAN
 Address Family: IPv4+IPv6
 Protocol: any
-Source: 10.0.0.0/8
+Source: 10.0.0.0/16
 Destination: any
 Translation -> Address: Interface Address
 ```
@@ -153,9 +155,9 @@ Destination: this firewall (self)
 Destination Port Range: From "HTTP (80)" to "HTTPS (443)"
 ```
 
-Click "Save" and apply the changes. Now go back to `Firewall -> NAT -> Outbound` and apply the changes.
+Click `Save` and apply the changes. Now go back to `Firewall -> NAT -> Outbound` and apply the changes.
 It may happen that the browser is caching the session.
-In this case, close the browser and re-open it. The pfSense UI should not reachable with the public IP address anymore.
+In this case, close the browser and re-open it. The pfSense UI should be not reachable with the public IP address anymore.
 
 ## Step 3 - Set up the client server
 

--- a/tutorials/how-to-route-cloudserver-over-private-network-using-pfsense-and-hcnetworks/01.en.md
+++ b/tutorials/how-to-route-cloudserver-over-private-network-using-pfsense-and-hcnetworks/01.en.md
@@ -157,7 +157,7 @@ Destination Port Range: From "HTTP (80)" to "HTTPS (443)"
 
 Click `Save` and apply the changes. Now go back to `Firewall -> NAT -> Outbound` and apply the changes.
 It may happen that the browser is caching the session.
-In this case, close the browser and re-open it. The pfSense UI should be not reachable with the public IP address anymore.
+In this case, close the browser and re-open it. The pfSense UI should not be reachable with the public IP address anymore.
 
 ## Step 3 - Set up the client server
 


### PR DESCRIPTION
Due to various problems with the upload speed, this PR adds a description of "how to disable hardware checksum offload", which is the root cause for the bad upload.