### PR TITLE
fix incorrect path in consul service config

### DIFF
--- a/tutorials/install-nomad-consul-cluster/01.en.md
+++ b/tutorials/install-nomad-consul-cluster/01.en.md
@@ -212,7 +212,7 @@ ConditionFileNotEmpty=/etc/consul.d/consul.hcl
 Type=exec
 User=consul
 Group=consul
-ExecStart=/usr/bin/consul agent -config-dir=/etc/consul.d/
+ExecStart=/usr/local/bin/consul agent -config-dir=/etc/consul.d/
 ExecReload=/bin/kill --signal HUP $MAINPID
 KillMode=process
 KillSignal=SIGTERM


### PR DESCRIPTION
the bin is installed to `/usr/local/bin` but the service config has `usr/bin`