### PR TITLE
Fix some typos in the symfony tutorial

### DIFF
--- a/tutorials/a-basic-guide-to-php-symfony/01.en.md
+++ b/tutorials/a-basic-guide-to-php-symfony/01.en.md
@@ -346,11 +346,11 @@ a-basic-guide-to-php-symfony
 - Symfony has a `translations` engine built in; the translation files are held in this directory.
 - The `var` and the `vendor` folder can be safely ignored but shall not be deleted!
 
-Having done that, we are set an ready to learn something about Routes, Templates and Controllers in the next part of this tutorial.
+Having done that, we are set and ready to learn something about Routes, Templates and Controllers in the next part of this tutorial.
 
 ## Conclusion
 
-By now we have setup symfony and started the development server. This is essential in order to follow along with the next parts.
+By now we have setup Symfony and started the development server. This is essential in order to follow along with the next parts.
 
 <!---
 

--- a/tutorials/a-basic-guide-to-php-symfony/02.en.md
+++ b/tutorials/a-basic-guide-to-php-symfony/02.en.md
@@ -24,7 +24,7 @@ header_img: ""
 
 Symfony handles routing for us, that is one of its super powers. Routing means, that when we open `/hello/World` in our browser, it will match the request to the function generating our response.
 
-Symfony is based arround the concept of routes, a route is the path that comes after our domain. In the case of `https://example.com/hello/World` the `/hello/World` is our route. the functions symfony will match that request to, are organized in multiple controllers. It is possible, and therefore highly recommended, to use multiple well named controllers. Example given: an online Shop would have commended, to use multiple well named controllers. Example given: in an online Shop we may have a `ProductController`, a `PrivacyController` (may the GDPR be blessed), a `PurchaseController` and so on. If we someone looks at our code it immediatly is clear what this controller is for.
+Symfony is based around the concept of routes, a route is the path that comes after our domain. In the case of `https://example.com/hello/World` the `/hello/World` is our route. The functions Symfony will match that request to, are organized in multiple controllers. It is possible, and therefore highly recommended, to use multiple well named controllers. Example given: in an online Shop we may have a `ProductController`, a `PrivacyController` (may the GDPR be blessed), a `PurchaseController` and so on. If someone looks at our code it immediately is clear what this controller is for.
 
 ## Step 1 - Creating our first route
 
@@ -64,7 +64,7 @@ return $this->render('default/index.html.twig', [
 
 Here we can see two things:
 
-- `default/index.html.twig` is the path to the new files insides of our `templates` folder. This is the path to our twig template.
+- `default/index.html.twig` is the path to the new file inside of our `templates` folder. This is the path to our Twig template.
 - As a second argument we pass an array, containing `controller_name` with the value `DefaultController`. We use those parameters inside of our template. More on that later.
 
 Before we go ahead it's vital to understand the created code.
@@ -85,7 +85,7 @@ public function index()
 
 We can see in this comment-block, that our route is `/default`
 
-When we open `localhost:8000/default`, given your development server is running at this port, we should see a output containing `Hello DefaultController! ✅`. This is brought to us by the `return $this->render` expression inside of our index function. This generates the HTML content show the user, based on the passed template. `fault/index.html.twig` is that in our case. Parameters are also passed to our template. They are located inside of the square brackets at the end.
+When we open `localhost:8000/default`, given your development server is running at this port, we should see an output containing `Hello DefaultController! ✅`. This is brought to us by the `return $this->render` expression inside of our index function. This generates the HTML content shown to the user, based on the passed template, which is `default/index.html.twig` in our case. Parameters are also passed to our template. They are located inside of the square brackets at the end.
 
 At the moment we only pass the argument `controller_name` with the value `'DefaultController'`. In the next step we will learn how to use those arguments passed.
 
@@ -97,11 +97,11 @@ Symfony uses [Twig](https://twig.symfony.com/) as a template engine. Such a temp
 - it doesn't clutter our PHP code
 - it's easier to split the work for the backend / frontend
 
-For now we look at the `templates/default/index.html.twig` . In here we notice a couple of things:
+For now we look at the `templates/default/index.html.twig`. In here we notice a couple of things:
 
-- `{% extends 'base.html.twig' %}`: This indicates that all of our content is based on the `base.html.twig`. In here we would include our CSS and JS. Navabars would preferably be defined here to.
-- `{% block body %} [...]{% endblock %}`: In our base template we define several blocks. They act like placeholders. If a block is previously defined in another template, it will be overwritten. By utilizing that we may define default values, for example in the title.
-- `<h1>Hello {{ controller_name }}! ✅</h1>`: This is a basic h1 tag. The `{{ controller_name }}` is the most interesting part in here. In the previous section we passed an argument with the same name to our template.
+- `{% extends 'base.html.twig' %}`: This indicates that all of our content is based on the `base.html.twig`. In here we would include our CSS and JS. Navbars would preferably be defined here to.
+- `{% block body %} [...] {% endblock %}`: In our base template we define several blocks. They act like placeholders. If a block is previously defined in another template, it will be overwritten. By utilizing that we may define default values, for example in the title.
+- `<h1>Hello {{ controller_name }}! ✅</h1>`: This is a basic `h1` tag. The `{{ controller_name }}` is the most interesting part in here. In the previous section we passed an argument with the same name to our template.
 
 <details>
     <summary>(Click to expand) full index.html.twig</summary>
@@ -180,11 +180,11 @@ This is a simple task to consolidate our knowledge:
 
 </details>
 
-We now know how templates work and how we pass arguments to them. For a more in depth documentation of the functions twig offers please refer to the [official Twig documentation](https://twig.symfony.com/doc/2.x/).
+We now know how templates work and how we pass arguments to them. For a more in depth documentation of the functions Twig offers please refer to the [official Twig documentation](https://twig.symfony.com/doc/2.x/).
 
 ## Step 4 - Creating our first custom routes
 
-Creating our first custom route is the first step to take full advantage of Symfonys Routing feature. An infamous hello world page will be enough for now:
+Creating our first custom route is the first step to take full advantage of Symfony's Routing feature. An infamous hello world page will be enough for now:
 
 - Add the route `/default/hello`
 - Create a `hello.html.twig` template
@@ -268,7 +268,7 @@ We have all seen it, for example in an online shop: the name or ID of a product 
 The content of the following steps is:
 
 - outsourcing our hello world into a `HelloController`
-- rename the route `/default/hello` to `/hello/World` where the `World` part is modifiably by the user and is passed to the template
+- rename the route `/default/hello` to `/hello/World` where the `World` part is modifiable by the user and is passed to the template
 
 We create our new controller by using the command `php bin/console make:controller HelloController`. In Step 1 this was already covered. The `/default/hello` route is no longer needed and can therefore be removed. We also move our `hello.html.twig` from `templates/default/hello.html.twig` to `templates/hello/index.html.twig`. The `hello/index.html.twig` can be overwritten / deleted beforehand.
 
@@ -294,7 +294,7 @@ When we open [localhost:8000/hello/World](http://localhost:8000/hello/World). We
 
 That's just what we had before. But what if we want to greet Hetzner as a thank you for this community space? Well, just replace the `World` with `Hetzner` and we're greeted by a `Hello Hetzner!`.
 
-This is cool isn't it? But what happens when we open `/hello/`? Now we are greeted by a `No route found for "GET /hello/": HTTP 404 Not Found`. This is neither our template nor even anything nice at all. But what can we do about it? We can define default values! Since the route parameters are passed as function parametes, we can define this directly at the function.
+This is cool isn't it? But what happens when we open `/hello/`? Now we are greeted by a `No route found for "GET /hello/": HTTP 404 Not Found`. This is neither our template nor even anything nice at all. But what can we do about it? We can define default values! Since the route parameters are passed as function parameters, we can define this directly at the function.
 
 We just change the function from `public function index($who)` to `public function index($who = "World")`! This is the exact same way we set default values for a function parameter in php!
 
@@ -304,7 +304,7 @@ If you want to do more reading on route parameters, for example how to verify th
 
 You may have noticed that we set a name for each and every one of our routes. But we haven't used them yet, so it's reasonable to assume that it's unneeded overhead. First of all, it's not needed! We do not have to write the `name="default"` part of the annotation. But why are we doing it anyways? Because you can do powerful things with it!
 
-There are two main features we will take a look at for now. Those beeing redirecting and linking.
+There are two main features we will take a look at for now. Those being redirecting and linking.
 
 ### Redirecting
 
@@ -359,19 +359,19 @@ This keeps us away from problems if we may change the route from `/hello/{who}` 
 
 ### Linking
 
-It is super easy to generate links inside of our template. Those we can use or an `a href` but also everywhere else.
+It is super easy to generate links inside of our template. Those we can use for an `a href` but also everywhere else.
 
-Two twig functions will be employed by us in the following steps:
+Two Twig functions will be employed by us in the following steps:
 
 - `path`
 - `url`
 
-The first one we mostly use for linking on the website because it only generates the relative URL. So it spits out the `/hello/Guest`.  When the user is already on our website this is perfectly fine. But when we want to offer users a share link or anythink like this, it isn't feesable to only have the relative path. The `url` function is used when you want to include the domain in the output. Passing a simple argument we can get the result of the other function too, it's way clearer when we stick to `path` for on-site linking and `url` for anything that comes from of-site.
+The first one we mostly use for linking on the website because it only generates the relative URL. So it spits out the `/hello/Guest`.  When the user is already on our website this is perfectly fine. But when we want to offer users a share link or anything like this, it isn't feasible to only have the relative path. The `url` function is used when you want to include the domain in the output. Passing a simple argument we can get the result of the other function too, it's way clearer when we stick to `path` for on-site linking and `url` for anything that comes from of-site.
 
 We do the following:
 
 - link from `/default/` to `/hello/You`
-- show the user a sharable url on `/hello/{who}`
+- show the user a shareable url on `/hello/{who}`
 
 By adding one line to our `templates/default/index.html.twig` we can accomplish the first thing. Since this is a HTML Hyperlink, we are using the `a` tag.
 
@@ -379,9 +379,9 @@ By adding one line to our `templates/default/index.html.twig` we can accomplish 
 <li><a href="{{ path('hello', {'who': 'You'}) }}">Hello You!</a></li>
 ```
 
-We pass two parameters to our `path` function, the same as we did when redirecting. First is the route_name and in second position the route parameters.
+We pass two parameters to our `path` function, the same as we did when redirecting. First is the route name and in second position the route parameters.
 
-By adding the following lines to our hello page, we show our users a sharable link:
+By adding the following lines to our hello page, we show our users a shareable link:
 
 ```twig
 <br>


### PR DESCRIPTION
While reading the Symfony tutorial I found some typos and fixed them.

---

I have read and understood the Contributor's Certificate of Origin available at the end of 
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Bernd Stellwag <burned@zerties.org>