### PR TITLE
Fix path of tutorial

### DIFF
--- a/tutorials/debian-10-docker-install-dualstack-ipv6nat-firewall/01.en.md
+++ b/tutorials/debian-10-docker-install-dualstack-ipv6nat-firewall/01.en.md
@@ -1,6 +1,6 @@
 ---
 SPDX-License-Identifier: MIT
-path: "/tutorials/debian-10-docker-install-dual stack-ipv6nat-firewall"
+path: "/tutorials/debian-10-docker-install-dualstack-ipv6nat-firewall"
 slug: "debian-10-docker-install-dualstack-ipv6nat-firewall"
 date: "2019-08-20"
 title: "Install Docker CE on Debian 10 with Dual stack IPv6-NAT and Firewall Support"


### PR DESCRIPTION
There is a space in the path of the tutorial.