### PR TITLE
Added english tutorial for Grafana monitoring

### DIFF
--- a/tutorials/server-monitoring-using-grafana-and-influxdb/01.en.md
+++ b/tutorials/server-monitoring-using-grafana-and-influxdb/01.en.md
@@ -1,0 +1,309 @@
+## Monitor your Servers on Grafana with InfluxDB and Telegraf on Ubuntu 20.04
+
+### Introduction
+
+Grafana is Monitoring Software for Data visualization. You can display every data, on several Graphs or Gauges. We will use Telegraf for storing the Data into InfluxDB, which will be displayed on a Grafana Dashboard.
+
+
+![grafik](https://user-images.githubusercontent.com/83845082/117866040-f3335c00-b296-11eb-9afc-641b1ae2c755.png)
+
+
+### Step 1 - Setup DNS Entry
+
+We now set up a DNS record. In the end, a web server will run with Grafana. For an SSL certificate, this is necessary.
+
+If you use the Hetzner DNS console, you can edit the following entry as you wish and insert it accordingly via the "manual Zonefile editing". Otherwise it would be necessary to create a DNS entry with your respective provider. We will proceed here with `grafana.yourdomain.com` .
+
+Grafana address:
+
+`grafana IN A <yourServerIPv4>`
+
+`grafana IN AAAA <yourServerIPv6>`
+
+Influx address:
+
+`influx IN A <yourServerIPv4>`
+
+`influx IN AAAA <yourServerIPv6>`
+
+### Step 2 - Install InfluxDB
+
+Therefore we need to add the InfluxDB repos to our OS:
+```
+$ curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+$ source /etc/lsb-release
+$ echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
+```
+After that, we need to update and install the package:
+```
+$ apt-get update && apt-get install influxdb -y
+```
+Now we need to start and start our service and check if its running without problems:
+Starting:
+```
+$ systemctl start influxdb
+```
+Checking:
+```
+$ systemctl status influxdb
+```
+
+The Output should look similar to this:
+
+```
+● influxdb.service - InfluxDB is an open-source, distributed, time series database
+     Loaded: loaded (/lib/systemd/system/influxdb.service; enabled; vendor preset: enabled)
+     Active: active (running) since Sun 2021-05-09 21:25:00 CEST; 2s ago
+       Docs: https://docs.influxdata.com/influxdb/
+   Main PID: 6038 (influxd)
+      Tasks: 8 (limit: 2286)
+     Memory: 8.7M
+     CGroup: /system.slice/influxdb.service
+             └─6038 /usr/bin/influxd -config /etc/influxdb/influxdb.conf
+```
+
+We have now correctly Installed Influx. Your service should now already available on the default Port 8086
+
+In order to start InfluxDB on restart, we need to run the following command:
+```
+$ systemctl enable influxdb
+```
+Now that we have installed influxdb correctly we will go to to the `influxdb cli` and create a admin- and telegrafuser for authentification. (Please use a secure password for authenfication)
+
+```
+influx
+```
+```
+> CREATE USER admin WITH PASSWORD 'password' WITH ALL PRIVILEGES
+> CREATE USER telegraf WITH PASSWORD 'password' WITH ALL PRIVILEGES
+> show users
+```
+The output should look like this:
+```
+user     admin
+----     -----
+admin    true
+telegraf true
+```
+Leave the influx-cli with the command `exit`
+
+Now that we have created our Users, we can configure InfluxDB for basic auth.
+Edit the file `/etc/influxdb/influxdb.conf` with a texteditor of your choice.
+As a beginner you can use `nano` -> for example: `nano /etc/influxdb/influxdb.conf`
+
+Uncomment the neccesary lines to get a output like this:
+```
+[http]
+  # Determines whether HTTP endpoint is enabled.
+  enabled = true
+  # The bind address used by the HTTP service.
+  bind-address = ":8086"
+  # Determines whether user authentication is enabled over HTTP/HTTPS.
+  auth-enabled = true
+```
+To refresh our changes to the config, we need to restart InfluxDB
+```
+$ systemctl restart influxdb
+```
+
+### Step 3 - Install Telegraf
+Telegraf will pass the neccessary information, of the system to monitor, to InfluxDB.
+
+Add the corresponding repositories for Telegraf:
+
+```
+$ wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+$ source /etc/lsb-release
+$ echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
+```
+Update again and install Telegraf
+```
+$ apt-get update
+$ apt-get install apt-transport-https -y && sudo apt-get install telegraf -y
+```
+Now we do not start the software immidiately, but we edit the `/etc/telegraf/telegraf.conf`
+
+```
+## HTTP Basic Auth
+  username = "telegraf"
+  password = "password"
+```
+Now we we need to add a configfile for the collection of some extra data:
+```
+touch /etc/telegraf/telegraf.d/netquery.conf
+```
+Now that we have created the file edit it (`/etc/telegraf/telegraf.d/netquery.conf`).
+
+Here you paste the following content
+```
+[[inputs.net]]
+[[inputs.netstat]]
+```
+It’s possible to check your new configuration, isolated from the running Telegraf service:
+
+```
+telegraf --test --config /etc/telegraf/telegraf.d/netquery.conf
+```
+If the test runs well the output should look similar like this:
+
+```
+2021-05-11T18:55:12Z I! Starting Telegraf 1.18.2                                                                                                                                                                                             │·······
+> net,host=influxderlux,interface=eth0 bytes_recv=277919062i,bytes_sent=10841698i,drop_in=0i,drop_out=0i,err_in=0i,err_out=0i,packets_recv=26173i,packets_sent=20289i 1620759313000000000                                                    │·······
+> net,host=influxderlux,interface=all icmp_inaddrmaskreps=0i,icmp_inaddrmasks=0i,icmp_incsumerrors=0i,icmp_indestunreachs=40i,icmp_inechoreps=0i,icmp_inechos=0i,icmp_inerrors=0i,icmp_inmsgs=40i,icmp_inparmprobs=0i,icmp_inredirects=0i,icm│·······
+p_insrcquenchs=0i,icmp_intimeexcds=0i,icmp_intimestampreps=0i,icmp_intimestamps=0i,icmp_outaddrmaskreps=0i,icmp_outaddrmasks=0i,icmp_outdestunreachs=45i,icmp_outechoreps=0i,icmp_outechos=0i,icmp_outerrors=0i,icmp_outmsgs=45i,icmp_outparm│·······
+probs=0i,icmp_outredirects=0i,icmp_outsrcquenchs=0i,icmp_outtimeexcds=0i,icmp_outtimestampreps=0i,icmp_outtimestamps=0i,icmpmsg_intype3=40i,icmpmsg_outtype3=45i,ip_defaultttl=64i,ip_forwarding=2i,ip_forwdatagrams=0i,ip_fragcreates=0i,ip_│·······
+fragfails=0i,ip_fragoks=0i,ip_inaddrerrors=0i,ip_indelivers=11393i,ip_indiscards=0i,ip_inhdrerrors=0i,ip_inreceives=11395i,ip_inunknownprotos=0i,ip_outdiscards=20i,ip_outnoroutes=0i,ip_outrequests=13173i,ip_reasmfails=0i,ip_reasmoks=0i,i│·······
+p_reasmreqds=0i,ip_reasmtimeout=0i,tcp_activeopens=25i,tcp_attemptfails=0i,tcp_currestab=6i,tcp_estabresets=3i,tcp_incsumerrors=1i,tcp_inerrs=2i,tcp_insegs=26217i,tcp_maxconn=-1i,tcp_outrsts=83i,tcp_outsegs=23812i,tcp_passiveopens=108i,t│·······
+cp_retranssegs=17i,tcp_rtoalgorithm=1i,tcp_rtomax=120000i,tcp_rtomin=200i,udp_ignoredmulti=0i,udp_incsumerrors=0i,udp_indatagrams=206i,udp_inerrors=0i,udp_noports=45i,udp_outdatagrams=246i,udp_rcvbuferrors=0i,udp_sndbuferrors=0i,udplite_│·······
+ignoredmulti=0i,udplite_incsumerrors=0i,udplite_indatagrams=0i,udplite_inerrors=0i,udplite_noports=0i,udplite_outdatagrams=0i,udplite_rcvbuferrors=0i,udplite_sndbuferrors=0i 1620759313000000000                                            │·······
+> netstat,host=influxderlux tcp_close=0i,tcp_close_wait=0i,tcp_closing=0i,tcp_established=6i,tcp_fin_wait1=0i,tcp_fin_wait2=0i,tcp_last_ack=0i,tcp_listen=5i,tcp_none=20i,tcp_syn_recv=0i,tcp_syn_sent=0i,tcp_time_wait=0i,udp_socket=8i 162
+```
+
+
+Restart telegraf and check its status:
+```
+$ systemctl restart telegraf
+$ systemctl status telegraf
+```
+If everything runs without problems, also add it to the autostart:
+
+```
+$ systemctl enable telegraf
+```
+### Step 4 - Install Grafana
+
+Finally, we can install Grafana for visualisation of the InfluxDB Tables and Values, which are created by Telegraf.
+
+Therefore we install the neccesary software and add the grafana repository, after that we update and install Grafana.
+```
+$ apt-get install -y apt-transport-https
+$ apt-get install -y software-properties-common wget
+$ wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
+$ echo "deb https://packages.grafana.com/oss/deb stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
+$ apt-get update && apt-get install grafana -y
+```
+As we already did for InfluxDB and Telegraf we start the Software, check the Status and if everything runs well, we add it to the autostart:
+```
+$ systemctl daemon-reload && systemctl start grafana-server
+$ systemctl status grafana-server
+```
+If everything runs well, we also add it to the autostart:
+```
+$ systemctl enable grafana-server
+```
+### Step 5 - Install a Nginx as proxyserver, to secure your connections:
+
+If you would only use it on your local machine, you would not need to secure your connection, if you dont expose it to the internet. However, we also need a SSL Certificate for Grafana, so we need one anyway.
+
+Therefore we need to get a SSL Certificate. On this tutorial we will use a nginx webserver in order to redirect the traffic and get a Certificate for `grafana.<example.com>` and `influx.<example.com>` 
+```
+$ apt-get -y install certbot nginx python3-certbot-nginx
+$ touch /etc/nginx/sites-available/proxy
+```
+Edit `/etc/nginx/sites-available/proxy` and paste the following edited config:
+
+```
+server {
+  listen <yourServerIPv4>:443 ssl;
+  server_name influx.yourdomain.com;
+    ssl_certificate /etc/letsencrypt/live/influx.yourdomain.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/influx.yourdomain.com/privkey.pem;
+
+  location / {
+    proxy_pass http://127.0.0.1:8086;
+  }
+
+}
+
+server {
+  listen <yourServerIPv4>:443 ssl;
+  server_name grafana.yourdomain.com;
+    ssl_certificate /etc/letsencrypt/live/influx.yourdomain.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/influx.yourdomain.com/privkey.pem;
+
+  location / {
+    proxy_pass http://127.0.0.1:3000;
+  }
+
+}
+
+server {
+  listen 80;
+  listen [::]:80;
+    server_name influx.yourdomain.com grafana.yourdomain.com;
+    return 301 https://$host$request_uri;
+
+}
+```
+After editing run the following commands to create a certificate:
+```
+$ ln -s /etc/nginx/sites-available/proxy /etc/nginx/sites-enabled/proxy
+$ systemctl stop nginx.service
+$ certbot certonly -d influx.yourdomain.com -d grafana.yourdomain.com
+```
+Now spinup a temporary webserver, with option `2` and complete the necessary dialog.
+After that restart nginx
+```
+$ systemctl restart nginx.service
+```
+
+### Step 6 - Add a Datasource and a Dashboard
+
+Go to `https://grafana.<example.com>` and login with the default credentials `User: admin` `password: admin`
+
+After that go to "Datasources"
+
+![grafik](https://user-images.githubusercontent.com/83845082/117588999-64540180-b127-11eb-94c2-41c3f40c6ee7.png)
+
+With "Add data source" you can add your local InfluxDB Database
+
+Configure it as follows:
+![grafik](https://user-images.githubusercontent.com/83845082/117722259-22879180-b1e1-11eb-9784-4b8f4f5253dd.png)
+
+Now that we have a working datasource for Grafana, we can start importing a Dashboard for your Server.
+
+![grafik](https://user-images.githubusercontent.com/83845082/117589120-f52add00-b127-11eb-9552-2911e2e613dc.png)
+
+There are a plenty of already availabile dashboards for Telegraf and InfluxDB.
+As a example, we will work with a dashboard I created for this tutorial:
+
+https://grafana.com/grafana/dashboards/14419
+
+![grafik](https://user-images.githubusercontent.com/83845082/117866656-aac86e00-b297-11eb-9040-0fc7207d9315.png)
+
+Rename it to your needs and import it accordingly.
+
+![grafik](https://user-images.githubusercontent.com/83845082/117866852-e6fbce80-b297-11eb-81f9-93fac8625d01.png)
+
+Save the dashboard by clicking the "save" icon in the upper right corner. 
+
+![grafik](https://user-images.githubusercontent.com/83845082/117866986-0eeb3200-b298-11eb-84df-b67c55ae2826.png)
+
+
+### Step 7 (optional) - Monitor other Servers:
+
+Now, in order to monitor your other Servers, you would only need to install telegraf on the corresponding machine and edit the `/etc/telegraf/telegraf.conf`.
+Here we repleace the `http://127.0.0.1:8086` with `https://influx.yourdomain.com:8086`.
+```
+[[outputs.influxdb]]
+  ## The full HTTP or UDP URL for your InfluxDB instance.
+  ##
+  ## Multiple URLs can be specified for a single cluster, only ONE of the
+  ## urls will be written to each interval.
+  # urls = ["unix:///var/run/influxdb.sock"]
+  # urls = ["udp://127.0.0.1:8089"]
+   urls = ["https://influx.yourdomain.com:8086"]
+```
+
+We also need to add the credentials for the telegraf user, again:
+
+```
+## HTTP Basic Auth
+  username = "telegraf"
+  password = "password"
+```
+You can now add another Datasource on Grafana, with the same address and credentials, but another Database.
+
+## FINALLY! You made it. You installed a monitoring System for your Server
+
+You can now use Grafana. For example you can now  create additional dashboards and users. Grafana also offers an alerting function in case of e.g. unavailability.


### PR DESCRIPTION
I have written a tutorial on how to install Grafana on Ubuntu 20.04. It uses InfluxDB and Telegraf, there is also a corresponding dashboard.

I have read and understood the Contributor's Certificate of Origin available at the end of 
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Tim Stich