### PR TITLE
Debian 10 / Proxmox VE 6.0 Hinweis

### DIFF
--- a/tutorials/install-and-configure-proxmox_ve/01.de.md
+++ b/tutorials/install-and-configure-proxmox_ve/01.de.md
@@ -44,6 +44,7 @@ Um einen möglichst stabilen Betrieb zu ermöglichen empfiehlt es sich die geeig
 
 * Seit Proxmox 4.0: Debian 8 (jessie)
 * Seit Proxmox 5.0: Debian 9 (stretch)
+* Seit Proxmox 6.0: Debian 10 (buster)
 
 Nach Wunsch RAID-Level, Partitionierung und Hostnamen in der Konfiguration anpassen
 


### PR DESCRIPTION
In Zeile 47 den Hinweis für Debian 10 Proxmox VE 6.0 hinzugefügt