### PR TITLE
Update tutorial - remove wrong line

### DIFF
--- a/tutorials/secure-ubuntu-server-with-ferm-firewall-and-fail2ban/01.en.md
+++ b/tutorials/secure-ubuntu-server-with-ferm-firewall-and-fail2ban/01.en.md
@@ -151,7 +151,6 @@ nano /etc/ferm/ferm.conf
 ```
 
 ```
-@hook post "systemctl restart fail2ban.service";
 @hook flush "systemctl restart fail2ban.service";
 ```
 


### PR DESCRIPTION
The line removed from the tutorial will cause a server to be unable to boot correctly. Therefore this line should be removed quickly!