### PR TITLE
Install and configure Ogp Agent and run CSGO Server in Debian/Ubuntu

### DIFF
--- a/tutorials/install-and-configure-ogp-agent-and-csgo-server-in-debian-ubuntu/01.en.md
+++ b/tutorials/install-and-configure-ogp-agent-and-csgo-server-in-debian-ubuntu/01.en.md
@@ -1,0 +1,178 @@
+---
+SPDX-License-Identifier: MIT
+path: "/tutorials/install-and-configure-ogp-agent-and-csgo-server-in-debian-ubuntu"
+slug: "install-and-configure-ogp-agent-and-csgo-server-in-debian-ubuntu"
+date: "2020-04-06"
+title: "Install & Configure OGP Agent & CSGO Server in Debian or Ubuntu"
+short_description: "This tutorial explains the procedure to install, configure OGP Agent and run a CSGO Server using it, in Debian or Ubuntu OS."
+tags: ["Gaming", "Gameserver", "OGP", "Agent", "CSGO", "Server"]
+author: "Zishan Ansari"
+author_link: "https://github.com/kinnngg"
+author_img: "https://avatars3.githubusercontent.com/u/3089863"
+author_description: ""
+language: "en"
+available_languages: ["en"]
+header_img: "header-2"
+---
+
+## Introduction
+
+In this tutorial we will be installing the Agent of OGP which is responsible for running gameservers.
+
+*We can install Agent in same server where Panel is installed or we can install it in a totally fresh server and link it to panel running on different server.* 
+
+**Prerequisites**
+
+1. You will need a server with either Debian (9 or 10) or Ubuntu (18.04 or 16.04).
+
+2. We assume you already have installed Open Game Panel by following previous tutorial [here](https://community.hetzner.com/tutorials/install-and-configure-ogp-panel-in-debian-ubuntu).
+You need a Panel to control your Agent so it is recommend to follow it if you have not installed Panel yet.
+
+## Step 1 - Agent Prerequisites
+
+In this step we will be installing the packages that are needed to run the agent.
+
+**Note:** If you are using Debian 10 or lower make sure you have sudo installed. If not then go ahead and install sudo using `apt-get install sudo` using your root account.
+
+Add your user to sudoer if not already done, using:
+```
+usermod -aG sudo "{REPLACE_WITH_YOUR_LINUX_USERNAME}"
+```
+
+### Step 1.1 General Update
+
+**For all Distributions**
+```
+sudo apt-get -y update && sudo apt-get -y upgrade
+```
+
+### Step 1.2 Install Required Packages
+
+**For all versions of Ubuntu**
+```
+sudo apt-get update  
+sudo apt-get upgrade  
+sudo apt-get install libxml-parser-perl libpath-class-perl perl-modules screen rsync sudo e2fsprogs unzip subversion libarchive-extract-perl pure-ftpd libarchive-zip-perl libc6 libgcc1 git curl  
+sudo apt-get install libc6-i386  
+sudo apt-get install libgcc1:i386  
+sudo apt-get install lib32gcc1  
+sudo apt-get install libhttp-daemon-perl
+```
+
+**For all versions of Debian**
+```
+sudo apt-get install libxml-parser-perl libpath-class-perl perl-modules screen rsync sudo e2fsprogs unzip subversion pure-ftpd libarchive-zip-perl libc6 libgcc1 git curl  
+sudo apt-get install libc6-i386 lib32gcc1  
+sudo apt-get install libhttp-daemon-perl
+sudo apt-get install libarchive-extract-perl
+```
+
+## Step 2 - Installing the Agent
+
+Now we will download the Agent Easy-Installer of OGP and run it.
+
+### Step 2.1 Download & Install
+
+```
+wget "https://github.com/OpenGamePanel/Easy-Installers/raw/master/Linux/Debian-Ubuntu/ogp-agent-latest.deb"
+sudo dpkg -i "ogp-agent-latest.deb"
+```
+
+The OGP agent user (with sudo access) will be created automatically for you by the installer with a random password. To view the automatically generated encryption key, OGP username, and OGP user password, run the following command:
+
+```
+sudo cat /root/ogp_user_password
+```
+It will returns something like this:
+```
+root@local# sudo cat /root/ogp_user_password
+ogpUser=ogp_agent
+ogpPass=piLKDZYlAsAavRj
+ogpEnc=wq6yw4s5
+```
+You'll need the encryption key for the panel. *Eg: wq6yw4s5*
+
+### Step 2.2 Add to Panel
+
+Now open the Panel in your browser and navigate to Servers section:
+`Administration -> Servers`
+"Add New Remote Host" form will be displayed, Fill the form as per your Server credentials:
+```
+Remote Host: Your_Server_Ip
+Remote Host Port: 12679
+Remote Host Name: Any_Unique_Name_You_Want
+FTP IP: Your_Server_Ip
+FTP Port: 21
+Remote Encryption Key: Agent_Encryption_Key
+Time Out: 5
+Use NAT: off
+Display Public IP: Your_Server_Ip
+```
+Click on "Add Remote Host" button once you filled the form. You will get a green success message if everything is done as per tutorial.
+
+You will be able to see your Server added in Remote Host section just below the form. It should show your server status as "Online"
+
+Congrats! OGP Agent is now installed and added to your Panel. You can now add and run supported gameservers in it.
+
+## Step 3 - Running a CSGO Server (Optional)
+
+Counter Strike Global Offensive is a supported gameserver in OGP.
+If you wanna run a CSGO Server you can continue to read below (or you can go ahead and run other gameservers).
+
+Open the Panel in your browser and navigate to Game Servers section:
+`Administration -> Game Servers`
+
+Click on "Add new game server" button.
+
+It will show a dropdown to select the Agent you wanna add the gameserver to. Select your agent from dropdown and the page will reload with a new form asking for Game Type.
+
+Select `Counter Strike Global Offensive (Linux)` from the dropdown and click "Add game server" leaving every other option as default.
+
+It will create your server and open up Editing section of the server.
+In this section you can change name of server, set game password etc.
+
+Scroll down to the "IPs and Ports" section and assign any port you like to the server, and then go back to Game Monitor section using `<<Back to Game Monitor` button.
+
+Now we need to install the CSGO Server files from Steam. Click on `Install/Update via Steam` button and let the download complete.
+
+Once it is completed you can start the gameserver by clicking Start Server.
+
+CSGO Servers requires a token called GSLT. OGP will ask you to pass the token before starting the server.
+You can get one from here: [https://steamcommunity.com/dev/managegameservers](https://steamcommunity.com/dev/managegameservers)
+
+Your CSGO Server is now ready.
+
+## Conclusion
+
+Your OGP Agent is installed and added the the Panel which can be used to run hundreds of supported games with ease.
+
+##### License: MIT
+
+<!--
+
+Contributor's Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it under the license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate license and I have the
+    right under that license to submit that work with modifications,
+    whether created in whole or in part by me, under the same license
+    (unless I am permitted to submit under a different license), as
+    indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are
+    public and that a record of the contribution (including all personal
+    information I submit with it, including my sign-off) is maintained
+    indefinitely and may be redistributed consistent with this project
+    or the license(s) involved.
+
+Signed-off-by: kinnngg786@gmail.com
+
+-->

--- a/tutorials/install-and-configure-ogp-agent-and-csgo-server-in-debian-ubuntu/01.en.md
+++ b/tutorials/install-and-configure-ogp-agent-and-csgo-server-in-debian-ubuntu/01.en.md
@@ -53,19 +53,12 @@ sudo apt-get -y update && sudo apt-get -y upgrade
 ```
 sudo apt-get update  
 sudo apt-get upgrade  
-sudo apt-get install libxml-parser-perl libpath-class-perl perl-modules screen rsync sudo e2fsprogs unzip subversion libarchive-extract-perl pure-ftpd libarchive-zip-perl libc6 libgcc1 git curl  
-sudo apt-get install libc6-i386  
-sudo apt-get install libgcc1:i386  
-sudo apt-get install lib32gcc1  
-sudo apt-get install libhttp-daemon-perl
+sudo apt-get install libxml-parser-perl libpath-class-perl perl-modules screen rsync sudo e2fsprogs unzip subversion libarchive-extract-perl pure-ftpd libarchive-zip-perl libc6 libgcc1 git curl libc6-i386 libgcc1:i386 lib32gcc1 libhttp-daemon-perl 
 ```
 
 **For all versions of Debian**
 ```
-sudo apt-get install libxml-parser-perl libpath-class-perl perl-modules screen rsync sudo e2fsprogs unzip subversion pure-ftpd libarchive-zip-perl libc6 libgcc1 git curl  
-sudo apt-get install libc6-i386 lib32gcc1  
-sudo apt-get install libhttp-daemon-perl
-sudo apt-get install libarchive-extract-perl
+sudo apt-get install libxml-parser-perl libpath-class-perl perl-modules screen rsync sudo e2fsprogs unzip subversion pure-ftpd libarchive-zip-perl libc6 libgcc1 git curl libc6-i386 lib32gcc1 libhttp-daemon-perl libarchive-extract-perl
 ```
 
 ## Step 2 - Installing the Agent

--- a/tutorials/install-and-configure-ogp-agent-and-csgo-server-in-debian-ubuntu/01.en.md
+++ b/tutorials/install-and-configure-ogp-agent-and-csgo-server-in-debian-ubuntu/01.en.md
@@ -4,7 +4,7 @@ path: "/tutorials/install-and-configure-ogp-agent-and-csgo-server-in-debian-ubun
 slug: "install-and-configure-ogp-agent-and-csgo-server-in-debian-ubuntu"
 date: "2020-04-06"
 title: "Install & Configure OGP Agent & CSGO Server in Debian or Ubuntu"
-short_description: "This tutorial explains the procedure to install, configure OGP Agent and run a CSGO Server using it, in Debian or Ubuntu OS."
+short_description: "This tutorial explains the procedure to install, configure OGP Agent and run a CSGO Server or any other gameserver using it, in Debian or Ubuntu OS."
 tags: ["Gaming", "Gameserver", "OGP", "Agent", "CSGO", "Server"]
 author: "Zishan Ansari"
 author_link: "https://github.com/kinnngg"
@@ -17,7 +17,8 @@ header_img: "header-2"
 
 ## Introduction
 
-In this tutorial we will be installing the Agent of OGP which is responsible for running gameservers.
+In this tutorial we will be installing the Agent of OGP which is responsible for running gameservers. 
+We will also learn to run a basic CSGO gameserver using it. You can also follow similar procedure to run various other supported gameservers.
 
 *We can install Agent in same server where Panel is installed or we can install it in a totally fresh server and link it to panel running on different server.* 
 

--- a/tutorials/install-and-configure-ogp-agent-and-csgo-server-in-debian-ubuntu/01.en.md
+++ b/tutorials/install-and-configure-ogp-agent-and-csgo-server-in-debian-ubuntu/01.en.md
@@ -2,9 +2,9 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/install-and-configure-ogp-agent-and-csgo-server-in-debian-ubuntu"
 slug: "install-and-configure-ogp-agent-and-csgo-server-in-debian-ubuntu"
-date: "2020-04-06"
+date: "2020-04-17"
 title: "Install & Configure OGP Agent & CSGO Server in Debian or Ubuntu"
-short_description: "This tutorial explains the procedure to install, configure OGP Agent and run a CSGO Server or any other gameserver using it, in Debian or Ubuntu OS."
+short_description: "This tutorial explains the procedure to install and configure OGP Agent to run a CSGO Server or any other game server using it, in Debian or Ubuntu."
 tags: ["Gaming", "Gameserver", "OGP", "Agent", "CSGO", "Server"]
 author: "Zishan Ansari"
 author_link: "https://github.com/kinnngg"
@@ -17,17 +17,15 @@ header_img: "header-2"
 
 ## Introduction
 
-In this tutorial we will be installing the Agent of OGP which is responsible for running gameservers. 
-We will also learn to run a basic CSGO gameserver using it. You can also follow similar procedure to run various other supported gameservers.
+In this tutorial we will be installing the Agent of OGP which is responsible for running game servers.
+We will also learn to run a basic CSGO game server using it. You can also follow similar procedure to run various other supported game servers.
 
-*We can install Agent in same server where Panel is installed or we can install it in a totally fresh server and link it to panel running on different server.* 
+*We can install Agent in same server where Panel is installed or we can install it in a totally fresh server and link it to panel running on different server.*
 
 **Prerequisites**
 
-1. You will need a server with either Debian (9 or 10) or Ubuntu (18.04 or 16.04).
-
-2. We assume you already have installed Open Game Panel by following previous tutorial [here](https://community.hetzner.com/tutorials/install-and-configure-ogp-panel-in-debian-ubuntu).
-You need a Panel to control your Agent so it is recommend to follow it if you have not installed Panel yet.
+* A server with either Debian (9 or 10) or Ubuntu (18.04 or 16.04).
+* Open Game Panel already installed and configured. You can follow the [previous tutorial](https://community.hetzner.com/tutorials/install-and-configure-ogp-panel-in-debian-ubuntu) to do so.
 
 ## Step 1 - Agent Prerequisites
 
@@ -36,28 +34,28 @@ In this step we will be installing the packages that are needed to run the agent
 **Note:** If you are using Debian 10 or lower make sure you have sudo installed. If not then go ahead and install sudo using `apt-get install sudo` using your root account.
 
 Add your user to sudoer if not already done, using:
-```
+
+```bash
 usermod -aG sudo "{REPLACE_WITH_YOUR_LINUX_USERNAME}"
 ```
 
-### Step 1.1 General Update
+Make sure your server is up-to-date (this works for all distributions):
 
-**For all Distributions**
-```
+```bash
 sudo apt-get -y update && sudo apt-get -y upgrade
 ```
 
-### Step 1.2 Install Required Packages
+Then install the required packages.
 
-**For all versions of Ubuntu**
-```
-sudo apt-get update  
-sudo apt-get upgrade  
+For all versions of Ubuntu:
+
+```bash 
 sudo apt-get install libxml-parser-perl libpath-class-perl perl-modules screen rsync sudo e2fsprogs unzip subversion libarchive-extract-perl pure-ftpd libarchive-zip-perl libc6 libgcc1 git curl libc6-i386 libgcc1:i386 lib32gcc1 libhttp-daemon-perl 
 ```
 
-**For all versions of Debian**
-```
+For all versions of Debian:
+
+```bash
 sudo apt-get install libxml-parser-perl libpath-class-perl perl-modules screen rsync sudo e2fsprogs unzip subversion pure-ftpd libarchive-zip-perl libc6 libgcc1 git curl libc6-i386 lib32gcc1 libhttp-daemon-perl libarchive-extract-perl
 ```
 
@@ -67,31 +65,36 @@ Now we will download the Agent Easy-Installer of OGP and run it.
 
 ### Step 2.1 Download & Install
 
-```
+```bash
 wget "https://github.com/OpenGamePanel/Easy-Installers/raw/master/Linux/Debian-Ubuntu/ogp-agent-latest.deb"
 sudo dpkg -i "ogp-agent-latest.deb"
 ```
 
 The OGP agent user (with sudo access) will be created automatically for you by the installer with a random password. To view the automatically generated encryption key, OGP username, and OGP user password, run the following command:
 
-```
+```bash
 sudo cat /root/ogp_user_password
 ```
+
 It will returns something like this:
-```
+
+```bash
 root@local# sudo cat /root/ogp_user_password
 ogpUser=ogp_agent
 ogpPass=piLKDZYlAsAavRj
 ogpEnc=wq6yw4s5
 ```
-You'll need the encryption key for the panel. *Eg: wq6yw4s5*
+
+You'll need the encryption key for the panel. *In this case: wq6yw4s5*
 
 ### Step 2.2 Add to Panel
 
-Now open the Panel in your browser and navigate to Servers section:
+Now open the Panel in your browser and navigate to the servers section:
 `Administration -> Servers`
-"Add New Remote Host" form will be displayed, Fill the form as per your Server credentials:
-```
+
+"Add New Remote Host" form will be displayed. Fill the form as per your server credentials:
+
+```bash
 Remote Host: Your_Server_Ip
 Remote Host Port: 12679
 Remote Host Name: Any_Unique_Name_You_Want
@@ -102,43 +105,42 @@ Time Out: 5
 Use NAT: off
 Display Public IP: Your_Server_Ip
 ```
+
 Click on "Add Remote Host" button once you filled the form. You will get a green success message if everything is done as per tutorial.
 
-You will be able to see your Server added in Remote Host section just below the form. It should show your server status as "Online"
+You will be able to see your server added in Remote Host section just below the form. It should show your server status as "Online"
 
-Congrats! OGP Agent is now installed and added to your Panel. You can now add and run supported gameservers in it.
+Congrats! OGP Agent is now installed and added to your Panel. You can now add and run supported game servers in it.
 
 ## Step 3 - Running a CSGO Server (Optional)
 
-Counter Strike Global Offensive is a supported gameserver in OGP.
-If you wanna run a CSGO Server you can continue to read below (or you can go ahead and run other gameservers).
+Counter Strike Global Offensive is a supported game server in OGP. If you want to run a CSGO server you can continue to read below (or you can go ahead and run other game servers).
 
 Open the Panel in your browser and navigate to Game Servers section:
 `Administration -> Game Servers`
 
 Click on "Add new game server" button.
 
-It will show a dropdown to select the Agent you wanna add the gameserver to. Select your agent from dropdown and the page will reload with a new form asking for Game Type.
+It will show a dropdown to select the Agent you want to add the game server to. Select your agent from the dropdown and the page will reload with a new form asking for Game Type.
 
 Select `Counter Strike Global Offensive (Linux)` from the dropdown and click "Add game server" leaving every other option as default.
 
-It will create your server and open up Editing section of the server.
-In this section you can change name of server, set game password etc.
+It will create your server and open up the editing section of the server. In this section you can change the name of server, set a game password, etc.
 
-Scroll down to the "IPs and Ports" section and assign any port you like to the server, and then go back to Game Monitor section using `<<Back to Game Monitor` button.
+Scroll down to the "IPs and Ports" section and assign any port you like to the server, and then go back to the Game Monitor section using `<<Back to Game Monitor` button.
 
 Now we need to install the CSGO Server files from Steam. Click on `Install/Update via Steam` button and let the download complete.
 
-Once it is completed you can start the gameserver by clicking Start Server.
+Once it is completed you can start the game server by clicking Start Server.
 
-CSGO Servers requires a token called GSLT. OGP will ask you to pass the token before starting the server.
+CSGO servers requires a token called GSLT. OGP will ask you for the token before starting the server.
 You can get one from here: [https://steamcommunity.com/dev/managegameservers](https://steamcommunity.com/dev/managegameservers)
 
-Your CSGO Server is now ready.
+Your CSGO server is now ready.
 
 ## Conclusion
 
-Your OGP Agent is installed and added the the Panel which can be used to run hundreds of supported games with ease.
+Your OGP Agent is installed and added to the Panel which can be used to run hundreds of supported games with ease.
 
 ##### License: MIT
 


### PR DESCRIPTION
This is a follow-up tutorial for my previous tutorial of the OGP Panel. This will explain to install Agent and link it to be used for any supported game servers.

I have read and understood the Contributor's Certificate of Origin available at the end of 
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Zishan Ansari <kinnngg786@gmail.com>