### PR TITLE
Add further clarification on why there is an explicit check if the server exists

### DIFF
--- a/tutorials/howto-hcloud-kickstart-centos/01.en.md
+++ b/tutorials/howto-hcloud-kickstart-centos/01.en.md
@@ -119,8 +119,9 @@ Then check if the server already exists and ensure it is created:
 ```
 
 Why the explicit check if the server exists?
-It is not possible to know if a server was newly created based on the return values of the `hcloud_server` module.
-Kickstarting is a rather destructive operation.
+We want this playbook to be idempotent, meaning that it can be run multiple times without affecting any servers that are already deployed.
+The `hcloud_server` module has built-in safeguards that will prevent it from trying to recreate an existing server, but it is not possible to know if a server was newly created based on its return values.
+Later on in the playbook we want to make sure that only brand new servers are being kickstarted since this is a rather destructive operation.
 I prefer that it does not happen when I change the size of my server.
 
 Finally update the in-memory inventory with the IP address of the server.


### PR DESCRIPTION
I was following the tutorial but it was not clear at this point why the `hcloud_server_info` check is done. The existing explanation makes it seem that it is done to allow the following step to be skipped, but its value is never read.

Only after completing the full tutorial it becomes clear that this value is used later on, and the `hcloud_server` module is in fact not recreating an existing server.