### PR TITLE
Update Robot URL

### DIFF
--- a/tutorials/hcloud-install-rancher-single/01.en.md
+++ b/tutorials/hcloud-install-rancher-single/01.en.md
@@ -32,7 +32,7 @@ This tutorial has been tested on Hetzner Cloud Servers.
 * A SSH client, such as the `ssh` command on Linux/Mac/[WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10), or [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) on Windows (we'll use WSL in this tutorial)
 * A domain (e.g. `example.com`)
 
-In order to follow this tutorial, you'll need a domain. You can obtain a domain through the [Hetzner Robot](https://robot.your-server.de/order/index). In theory the cluster could be run without a domain, but this would require self signed certificates (or no security at all) which is unsecure and unnecessarily complicates the setup.
+In order to follow this tutorial, you'll need a domain. You can obtain a domain through the [Hetzner Robot](https://robot.hetzner.com/order/index). In theory the cluster could be run without a domain, but this would require self signed certificates (or no security at all) which is unsecure and unnecessarily complicates the setup.
 
 If you don't want to buy your own domain, you can use any of the free subdomain services available on the net. As we are going to use [Let's Encrypt](https://letsencrypt.org/) certificates for security, it is not recommended to skip the usage of a domain and thus continue without HTTPS security. Also, skipping security will most likely fail when adding nodes to the cluster.
 
@@ -97,7 +97,7 @@ The Hetzner Cloud Console displays the IP address of your server right at the pr
 
 Now go to your domain name provider's management panel to create / change an A record that points your domain to the IP address of your server.
 
-In this example, we are using the domain `rancher.example.com`. As mentioned in the prerequisites, you will need to buy / register your own domain to proceed. I recommend the [Hetzner Robot](https://robot.your-server.de/order/index) for that purpose.
+In this example, we are using the domain `rancher.example.com`. As mentioned in the prerequisites, you will need to buy / register your own domain to proceed. I recommend the [Hetzner Robot](https://robot.hetzner.com/order/index) for that purpose.
 
 After setting the DNS record, you'll probably need to wait some time until the DNS system recognizes your setting. The waiting time depends on the TTL setting of your provider. Run a `ping` or `nslookup` command to verify the DNS change.
 

--- a/tutorials/install-and-configure-routervm-for-vmware-vsphere/01.en.md
+++ b/tutorials/install-and-configure-routervm-for-vmware-vsphere/01.en.md
@@ -36,9 +36,9 @@ Using a subnet requires at least one additional single IP address which must be 
 
 **IPv6**
 
-All servers come with a /64 IPv6 subnet. To see which IPv6 subnet the server has please check the "IPs" tab of the server in [Hetzner Robot](https://robot.your-server.de).
+All servers come with a /64 IPv6 subnet. To see which IPv6 subnet the server has please check the "IPs" tab of the server in [Hetzner Robot](https://robot.hetzner.com).
 
-The IPv6 subnet is routed to the default link-local address (which is derived from the MAC address) of the main IP. Via [Hetzner Robot](https://robot.your-server.de) the routing of the IPv6 subnet can be switched to the link-local address of the virtual MAC (in other words, the additional single IP). This can be using the same symbol which is found next to additional single IPs to request virtual MAC addresses. In this case, the host running vSphere receives no IPv6 address. This is neither necessary not possible because ESXi does not work with an `fe80::1` gateway.
+The IPv6 subnet is routed to the default link-local address (which is derived from the MAC address) of the main IP. Via [Hetzner Robot](https://robot.hetzner.com) the routing of the IPv6 subnet can be switched to the link-local address of the virtual MAC (in other words, the additional single IP). This can be using the same symbol which is found next to additional single IPs to request virtual MAC addresses. In this case, the host running vSphere receives no IPv6 address. This is neither necessary not possible because ESXi does not work with an `fe80::1` gateway.
 
 ## Step 1 - Creation of Port groups and vSwitch
 

--- a/tutorials/install-and-configure-vmware-vsphere/01.en.md
+++ b/tutorials/install-and-configure-vmware-vsphere/01.en.md
@@ -64,7 +64,7 @@ Using a custom installation ISO with 3rd party / community drivers may allow ins
 
 When ordering the desired server, make sure to select "Rescue System" to ensure no other operating system is present on the drives. If needed a RAID controller can be added on non-NVMe models during the order process.  It must be configured prior to the installation.
 
-After the server has been provisioned, request a KVM console via [Hetzner Robot](https://robot.your-server.de). The KVM Console allows you to connect a virtual DVD drive to the server from which vSphere can be installed.
+After the server has been provisioned, request a KVM console via [Hetzner Robot](https://robot.hetzner.com). The KVM Console allows you to connect a virtual DVD drive to the server from which vSphere can be installed.
 
 Insert the ISO into the virtual drive and boot the server from the image.  The installer only requires answers to a few questions like locale, root password and target drive.
 

--- a/tutorials/plesk-backup-storage-box/01.en.md
+++ b/tutorials/plesk-backup-storage-box/01.en.md
@@ -31,7 +31,7 @@ For the location of your storage box, I´d say there are two different approache
 
 After your order, you´ll receive a confirmation of your order and some minutes later you´ll receive a message that your order is completed.
 
-Now you have to login to the [Robot administrator interface](https://robot.your-server.de) and click on the menu item "Storage boxes". After clicking on the new Storage Box, you will see the access details and you can set an initial password.
+Now you have to login to the [Robot administrator interface](https://robot.hetzner.com) and click on the menu item "Storage boxes". After clicking on the new Storage Box, you will see the access details and you can set an initial password.
 
 ![Storage Box](images/storage_box.png)
 

--- a/tutorials/prometheus-discovery/01.en.md
+++ b/tutorials/prometheus-discovery/01.en.md
@@ -34,7 +34,7 @@ For general help with installing and configuring Prometheus see the [excellent d
 
 Depending on which servers you would like to "discover", you will need credentials for the appropriate access.
 
-For Robot servers, you will need Robot Webservice credentials. To get these, log in to [Robot](https://robot.your-server.de/) and go to "Settings" by clicking the user menu icon in the upper right corner.
+For Robot servers, you will need Robot Webservice credentials. To get these, log in to [Robot](https://robot.hetzner.com/) and go to "Settings" by clicking the user menu icon in the upper right corner.
 
 For Cloud servers, you will need a Hetzner Cloud API token. To create one, log in to the [Cloud Console](https://console.hetzner.cloud), select your project and go to the "Security" tab.
 

--- a/tutorials/proxmox-docker-zfs/01.en.md
+++ b/tutorials/proxmox-docker-zfs/01.en.md
@@ -29,7 +29,7 @@ Proxmox VE is a Type 1 Hypervisor, that uses KVM for full VMs, and LXC for conta
 
 ## Step 1 - Initial Server Setup
 
-To start the installation, we will need to be in the [Rescue System](https://docs.hetzner.com/robot/dedicated-server/troubleshooting/hetzner-rescue-system/). If you have just ordered the server, it is highly likely you are already booted into it. If not, you can enter it by navigating to the `Rescue` tab of your server in the [Hetzner Robot Panel](https://robot.your-server.de/), and selecting "Linux x64". When you confirm this selection, you will be presented with the password for the [Rescue System](https://docs.hetzner.com/robot/dedicated-server/troubleshooting/hetzner-rescue-system/). Please make a note of this. Once you have, you can navigate to the Reset tab, and execute an "Automatic Hardware Reset", which will reboot the server into the [Rescue System](https://docs.hetzner.com/robot/dedicated-server/troubleshooting/hetzner-rescue-system/). You can now open an SSH session to your server to proceed with installation.
+To start the installation, we will need to be in the [Rescue System](https://docs.hetzner.com/robot/dedicated-server/troubleshooting/hetzner-rescue-system/). If you have just ordered the server, it is highly likely you are already booted into it. If not, you can enter it by navigating to the `Rescue` tab of your server in the [Hetzner Robot Panel](https://robot.hetzner.com/), and selecting "Linux x64". When you confirm this selection, you will be presented with the password for the [Rescue System](https://docs.hetzner.com/robot/dedicated-server/troubleshooting/hetzner-rescue-system/). Please make a note of this. Once you have, you can navigate to the Reset tab, and execute an "Automatic Hardware Reset", which will reboot the server into the [Rescue System](https://docs.hetzner.com/robot/dedicated-server/troubleshooting/hetzner-rescue-system/). You can now open an SSH session to your server to proceed with installation.
 
 ### Step 1.1 - Setting up the VM
 
@@ -91,7 +91,7 @@ The first thing you will want to do is to configure the storage. For this tutori
 
 <img src="images/proxmox2.png" alt="&quot;Install Proxmox&quot;" title="Install Proxmox" style="zoom:67%;" />
 
-After that, you can fill out other information about you and your server. Please be sure to select a sufficiently secure password. For the network configuration, your server should automatically get the correct information using DHCP, but you will want to check this against the intended Main IP in the [Hetzner Robot Panel](https://robot.your-server.de/), as sometimes DHCP can hand out an additional IP instead.
+After that, you can fill out other information about you and your server. Please be sure to select a sufficiently secure password. For the network configuration, your server should automatically get the correct information using DHCP, but you will want to check this against the intended Main IP in the [Hetzner Robot Panel](https://robot.hetzner.com/), as sometimes DHCP can hand out an additional IP instead.
 
 <img src="images/proxmox3.png" alt="&quot;Install Proxmox&quot;" title="Install Proxmox" />
 
@@ -232,7 +232,7 @@ To apply these network configurations, you can simply reboot by typing `reboot` 
 
 ### Step 4.3 - Network configuration inside the VM
 
-Since we are using bridges, the network details needed to connect the IP will be different to the details in the [Hetzner Robot Panel](https://robot.your-server.de/). For IPv4 subnets, you can use the following details:
+Since we are using bridges, the network details needed to connect the IP will be different to the details in the [Hetzner Robot Panel](https://robot.hetzner.com/). For IPv4 subnets, you can use the following details:
 
 | Field   | Value                    | Description                                                  |
 | ------- | ------------------------ | ------------------------------------------------------------ |
@@ -264,7 +264,7 @@ Since you now have your complementary storage box setup, you may as well use it 
 
 <img src="images/proxmox-add.png" alt="Adding storage to Proxmox" title="Adding storage to Proxmox" style="zoom: 67%;" />
 
-Type in the details from the [Hetzner Robot Panel](https://robot.your-server.de/), and press Add. Once that's done, you will have a new storage visible on your server. If you navigate into the backup box, you will see a folder called `template` has been made. Another folder called `iso` is in there, and that's where you can upload your ISOs.
+Type in the details from the [Hetzner Robot Panel](https://robot.hetzner.com/), and press Add. Once that's done, you will have a new storage visible on your server. If you navigate into the backup box, you will see a folder called `template` has been made. Another folder called `iso` is in there, and that's where you can upload your ISOs.
 
 ## Step 6 - Installing Docker
 


### PR DESCRIPTION
Hetzner Robot URL has changed on the 21st September 2022
Old URL: https://robot.your-server.de/
New URL: https://robot.hetzner.com/

Source: https://status.hetzner.com/incident/1883187a-fe64-44ad-a3eb-25c6bab6e78c

This commit changes all 'robot.your-server.de' to 'robot.hetzner.com'.