### PR TITLE
Add necessary steps to terraform provider tutorial

### DIFF
--- a/tutorials/howto-hcloud-terraform/01.en.md
+++ b/tutorials/howto-hcloud-terraform/01.en.md
@@ -31,11 +31,12 @@ In order to create a Hetzner Cloud API token, please visit Hetzner Cloud Console
 
 ## Step 1 - Basic Usage
 
-First of all, we create a new directory which will contain our Terraform configuration. We will call it `terraform` and create a new file there called `hcloud.tf`. You can name the file as you like.
+First of all, we create a new directory which will contain our Terraform configuration. We will call it `terraform` and create two new files called `hcloud.tf` and `variables.tf`. You can name the files as you like.
 
 ```bash
 mkdir terraform
 touch hcloud.tf
+touch variables.tf
 ```
 
 You can now edit the `hcloud.tf` with a text editor of your choice.
@@ -87,6 +88,37 @@ resource "hcloud_server" "web" {
 ```
 
 This short snippet does basically nothing. It just defines a resource from type `hcloud_server` called `web`. But it won't work, because we didn't tell Terraform which server should be created.
+
+You can now edit the `variables.tf` with a text editor of your choice.
+
+We will first copy the `Example` from the documentation.
+
+```hcl
+terraform {
+  required_providers {
+    hcloud = {
+      source = "hetznercloud/hcloud"
+    }
+  }
+  required_version = ">= 0.13"
+}
+```
+We will see, what the specific parts mean:
+
+```hcl
+required_providers {
+    hcloud = {
+      source = "hetznercloud/hcloud"
+    }
+}
+```
+Each Terraform module must declare which providers it requires, so that Terraform can install and use them. Provider requirements are declared in a `required_providers` block.
+A provider requirement consists of a local `name` (`hcloud`), a `source` location (`hetznercloud/hcloud`) , and a `version` constraint. In our case, we only add the `source` which forces terraform to use the latest provider version.
+
+```hcl
+  required_version = ">= 0.13"
+```
+The `required_version` setting accepts a version constraint string, which specifies which versions of Terraform can be used with your configuration. in our case, we use v0.13 or higher.
 
 So now you should create a `terraform.tfvars` -file which will contain the following content:
 


### PR DESCRIPTION
The current tutorial will lead to an error due terraform updates over time:
```
Error: Failed to query available provider packages
Could not retrieve the list of available versions for provider hashicorp/hcloud: provider registry registry.terraform.io does not have a provider named registry.terraform.io/hashicorp/hcloud
 
Did you intend to use hetznercloud/hcloud? If so, you must specify that source address in each module which requires that provider. To see which modules are currently depending on hashicorp/hcloud, run the following command: terraform providers
```

The steps to avoid this can be found in the MR.