### PR TITLE
Use versionless bootstrap tarball in Arch Linux tutorial

### DIFF
--- a/tutorials/how-to-install-archlinux-on-a-hetzner-cloud-server/01.en.md
+++ b/tutorials/how-to-install-archlinux-on-a-hetzner-cloud-server/01.en.md
@@ -3,9 +3,9 @@ SPDX-License-Identifier: MIT
 path: "/tutorials/how-to-install-archlinux-on-a-hetzner-cloud-server"
 slug: "how-to-install-archlinux-on-a-hetzner-cloud-server"
 date: "2022-05-25"
-title: "How to install Archlinux on a Hetzner Cloud server"
-short_description: "In this tutorial we will learn how to install Archlinux on any system running a live ISO"
-tags: ["Hetzner Cloud", "Archlinux", "linux"]
+title: "How to install Arch Linux on a Hetzner Cloud server"
+short_description: "In this tutorial we will learn how to install Arch Linux on any system running a live ISO"
+tags: ["Hetzner Cloud", "Arch Linux", "linux"]
 author: "Patrick Michl"
 author_link: "https://github.com/Huanzo"
 author_img: "https://avatars3.githubusercontent.com/u/28699007"
@@ -18,7 +18,7 @@ cta: "cloud"
 
 ## Introduction
 
-In this article we will install a barebones Archlinux system on a server that is currently running an OS from RAM or a live ISO.
+In this article we will install a barebones Arch Linux system on a server that is currently running an OS from RAM or a live ISO.
 As long as the target disks are not in use any linux distribution will work.
 For this tutorial I will be using a Hetzner Cloud server booted into the Rescue System.
 
@@ -31,30 +31,30 @@ I will also use the prompt text to indicate which chroot we are currently in.
 
 - `root@rescue ~ # <cmd>` will indicate a command running without chroot
 - `[root@bootstrap /]# <cmd>` will be inside the bootstrap environment
-- `[root@chroot /]# <cmd>` is inside the Archlinux installation on the disk
+- `[root@chroot /]# <cmd>` is inside the Arch Linux installation on the disk
 
 ## Step 1 - Setting up the bootstrap environment
 
-We will start by getting the current bootstrap image from a trusted Archlinux mirror.
+We will start by getting the current bootstrap image from a trusted Arch Linux mirror.
 This will provide us with the necessary tools for an arch installation.
 While we are at it we will also get the corresponding signature and verify the image before continuing our installation.
 
 ```shell
-root@rescue ~ # curl -o archlinux-bootstrap.tgz "https://mirror.pkgbuild.com/iso/latest/archlinux-bootstrap-$(date '+%Y.%m.01')-x86_64.tar.gz"
+root@rescue ~ # curl -LO 'https://geo.mirror.pkgbuild.com/iso/latest/archlinux-bootstrap-x86_64.tar.gz'
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100  164M  100  164M    0     0   115M      0  0:00:01  0:00:01 --:--:--  115M
 ```
 
 ```shell
-root@rescue ~ # curl -o archlinux-bootstrap.sig "https://mirror.pkgbuild.com/iso/latest/archlinux-bootstrap-$(date '+%Y.%m.01')-x86_64.tar.gz.sig"
+root@rescue ~ # curl -LO 'https://archlinux.org/iso/latest/archlinux-bootstrap-x86_64.tar.gz.sig'
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100   331  100   331    0     0   4728      0 --:--:-- --:--:-- --:--:--  4728
 ```
 
 ```shell
-root@rescue ~ # gpg --keyserver https://hkps.pool.sks-keyservers.net:443 --keyserver-options auto-key-retrieve --verify archlinux-bootstrap.sig archlinux-bootstrap.tgz
+root@rescue ~ # gpg --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify archlinux-bootstrap-x86_64.tar.gz.sig
 gpg: Signature made Tue 01 Mar 2022 04:54:14 PM CET
 gpg:                using RSA key 4AA4767BBC9C4B1D18AE28B77F2D434B9741E8AC
 gpg:                issuer "pierre@archlinux.de"
@@ -71,7 +71,7 @@ Primary key fingerprint: 4AA4 767B BC9C 4B1D 18AE  28B7 7F2D 434B 9741 E8AC
 When no error occurs we can move on to unpacking the image.
 
 ```shell
-root@rescue ~ # tar xzf archlinux-bootstrap.tgz
+root@rescue ~ # tar xzf archlinux-bootstrap-x86_64.tar.gz
 tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.security.capability'
 tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.security.capability'
 ```
@@ -82,7 +82,7 @@ After extraction we need to bind mount the directory over itself. We do this to 
 root@rescue ~ # mount --bind root.x86_64 root.x86_64
 ```
 
-## Step 2 - Setting up boot disk and bootstrapping Archlinux
+## Step 2 - Setting up boot disk and bootstrapping Arch Linux
 
 From here on we need to work from within the bootstrap environment we just set up. We do this by using `arch-chroot`
 
@@ -95,7 +95,7 @@ However `gdisk` is not installed in the boostrap image.
 To do this we need to first configure a mirror and setup the pacman keyring and then install `gdisk`:
 
 ```shell
-[root@bootstrap /]# echo 'Server = https://mirror.pkgbuild.com/$repo/os/$arch' > /etc/pacman.d/mirrorlist
+[root@bootstrap /]# echo 'Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch' > /etc/pacman.d/mirrorlist
 
 [root@bootstrap /]# pacman-key --init
 gpg: /etc/pacman.d/gnupg/trustdb.gpg: trustdb created
@@ -209,7 +209,7 @@ We then mount it to `/mnt` and generate our fstab from that:
 [root@bootstrap /]# genfstab -U /mnt >> /etc/fstab
 ```
 
-Now we can install Archlinux via pacstrap. We will use this opportunity to install openssh as we will need it to connect to our server later.
+Now we can install Arch Linux via pacstrap. We will use this opportunity to install openssh as we will need it to connect to our server later.
 This may take some time depending on the speed of your internet connection and disks.
 
 ```shell
@@ -241,7 +241,7 @@ Total Installed Size:  852.18 MiB
   Skipped: Running in chroot.
 ```
 
-## Step 3 - Finalizing the Archlinux installation
+## Step 3 - Finalizing the Arch Linux installation
 
 We can now `exit` out of the bootstrap environment and change root into the installed system to finish setting up:
 
@@ -252,7 +252,7 @@ root@rescue ~ # ./root.x86_64/usr/bin/arch-chroot root.x86_64/mnt
 We will again start by configuring a mirror and initializing the pacman keyring:
 
 ```shell
-[root@chroot /]# echo 'Server = https://mirror.pkgbuild.com/$repo/os/$arch' > /etc/pacman.d/mirrorlist
+[root@chroot /]# echo 'Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch' > /etc/pacman.d/mirrorlist
 [root@chroot /]# pacman-key --init
 [root@chroot /]# pacman-key --populate archlinux
 ```
@@ -312,11 +312,11 @@ Created symlink /etc/systemd/system/multi-user.target.wants/sshd.service → /us
 ```
 
 We can now exit out from the chroot and reboot our system.
-After a few seconds you server should boot into your freshly installed Archlinux and be reachable via SSH on port 22 using your public key.
+After a few seconds you server should boot into your freshly installed Arch Linux and be reachable via SSH on port 22 using your public key.
 
 ## Conclusion
 
-Congratulations! You now have a minimal Archlinux installation on your server. From here on you can start installing additional services like docker, nginx, K8S, etc.
+Congratulations! You now have a minimal Arch Linux installation on your server. From here on you can start installing additional services like docker, nginx, K8S, etc.
 
 ##### License: MIT
 


### PR DESCRIPTION
There is now a `archlinux-bootstrap-x86_64.tar.gz` file on the mirrors.

Additionally:

* Fix Arch Linux name. See https://wiki.archlinux.org/title/Arch_terminology#Arch_Linux.
* Download the signature file from archlinux.org since getting it from the mirrors is not safe.
* The mirror.pkgbuild.com mirror is [not public](https://archlinux.org/mirrors/mirror.pkgbuild.com/), use geo.mirror.pkgbuild.com instead.
* Use keyserver.ubuntu.com since the sks keyserver pool is dead.