### PR TITLE
Fix typos (closes: #422)

### DIFF
--- a/tutorials/install-and-configure-borgbackup/01.en.md
+++ b/tutorials/install-and-configure-borgbackup/01.en.md
@@ -87,7 +87,7 @@ For more information, please visit the [Borg create documentation](http://borgba
 
 ### Step 2.4 - Following (incremental) backups
 
-The follwing backups are identical to the first one. Thanks to deduplication, however, they are much faster and extremely memory-efficient, since they are only incremental.
+The following backups are identical to the first one. Thanks to deduplication, however, they are much faster and extremely memory-efficient, since they are only incremental.
 
 You only need to adjust the name of the backup during the follow-up backup. Remember, you must use unique names as mentioned above.
 
@@ -224,7 +224,7 @@ borg create -v --stats                   \
 
 ### Step 3.2 - Deduplication and reliability
 
-Since BorgBackup uses duplication, you can make backups very quickly and without using much storage.
+Since BorgBackup uses deduplication, you can make backups very quickly and without using much storage.
 
 But you also have to be aware that each file is saved exactly once. Should a file be damaged by a disk failure, for example, this file will be corrupted in all following backups.
 


### PR DESCRIPTION
Side note: you have a couple of CRLF termination and you may want to normalize this.

See: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings

```console
❯ file tutorials/*/* | grep CRLF
tutorials/configuring-windows-remote-desktop-services/01.de.md:                                UTF-8 Unicode text, with very long lines, with CRLF line terminators
tutorials/configuring-windows-remote-desktop-services/01.en.md:                                ASCII text, with very long lines, with CRLF line terminators
tutorials/cyberpanel-openlitespeed-mybb/01.en.md:                                              UTF-8 Unicode text, with very long lines, with CRLF line terminators
tutorials/howto-initial-setup-ubuntu/01.de.md:                                                 UTF-8 Unicode text, with very long lines, with CRLF line terminators
tutorials/howto-initial-setup-ubuntu/01.en.md:                                                 UTF-8 Unicode text, with very long lines, with CRLF line terminators
tutorials/howto-ssh-key/01.de.md:                                                              UTF-8 Unicode text, with very long lines, with CRLF line terminators
tutorials/howto-ssh-key/01.en.md:                                                              ASCII text, with very long lines, with CRLF line terminators
tutorials/install-and-configure-borgbackup/01.de.md:                                           UTF-8 Unicode text, with very long lines, with CRLF line terminators
tutorials/install-and-configure-borgbackup/01.en.md:                                           ASCII text, with very long lines, with CRLF line terminators
tutorials/ipsec_nat/01.de.md:                                                                  UTF-8 Unicode text, with CRLF line terminators
tutorials/ipsec_nat/01.en.md:                                                                  ASCII text, with CRLF line terminators
tutorials/ipsec_nat/01.ru.md:                                                                  UTF-8 Unicode text, with CRLF line terminators
tutorials/iptables/01.de.md:                                                                   UTF-8 Unicode text, with CRLF line terminators
tutorials/iptables/01.en.md:                                                                   ASCII text, with CRLF line terminators
tutorials/setup-openvpn-access-server-lan-access/01.en.md:                                     ASCII text, with very long lines, with CRLF line terminators
```