### PR TITLE
[Mailcow] Update to current state, remove malicious link and added new topics

### DIFF
--- a/tutorials/setup-mailserver-with-mailcow/01.en.md
+++ b/tutorials/setup-mailserver-with-mailcow/01.en.md
@@ -2,53 +2,66 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/setup-mailserver-with-mailcow"
 slug: "setup-mailserver-with-mailcow"
-date: "2019-03-18"
-title: "Setup your own mail server with Mailcow"
+date: "2022-12-10"
+title: "Set up your own mail server with Mailcow"
 short_description: "This tutorial will walk you through the process of setting up your own mail server on Ubuntu running in Docker"
 tags: ["Mailserver", "Docker"]
-author: "ntimo"
-author_link: "https://github.com/ntimo"
-author_img: "https://avatars3.githubusercontent.com/u/6145026"
+author: "kev-ac"
+author_link: "https://github.com/kev-ac"
+author_img: "https://avatars.githubusercontent.com/u/60135953"
 author_description: ""
 language: "en"
 available_languages: ["en", "ru"]
 header_img: "header-1"
 ---
 
+_(The original tutorial was written by [ntimo](https://github.com/ntimo) in 2019 and was updated to the current state and new topics)_
+
 ## Introduction
 
 In this tutorial you will setup your own mail server running on an Ubuntu Server in the Hetzner Cloud.
-With Mailcow you can host your own mail server with your custom domain. Mailcow also provides a way to sync your Contacts and Calender.
+With Mailcow you can host your own mail server with your custom domain. Mailcow also provides a way to sync your Contacts and Calendar.
 
-Official documentation: [https://mailcow.github.io/mailcow-dockerized-docs/](https://mailcow.github.io/mailcow-dockerized-docs/)
-Project Website: [https://mailcow.email](https://mailcow.email)
-GitHub: [https://github.com/mailcow/mailcow-dockerized](https://github.com/mailcow/mailcow-dockerized)
-Forum: [https://mailcow.farm](https://mailcow.farm)
+Official documentation: [https://mailcow.github.io/mailcow-dockerized-docs/](https://mailcow.github.io/mailcow-dockerized-docs/)<br>
+Project Website: [https://mailcow.email](https://mailcow.email)<br>
+GitHub: [https://github.com/mailcow/mailcow-dockerized](https://github.com/mailcow/mailcow-dockerized)<br>
+Community forum: [https://community.mailcow.email](https://community.mailcow.email)
 
 **Prerequisites**
 
 * You need a domain name
 * A bit of knowledge of how Docker works
-* Hetzner Cloud servers **by default blocks port 25 and 465** to protect from spammers. You can get these unblocked after your first invoice was paid. This basically acts as a simple verification, that you are not a spammer.
+* Hetzner Cloud servers **by default block port 25 and 465** to protect from spammers. You can request to get the ports unblocked after your first invoice was paid. This basically acts as a simple verification, that you are not a spammer.
 
 ## Step 1 - Create a new Cloud server
 
-* Login to your cloud dashboard from [https://console.hetzner.cloud]
-* Create new project and name it whatever you want
-* Choose your server location it's up to you
-* Click `Add Server` and select your server image. This tutorial is based around `Ubuntu 20.04` but can easily be adapted to `Debian 11`, which is more stable and lighter
+* Sign-in to the [Cloud Console](https://console.hetzner.cloud)
+* Create a new project and name it whatever you want
+* Choose a server location and type depending on your needs. _See below for tips if you are unsure._
+* Click `Add Server` and select your server image. This tutorial is based around `Ubuntu 22.04` but can easily be adapted to `Debian 11`, which is more stable and lighter
 * Choose the resources you need from Type
-* Click on the field `User Data` enter this `#include https://get.docker.com` (this will install docker)
+* Click on the field `Cloud config` enter this: `#include https://get.docker.com` (this will install docker)
 * Select your SSH-Key
     * You can read [this article](https://help.github.com/en/enterprise/2.16/user/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) to learn how to generate an SSH key
 * Write your server hostname in `name` input (mail.example.com)
 * Click `Create & Buy Now`
 
+### How to choose the correct server location and type
+
+Choose a server location which is geographically closest to you or your user base.
+
+
+In regard to the correct server type keep in mind that Mailcow requires **at least** 7GB RAM to function properly.<br>
+Mailcow is a fully-featured groupware solution.
+Having that said the lowest server type available would be a **CX31*** or **CPX31**.
+
+_*Availability of the CX line depends on your chosen location. As of the time of writing CX servers are not available in US locations._
+
 ## Step 2 - Setup DNS
 
 Basically you want to create a new DNS record called mail.example.com and add your server IPv4 (A record) and IPv6 (AAAA record) to it.
-Then you can setup your domains MX record to point to your mail.example.com subdomain that you just created.
-You also need to setup an autodiscover.example.com and autoconfig.example.com subdomain, both should be of the type CNAME and point to mail.example.com
+Then you can set up your domains MX record to point to your ``mail.example.com`` subdomain that you just created.
+You also need to set up an ``autodiscover.example.com`` and ``autoconfig.example.com`` subdomain, both should be of the type CNAME and point to ``mail.example.com``.
 
 Your DNS configuration should look similar to this:
 
@@ -62,7 +75,7 @@ autoconfig          IN CNAME   mail
 @                   IN MX 10   mail
 ```
 
-[More Info](https://mailcow.github.io/mailcow-dockerized-docs/prerequisite-dns/)
+For a more advanced setup there are more DNS records you should watch out for in the [Mailcow documentation](https://mailcow.github.io/mailcow-dockerized-docs/prerequisite-dns/).
 
 ## Step 3 - Install updates and Docker Compose on the server
 
@@ -71,17 +84,7 @@ Now you should install available updates on your server by running:
 
 `apt update && apt upgrade -y`
 
-Now you need to install Docker compose you can do this by running:
-
-```
-curl -L https://github.com/docker/compose/releases/download/$(curl -s "https://api.github.com/repos/docker/compose/releases/latest" | awk -F '"' '/tag_name/{print $4}')/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
-```
-
-This command asks the GitHub API for the latest version of docker and than downloads the corresponding file.
-
-Make Docker-Compose executable using chmod:
-
-`chmod +x /usr/local/bin/docker-compose`
+This is a good time to reboot the server after all upgrades are finished, especially if there are kernel updates.
 
 ## Step 4 - Clone the Mailcow Repository
 
@@ -89,7 +92,7 @@ Now we are going to clone the Mailcow GitHub repository, so first you need to `c
 
 `cd /opt`
 
-once your are in /opt you can run:
+once you are in /opt you can run:
 
 `git clone https://github.com/mailcow/mailcow-dockerized`
 
@@ -97,37 +100,89 @@ once your are in /opt you can run:
 
 To create the config, change your working directory to `/opt/mailcow-dockerized` with `cd /opt/mailcow-dockerized` and run `./generate_config.sh` this will generate the config. Now you have to enter your domain name (something like mail.example.com)
 
-We are nearly done. Now you have to run `docker-compose pull` to pull the docker images.
+We are nearly done. Now you have to run `docker compose pull` to pull the docker images.
 
-In order to start Mailcow run `docker-compose up -d`
+In order to start Mailcow run `docker compose up -d`
 
-## Step 6 - Setup a reverse DNS entry
+## Step 6 - Set up the reverse DNS entries
 
-Go to the Hetzner Cloud console and click on your project, select the server you just created and go to the `networking` tab, and there select the three dots near your IPv4, and then select `Edit Reverse DNS`, then enter your domain (mail.example.com). The same needs to be done for your IPv6 address, simply type `::1` into the field where the IP is and then again enter your domain name (mail.example.com).
+To set up your reverse DNS entries do the following steps:
 
-## Step 7 - Login and change your password
+- Go to the Hetzner Cloud console and click on your project
+- Select the server you just created and go to the `networking` tab
+- Click the three dots near your **IPv4** address, then select `Edit Reverse DNS` and enter your domain (mail.example.com) and confirm the change.
+- Click the three dots near your **IPv6** subnet, then select `Edit Reverse DNS`, type `::1` into the field where the IP is below your domain name (mail.example.com).
 
-Now you can open mail.example.com in your browser and login using the default login:
+## Step 7 - First login to your Mailcow instance
+
+Visit your Mailcow instance at `https://mail.example.org` and log in with the default credentials:
 
 * Username: `admin`
 * Password: `moohoo`
 
-Do not forget to change your password. A length of 16 characters or more effectively counts as very secure, if no predictable patterns are used.
+**Important:** Change your password as soon as possible as leaving it as is opens your server up for breaches.
 
-## Step 8 - Add your domain to Mailcow
+## Step 8 - Add domain(s) to Mailcow
 
 Now you can add your domain to Mailcow, simply go to `Configuration` -> `Mail setup`. Add your domain under the tab Domain.
 
 ## Step 9 - Setup DKIM
 
-Now when you go back to `Configuration` -> `Configuration & Details` you can setup DKIM. In the `Configuration` tap select DKIM in the sidebar. It should be at the top, scroll down till you see the mask where you can enter your domain. Simply click `Select domains with missing keys` shortcut to have your domain name filled in. Now select a `2048` key and click on `Add`. Once the key is added you can copy the public key and create a DNS TXT entry called `dkim._domainkey` with the content you just copied.
+Now when you go back to `Configuration` -> `Configuration & Details` you can set up DKIM. In the `Configuration` tap select DKIM in the sidebar. It should be at the top, scroll down till you see the mask where you can enter your domain. Simply click `Select domains with missing keys` shortcut to have your domain name filled in. Now select a `2048` key and click on `Add`. Once the key is added you can copy the public key and create a DNS TXT entry called `dkim._domainkey` with the content you just copied.
 
 ## Step 10 - Create a mailbox
 
 When you go back to `Configuration` -> `Mail setup` you can create a mailbox and log into SOGo by accessing it under https://mail.example.com/SOGo
 
-## Step 11 - Update Mailcow
+------
 
-Of course a mail server needs care and you should update it from time to time. Updating Mailcow is super easy, simply run: `./update.sh` and carefully follow the instructions.
+## Creating backups 
+
+Backups are essential for most server setups, your mail server is no different. Mailcow provides a very simple way to create backups of your mail data.
+
+### Create a manual backup
+
+- Connect to your server using your SSH key.
+- Go to the Mailcow directory which contains the backup script ``/opt/mailcow-dockerized/helper-scripts``
+- Run the backup script ``./backup_and_restore.sh backup all --delete-days 7``
+  - The script will ask you for your backup location.
+  - ``--delete-days 7`` will remove any backup in the chosen directory which is older than 7 days. Alter the value or remove it entirely depending on your needs.
+
+The process can take some minutes to a few hours depending on your mails size and server type.
+
+### Create automated backups
+
+- Connect to your server using your SSH key.
+- Run ``crontab -e`` to enter your cron task list.
+  - If it is the first time you run this command you will be asked to choose an editor. Choose `(1) /bin/nano` as it is the easiest for new users.
+- Paste the following into your crontab and update the details depending on your setup (see below):
+
+````
+0 5 * * * MAILCOW_BACKUP_LOCATION=/opt/mailcow-backups /opt/mailcow-dockerized/helper-scripts/backup_and_restore.sh backup all --delete-days 7
+````
+`MAILCOW_BACKUP_LOCATION` is the folder the backups will be written to. If you have a big mail database consider adding a Volume to your server to expand its storage.<br>
+``--delete-days 7`` will remove any backup in the chosen directory which is older than 7 days. Alter the value or remove it entirely depending on your needs.
+
+### General recommendations
+
+Consider the general rules of storing backups when creating a Mailcow instance. This includes having a copy of your backup in another location as your servers' disk (For example a [Hetzner Storagebox](https://www.hetzner.com/storage/storage-box)). 
+
+----
+
+## Updating your Mailcow instance
+
+Updates for Mailcow are generally released once per month by the authors. If there are urgent security patches or bugs more updates are released. It is wise to keep an eye on the [releases page](https://github.com/mailcow/mailcow-dockerized/releases) of Mailcow for information about changes.
+
+Before executing updates it is recommended to check if you have current backups of your data. You can also create server snapshot in the Hetzner Cloud Console to revert back quickly to a working state if something goes wrong.<br>
+If you don't want to use snapshots Mailcow also has a [built-in way to roll back from updates](https://docs.mailcow.email/i_u_m/i_u_m_update/#can-i-roll-back).
+
+- Connect to your server using your SSH key.
+- Go to the Mailcow directory ``/opt/mailcow-dockerized``
+- Run ``./update.sh``
+  - The script will first check if there is a new update.sh file available and will update it first. If this is the case you have to re-run the script.
+  - Then all other updates will be pulled and prepared to be updated. You have to confirm the update.
+- At the end Mailcow will ask if you want to delete the now unused components. Select **no** and optionally delete them manually later on to be prepared if something went wrong.
+- After the update is done Mailcow will start up all services and run internal upgrades. **Do not** shut down your server or the docker containers to prevent data corruption.
+
 
 ##### License: MIT

--- a/tutorials/setup-mailserver-with-mailcow/01.en.md
+++ b/tutorials/setup-mailserver-with-mailcow/01.en.md
@@ -181,3 +181,32 @@ If you don't want to use Hetzner Snapshots, Mailcow also has a [built-in way to 
 - After the update is done, Mailcow will start up all services and run internal upgrades. **Do not** shut down your server or the docker containers to prevent data corruption.
 
 ##### License: MIT
+
+<!--
+
+Contributor's Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it under the license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate license and I have the
+    right under that license to submit that work with modifications,
+    whether created in whole or in part by me, under the same license
+    (unless I am permitted to submit under a different license), as
+    indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are
+    public and that a record of the contribution (including all personal
+    information I submit with it, including my sign-off) is maintained
+    indefinitely and may be redistributed consistent with this project
+    or the license(s) involved.
+
+Signed-off-by: kev-ac oss@thiefes.de
+
+-->

--- a/tutorials/setup-mailserver-with-mailcow/01.en.md
+++ b/tutorials/setup-mailserver-with-mailcow/01.en.md
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/setup-mailserver-with-mailcow"
 slug: "setup-mailserver-with-mailcow"
-date: "2022-12-10"
+date: "2023-02-01"
 title: "Set up your own mail server with Mailcow"
 short_description: "This tutorial will walk you through the process of setting up your own mail server on Ubuntu running in Docker"
 tags: ["Mailserver", "Docker"]
@@ -38,10 +38,10 @@ Community forum: [https://community.mailcow.email](https://community.mailcow.ema
 * Sign-in to the [Cloud Console](https://console.hetzner.cloud)
 * Create a new project and name it whatever you want
 * Choose a server location and type depending on your needs. _See below for tips if you are unsure._
-* Click `Add Server` and select your server image. This tutorial is based around `Ubuntu 22.04` but can easily be adapted to `Debian 11`, which is more stable and lighter
+* Click `Add Server` and select your server image. This tutorial is based around `Ubuntu 22.04` but can easily be adapted to `Debian 11`, which is more stable and lighter.
 * Choose the resources you need from Type
 * Click on the field `Cloud config` enter this: `#include https://get.docker.com` (this will install docker)
-* Select your SSH-Key
+* Select your SSH key
     * You can read [this article](https://help.github.com/en/enterprise/2.16/user/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) to learn how to generate an SSH key
 * Write your server hostname in `name` input (mail.example.com)
 * Click `Create & Buy Now`
@@ -50,18 +50,17 @@ Community forum: [https://community.mailcow.email](https://community.mailcow.ema
 
 Choose a server location which is geographically closest to you or your user base.
 
-
-In regard to the correct server type keep in mind that Mailcow requires **at least** 7GB RAM to function properly.<br>
+In regard to the correct server type, keep in mind that Mailcow requires **at least** 7GB RAM to function properly.<br>
 Mailcow is a fully-featured groupware solution.
-Having that said the lowest server type available would be a **CX31*** or **CPX31**.
+Having that said, the lowest server type available would be a **CX31*** or **CPX31**.
 
 _*Availability of the CX line depends on your chosen location. As of the time of writing CX servers are not available in US locations._
 
 ## Step 2 - Setup DNS
 
-Basically you want to create a new DNS record called mail.example.com and add your server IPv4 (A record) and IPv6 (AAAA record) to it.
-Then you can set up your domains MX record to point to your ``mail.example.com`` subdomain that you just created.
-You also need to set up an ``autodiscover.example.com`` and ``autoconfig.example.com`` subdomain, both should be of the type CNAME and point to ``mail.example.com``.
+Basically, you want to create a new DNS record called mail.example.com and add your server IPv4 (A record) and IPv6 (AAAA record) to it.
+Then, you can set up your domains MX record to point to your `mail.example.com` subdomain that you just created.
+You also need to set up an `autodiscover.example.com` and `autoconfig.example.com` subdomain. Both should be of the type CNAME and point to `mail.example.com`.
 
 Your DNS configuration should look similar to this:
 
@@ -75,7 +74,7 @@ autoconfig          IN CNAME   mail
 @                   IN MX 10   mail
 ```
 
-For a more advanced setup there are more DNS records you should watch out for in the [Mailcow documentation](https://mailcow.github.io/mailcow-dockerized-docs/prerequisite-dns/).
+For a more advanced setup, there are more DNS records you should watch out for in the [Mailcow documentation](https://mailcow.github.io/mailcow-dockerized-docs/prerequisite-dns/).
 
 ## Step 3 - Install updates and Docker Compose on the server
 
@@ -92,26 +91,26 @@ Now we are going to clone the Mailcow GitHub repository, so first you need to `c
 
 `cd /opt`
 
-once you are in /opt you can run:
+Once you are in `/opt`, you can run:
 
 `git clone https://github.com/mailcow/mailcow-dockerized`
 
-## Step 5 - Create the config, Pull the Docker containers and start Mailcow
+## Step 5 - Create the config, pull the Docker containers, and start Mailcow
 
-To create the config, change your working directory to `/opt/mailcow-dockerized` with `cd /opt/mailcow-dockerized` and run `./generate_config.sh` this will generate the config. Now you have to enter your domain name (something like mail.example.com)
+To create the config, change your working directory to `/opt/mailcow-dockerized` with `cd /opt/mailcow-dockerized` and run `./generate_config.sh` this will generate the config. Now you have to enter your domain name (something like mail.example.com).
 
-We are nearly done. Now you have to run `docker compose pull` to pull the docker images.
+We are nearly done. Now, you have to run `docker compose pull` to pull the docker images.
 
-In order to start Mailcow run `docker compose up -d`
+In order to start Mailcow, run `docker compose up -d`
 
 ## Step 6 - Set up the reverse DNS entries
 
-To set up your reverse DNS entries do the following steps:
+To set up your reverse DNS entries, do the following steps:
 
 - Go to the Hetzner Cloud console and click on your project
-- Select the server you just created and go to the `networking` tab
-- Click the three dots near your **IPv4** address, then select `Edit Reverse DNS` and enter your domain (mail.example.com) and confirm the change.
-- Click the three dots near your **IPv6** subnet, then select `Edit Reverse DNS`, type `::1` into the field where the IP is below your domain name (mail.example.com).
+- Select the server you just created and go to the `NETWORKING` tab
+- Click the three dots near your **IPv4** address, select `Edit Reverse DNS`, enter your domain (mail.example.com), and confirm the change.
+- Click the three dots near your **IPv6** subnet, select `Edit Reverse DNS`, and type `::1` into the field where the IP is below your domain name (mail.example.com).
 
 ## Step 7 - First login to your Mailcow instance
 
@@ -120,69 +119,65 @@ Visit your Mailcow instance at `https://mail.example.org` and log in with the de
 * Username: `admin`
 * Password: `moohoo`
 
-**Important:** Change your password as soon as possible as leaving it as is opens your server up for breaches.
+**Important:** Change your password as soon as possible, as leaving it as is opens your server up for breaches.
 
 ## Step 8 - Add domain(s) to Mailcow
 
-Now you can add your domain to Mailcow, simply go to `Configuration` -> `Mail setup`. Add your domain under the tab Domain.
+Now, you can add your domain to Mailcow. Simply go to `Configuration` -> `Mail setup`. Add your domain under the tab "Domain".
 
 ## Step 9 - Setup DKIM
 
-Now when you go back to `Configuration` -> `Configuration & Details` you can set up DKIM. In the `Configuration` tap select DKIM in the sidebar. It should be at the top, scroll down till you see the mask where you can enter your domain. Simply click `Select domains with missing keys` shortcut to have your domain name filled in. Now select a `2048` key and click on `Add`. Once the key is added you can copy the public key and create a DNS TXT entry called `dkim._domainkey` with the content you just copied.
+Now, when you go back to `Configuration` -> `Configuration & Details` you can set up DKIM. In the `Configuration` tap, select DKIM in the sidebar. It should be at the top. Scroll down till you see the mask where you can enter your domain. Simply click `Select domains with missing keys` shortcut to have your domain name filled in. Now, select a `2048` key and click on `Add`. Once the key is added, you can copy the public key and create a DNS TXT entry called `dkim._domainkey` with the content you just copied.
 
 ## Step 10 - Create a mailbox
 
-When you go back to `Configuration` -> `Mail setup` you can create a mailbox and log into SOGo by accessing it under https://mail.example.com/SOGo
+When you go back to `Configuration` -> `Mail setup`, you can create a mailbox and log into SOGo by accessing it at https://mail.example.com/SOGo.
 
-------
+## Step 11 - Creating backups 
 
-## Creating backups 
-
-Backups are essential for most server setups, your mail server is no different. Mailcow provides a very simple way to create backups of your mail data.
+Backups are essential for most server setups. Your mail server is no different. Mailcow provides a very simple way to create backups of your mail data.
 
 ### Create a manual backup
 
 - Connect to your server using your SSH key.
-- Go to the Mailcow directory which contains the backup script ``/opt/mailcow-dockerized/helper-scripts``
-- Run the backup script ``./backup_and_restore.sh backup all --delete-days 7``
+- Go to the Mailcow directory which contains the backup script `/opt/mailcow-dockerized/helper-scripts`
+- Run the backup script `./backup_and_restore.sh backup all --delete-days 7`
   - The script will ask you for your backup location.
-  - ``--delete-days 7`` will remove any backup in the chosen directory which is older than 7 days. Alter the value or remove it entirely depending on your needs.
+  - `--delete-days 7` will remove any backup in the chosen directory which is older than 7 days. Alter the value or remove it entirely depending on your needs.
 
 The process can take some minutes to a few hours depending on your mails size and server type.
 
 ### Create automated backups
 
 - Connect to your server using your SSH key.
-- Run ``crontab -e`` to enter your cron task list.
-  - If it is the first time you run this command you will be asked to choose an editor. Choose `(1) /bin/nano` as it is the easiest for new users.
+- Run `crontab -e` to enter your cron task list.
+  - If it is the first time you run this command, you will be asked to choose an editor. Choose `(1) /bin/nano` as it is the easiest for new users.
 - Paste the following into your crontab and update the details depending on your setup (see below):
 
-````
+```
 0 5 * * * MAILCOW_BACKUP_LOCATION=/opt/mailcow-backups /opt/mailcow-dockerized/helper-scripts/backup_and_restore.sh backup all --delete-days 7
-````
-`MAILCOW_BACKUP_LOCATION` is the folder the backups will be written to. If you have a big mail database consider adding a Volume to your server to expand its storage.<br>
-``--delete-days 7`` will remove any backup in the chosen directory which is older than 7 days. Alter the value or remove it entirely depending on your needs.
+```
+
+`MAILCOW_BACKUP_LOCATION` is the folder the backups will be written to. If you have a big mail database, consider adding a Volume to your server to expand its storage.<br>
+`--delete-days 7` will remove any backup in the chosen directory which is older than 7 days. Alter the value or remove it entirely depending on your needs.
 
 ### General recommendations
 
-Consider the general rules of storing backups when creating a Mailcow instance. This includes having a copy of your backup in another location as your servers' disk (For example a [Hetzner Storagebox](https://www.hetzner.com/storage/storage-box)). 
+Consider the general rules of storing backups when creating a Mailcow instance. This includes having a copy of your backup in another location than your servers' disk (for example a [Hetzner Storagebox](https://www.hetzner.com/storage/storage-box)).
 
-----
+## Step 12 - Updating your Mailcow instance
 
-## Updating your Mailcow instance
+Updates for Mailcow are generally released once per month by the authors. If there are urgent security patches or bugs, more updates are released. It is wise to keep an eye on the [releases page](https://github.com/mailcow/mailcow-dockerized/releases) of Mailcow for information about changes.
 
-Updates for Mailcow are generally released once per month by the authors. If there are urgent security patches or bugs more updates are released. It is wise to keep an eye on the [releases page](https://github.com/mailcow/mailcow-dockerized/releases) of Mailcow for information about changes.
-
-Before executing updates it is recommended to check if you have current backups of your data. You can also create server snapshot in the Hetzner Cloud Console to revert back quickly to a working state if something goes wrong.<br>
-If you don't want to use snapshots Mailcow also has a [built-in way to roll back from updates](https://docs.mailcow.email/i_u_m/i_u_m_update/#can-i-roll-back).
+Before executing updates, it is recommended to check if you have current backups of your data. In the Hetzner Cloud Console, you can also create a [Snapshot](https://docs.hetzner.com/cloud/servers/backups-snapshots/overview) of your server to quickly revert back to a working state if something goes wrong.<br>
+If you don't want to use Hetzner Snapshots, Mailcow also has a [built-in way to roll back from updates](https://docs.mailcow.email/i_u_m/i_u_m_update/#can-i-roll-back).
 
 - Connect to your server using your SSH key.
-- Go to the Mailcow directory ``/opt/mailcow-dockerized``
-- Run ``./update.sh``
-  - The script will first check if there is a new update.sh file available and will update it first. If this is the case you have to re-run the script.
-  - Then all other updates will be pulled and prepared to be updated. You have to confirm the update.
-- At the end Mailcow will ask if you want to delete the now unused components. Select **no** and optionally delete them manually later on to be prepared if something went wrong.
-- After the update is done Mailcow will start up all services and run internal upgrades. **Do not** shut down your server or the docker containers to prevent data corruption.
-
+- Go to the Mailcow directory `/opt/mailcow-dockerized`
+- Run `./update.sh`
+  - The script will first check if there is a new `update.sh` file available and will update it. If this is the case, you have to re-run the script.
+  - Then, all other updates will be pulled and prepared to be updated. You have to confirm the update.
+- At the end, Mailcow will ask if you want to delete the now unused components. Select **no** and optionally delete them manually later on to be prepared if something went wrong.
+- After the update is done, Mailcow will start up all services and run internal upgrades. **Do not** shut down your server or the docker containers to prevent data corruption.
 
 ##### License: MIT


### PR DESCRIPTION
This commit updates the tutorial to the current state (OS, Docker), removes a link to a malicious site and adds the topic Backups and enhances information about updates.

Also fixes #497.

I have read and understood the Contributor's Certificate of Origin available at the end of 
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: kev-ac <oss@thiefes.de>