### PR TITLE
[Mailcow] Remove malicious link from Russian version of tutorial

### DIFF
--- a/tutorials/setup-mailserver-with-mailcow/01.ru.md
+++ b/tutorials/setup-mailserver-with-mailcow/01.ru.md
@@ -24,7 +24,6 @@ header_img: ""
 Официальная документация: [https://mailcow.github.io/mailcow-dockerized-docs/](https://mailcow.github.io/mailcow-dockerized-docs/)  
 Веб-сайт проекта: [https://mailcow.email](https://mailcow.email)  
 GitHub: [https://github.com/mailcow/mailcow-dockerized](https://github.com/mailcow/mailcow-dockerized)  
-Форум: [https://mailcow.farm](https://mailcow.farm)  
 
 **Требования**
 


### PR DESCRIPTION
This PR removes one line, a link to "mailcow.farm" from the tutorial.
The link seems to be redirecting to some dodgy pages now. 