### PR TITLE
Update tutorial with maintained version of watchtover docker image

### DIFF
--- a/tutorials/docker-compose-as-systemd-service/01.en.md
+++ b/tutorials/docker-compose-as-systemd-service/01.en.md
@@ -36,7 +36,7 @@ For this tutorial we will store our Docker Compose service configurations under 
 mkdir /etc/docker-compose
 ```
 
-Just as an example, let's say we want to run [watchtower](https://hub.docker.com/r/v2tec/watchtower/) to keep our running containers up to date. We have to create a directory for that service in `/etc/docker-compose`:
+Just as an example, let's say we want to run [watchtower](https://hub.docker.com/r/containrrr/watchtower) to keep our running containers up to date. We have to create a directory for that service in `/etc/docker-compose`:
 
 ```bash
 mkdir /etc/docker-compose/watchtower
@@ -49,14 +49,14 @@ version: "3"
 
 services:
   watchtower:
-    image: v2tec/watchtower
+    image: containrrr/watchtower
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     command: --cleanup --no-pull
 ```
 
-For more info about the options specified under `command` take a look at [watchtower](https://hub.docker.com/r/v2tec/watchtower/).
+For more info about the options specified under `command` take a look at [watchtower](https://hub.docker.com/r/containrrr/watchtower).
 Here we specify that old images should be removed after updating to a new image (`--cleanup`).
 We also tell watchtower that it should not check for newer images itself (`--no-pull`). This option is recommended if you are building your own images (without pushing them to the Docker Registry). We will take care of pulling new images regularly later. If you don't plan on building your own images then you can just omit `--no-pull` and also skip step 3.
 

--- a/tutorials/docker-compose-as-systemd-service/01.ru.md
+++ b/tutorials/docker-compose-as-systemd-service/01.ru.md
@@ -36,7 +36,7 @@ header_img: ""
 mkdir /etc/docker-compose
 ```
 
-В качестве примера предположим, что мы хотим запустить [watchtower](https://hub.docker.com/r/v2tec/watchtower/), чтобы поддерживать наши работающие контейнеры в актуальном состоянии. Мы должны создать каталог для этой службы в `/etc/docker-compose`:
+В качестве примера предположим, что мы хотим запустить [watchtower](https://hub.docker.com/r/containrrr/watchtower), чтобы поддерживать наши работающие контейнеры в актуальном состоянии. Мы должны создать каталог для этой службы в `/etc/docker-compose`:
 
 ```bash
 mkdir /etc/docker-compose/watchtower
@@ -49,14 +49,14 @@ version: "3"
 
 services:
   watchtower:
-    image: v2tec/watchtower
+    image: containrrr/watchtower
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     command: --cleanup --no-pull
 ```
 
-Для получения дополнительной информации о параметрах, указанных в `command`, посетите страницу [watchtower](https://hub.docker.com/r/v2tec/watchtower/).
+Для получения дополнительной информации о параметрах, указанных в `command`, посетите страницу [watchtower](https://hub.docker.com/r/containrrr/watchtower).
 Здесь мы указываем, что старые образы должны быть удалены после обновления до нового образа (`--cleanup`).
 Мы также говорим watchtower, что не нужно проверять наличие новых образов (`--no-pull`). Эта опция рекомендуется, если вы собираете свои собственные образы (без отправки их в Docker Registry). Мы настроим регулярное получение новых образов позже. Если вы не планируете собирать свои собственные образы, то вы можете просто опустить `--no-pull`, а также пропустить шаг 3.
 


### PR DESCRIPTION
The docker image `v2tec/watchtower` is not maintained anymore, instead use
the currently maintained version `containrrr/watchtower`.

---

I have read and understood the Contributor's Certificate of Origin
available at the end of https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Bernd Stellwag <burned@zerties.org>