### PR TITLE
Fix available_languages

### DIFF
--- a/tutorials/install-public-ntp-server-on-debian-ubuntu/01.en.md
+++ b/tutorials/install-public-ntp-server-on-debian-ubuntu/01.en.md
@@ -10,7 +10,7 @@ author_link: "https://github.com/n-se"
 author_img: "https://avatars0.githubusercontent.com/u/34218225?s=400&v=4"
 author_description: ""
 language: "en"
-available_languages: ["en, ru"]
+available_languages: ["en", "ru"]
 header_img: ""
 ---
 

--- a/tutorials/install-public-ntp-server-on-debian-ubuntu/01.ru.md
+++ b/tutorials/install-public-ntp-server-on-debian-ubuntu/01.ru.md
@@ -10,7 +10,7 @@ author_link: "https://github.com/n-se"
 author_img: "https://avatars0.githubusercontent.com/u/34218225?s=400&v=4"
 author_description: ""
 language: "ru"
-available_languages: ["en, ru"]
+available_languages: ["en", "ru"]
 header_img: ""
 ---
 


### PR DESCRIPTION
The `available_languages` array of the tutorial consists of a single language `en, ru` instead of two languages `en` and `ru`.