### PR TITLE
Fix the existing tutorial

### DIFF
--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption-with-clevis-and-tang/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption-with-clevis-and-tang/01.de.md
@@ -5,7 +5,7 @@ slug: "install-encrypted-ubuntu-2004-with-automated-unlock-via-tang-and-clevis"
 date: "2021-06-29"
 title: "Wie installiert man ein verschluesseltes Ubuntu20.04 mit automatisierter entsperrung via tang und clevis"
 short_description: "Dieses Tutorial beschreibt, wie Sie einen einfachen Tang-Server konfigurieren und ein verschlüsseltes Ubuntu 20.04 installieren, dass dann automatisch über clevis freigeschaltet wird"
-tags: ["Ubuntu", "installimage", "encryption", "clevis", "tang", "FDE", initramfs"]
+tags: ["Ubuntu", "installimage", "encryption", "clevis", "tang", "FDE", "initramfs"]
 author: "Philipp Roth"
 author_link: "https://github.com/roth-wine"
 author_img: "https://avatars.githubusercontent.com/u/64258033"

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption-with-clevis-and-tang/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption-with-clevis-and-tang/01.en.md
@@ -1,6 +1,6 @@
 ---
 SPDX-License-Identifier: MIT
-path: "/tutorials/install/install-encrypted-ubuntu-2004-with-automated-unlock-via-tang-and-clevis"
+path: "/tutorials/install-encrypted-ubuntu-2004-with-automated-unlock-via-tang-and-clevis"
 slug: "install-encrypted-ubuntu-2004-with-automated-unlock-via-tang-and-clevis"
 date: "2021-06-29"
 title: "How to install an encrypted ubuntu20.04 with automated unlocking via tang and clevis"

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption-with-clevis-and-tang/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption-with-clevis-and-tang/01.en.md
@@ -5,7 +5,7 @@ slug: "install-encrypted-ubuntu-2004-with-automated-unlock-via-tang-and-clevis"
 date: "2021-06-29"
 title: "How to install an encrypted ubuntu20.04 with automated unlocking via tang and clevis"
 short_description: "This tutorial describes how to configure a basic tang server and how to install an encrypted ubuntu20.04, which then unlocks automatically via clevis"
-tags: ["Ubuntu", "installimage", "encryption", "clevis", "tang", "FDE", initramfs"]
+tags: ["Ubuntu", "installimage", "encryption", "clevis", "tang", "FDE", "initramfs"]
 author: "Philipp Roth"
 author_link: "https://github.com/roth-wine"
 author_img: "https://avatars.githubusercontent.com/u/64258033"


### PR DESCRIPTION
Hello.

I found small issues with an existing tutorial.

Steps to reproduce:

1. Open https://community.hetzner.com/tutorials/install/install-encrypted-ubuntu-2004-with-automated-unlock-via-tang-and-clevis
2. Choose English in the language dropdown
3. Observe the 404 error