### PR TITLE
fix formatting

### DIFF
--- a/tutorials/install-and-configure-wireguard-vpn-debian/01.en.md
+++ b/tutorials/install-and-configure-wireguard-vpn-debian/01.en.md
@@ -3,8 +3,8 @@ SPDX-License-Identifier: MIT
 path: "/tutorials/install-and-configure-wireguard-vpn-debian"
 slug: "install-and-configure-wireguard-vpn-debian"
 date: "2019-06-18"
-title: "Installing and configuring a Wireguard VPN server on Debian 9.9"
-short_description: "This tutorial teaches you how to install Wireguard as a VPN on your server, as well as providing client examples for various purposes."
+title: "Installing and configuring a WireGuard VPN server on Debian 9.9"
+short_description: "This tutorial teaches you how to install WireGuard as a VPN on your server, as well as providing client examples for various purposes."
 tags: ["VPN", "Debian"]
 author: "Ben G"
 author_link: "https://github.com/benglvr"
@@ -18,13 +18,13 @@ cta: "dedicated"
 
 ## Introduction
 
-Wireguard is a fast and secure alternative to other VPN software such as IPSec and OpenVPN. The benefit of Wireguard is that it is multithreaded and built into the kernel, meaning you can achieve symmetrical throughputs of 1Gbps even on lower end boxes, something that is not possible with OpenVPN. The server is very lightweight and easy to setup. There are clients for most operating systems including Windows.
+WireGuard is a fast and secure alternative to other VPN software such as IPSec and OpenVPN. The benefit of WireGuard is that it is multithreaded and built into the kernel, meaning you can achieve symmetrical throughputs of 1Gbps even on lower end boxes, something that is not possible with OpenVPN. The server is very lightweight and easy to setup. There are clients for most operating systems including Windows.
 
-Some other benefits of Wireguard include being able to run internal services such as SSH, FTP, and remote desktop, on the VPN IP address instead of the main IP address of the server, which reduces the possible attack vectors on your server. For example, you can enable SSH access for one user on your public IP, and all other users on the VPN IP only.
+Some other benefits of WireGuard include being able to run internal services such as SSH, FTP, and remote desktop, on the VPN IP address instead of the main IP address of the server, which reduces the possible attack vectors on your server. For example, you can enable SSH access for one user on your public IP, and all other users on the VPN IP only.
 
-You can also tunnel part or all of your internet traffic over wireguard as a VPN, and easily achieve speeds of over 1Gbps. If you are behind NAT and cannot port forward, a simple Wireguard server on a low end VPS is a good way to allow servers running on your computer to be accessible from the internet.
+You can also tunnel part or all of your internet traffic over WireGuard as a VPN, and easily achieve speeds of over 1Gbps. If you are behind NAT and cannot port forward, a simple WireGuard server on a low end VPS is a good way to allow servers running on your computer to be accessible from the internet.
 
-This tutorial will focus on installing Wireguard on a Debian 9.9 (Stretch) server.
+This tutorial will focus on installing WireGuard on a Debian 9.9 (Stretch) server.
 
 ## Step 1 - Installation
 
@@ -32,7 +32,7 @@ After logging into your server via SSH, switch to the root user by typing `sudo 
 
 Run the following commands:
 
-```
+```bash
 echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.list.d/unstable-wireguard.list
 printf 'Package: *\nPin: release a=unstable\nPin-Priority: 150\n' > /etc/apt/preferences.d/limit-unstable
 apt-get update
@@ -40,13 +40,13 @@ apt-get update
 
 Install the headers for your kernel if you have not done so:
 
-```
+```bash
 apt-get install linux-headers-$(uname -r|sed 's/[^-]*-[^-]*-//')
 ```
 
-Then install wireguard:
+Then install WireGuard:
 
-```
+```bash
 apt-get install wireguard
 ```
 
@@ -62,11 +62,11 @@ If you do not see this and see an error instead, ensure the linux headers you ha
 
 ## Step 2 - Server configuration
 
-This guide will assume you have a server with a single client. Wireguard supports as many clients as needed, simply add another peer to the wg0.conf configuration file, and follow client installation steps again on the client.
+This guide will assume you have a server with a single client. WireGuard supports as many clients as needed, simply add another peer to the `wg0.conf` configuration file, and follow client installation steps again on the client.
 
 First, generate public and private keys on the server:
 
-```
+```bash
 wg genkey | tee /etc/wireguard/wg-private.key | wg pubkey > /etc/wireguard/wg-public.key
 ```
 
@@ -83,7 +83,7 @@ Here, `1.2.3.4` is the public IPv4 address of your server, `10.0.0.1` is the pri
 
 Add a configuration such as:
 
-```
+```ini
 [Interface]
 Address = 10.0.0.1/24
 SaveConfig = false
@@ -99,7 +99,7 @@ PersistentKeepalive = 25
 To explain each configuration parameter:
 
 * `Address` is the aforementioned private IPv4. The /24 subnet indicates that this will handle IPs `10.0.0.1 - 10.0.0.254`.
-* `SaveConfig` does not allow changes made in the command line to affect the configuration file, which may cause problems in wg-quick mode.
+* `SaveConfig` does not allow changes made in the command line to affect the configuration file, which may cause problems in `wg-quick` mode.
 * `ListenPort` is the listening port of your server. This will need to be opened in your firewall.
 * `PrivateKey` is the private key generated for the server. The public key will be given out to each client. The rule of thumb: the private key does not leave the device it was generated on, but the public key does.
 
@@ -114,13 +114,13 @@ Repeat the installation steps up until "configuration" if you are running Linux 
 
 Generate a public and private key on the client via the same process as the server, or with File -> Generate Key Pair in TunSafe. **TunSafe's default configuration comes with a public/private key that must be changed for security, it is the same across all installations.**
 
-Add the public key you just generated to the server wg0.conf in the peer's PublicKey section.
+Add the public key you just generated to the server `wg0.conf` in the peer's `PublicKey` section.
 
-Next, you will need to configure the client. The configuration is very similar to the server. In fact, you can run a client as a server by adding a ListenPort directive, and connect multiple servers together that way.
+Next, you will need to configure the client. The configuration is very similar to the server. In fact, you can run a client as a server by adding a `ListenPort` directive, and connect multiple servers together that way.
 
 An example Linux client configuration, which only tunnels VPN traffic on `10.0.0.0/24`, and not the entire internet of the client computer:
 
-```
+```ini
 [Interface]
 Address = 10.0.0.2/32
 SaveConfig = false
@@ -135,7 +135,7 @@ PersistentKeepalive = 25
 
 An example Windows client configuration (Windows does not support `/31` or `/32`), which tunnels all traffic through the server, with IPv6 support:
 
-```
+```ini
 [Interface]
 PrivateKey = PRIVATE KEY OF CLIENT GOES HERE
 # Switch DNS server while connected
@@ -151,15 +151,14 @@ PersistentKeepalive = 25
 
 Where `1.2.3.4` is the public IPv4 address of your server. Remove the IPv6 addresses if you do not want IPv6 support.
 
-If you want IPv6 support, you will also need to add the client's IPv6 address to the server configuration under the peer's AllowedIPs. Each server gets a `/64` so you can allocate an individual IP in there to your client (or a smaller subnet). Keep in mind when forwarding a public IPv6 you will need to firewall it correctly, which is outside the scope of this tutorial (it can either be firewalled on the client with windows firewall or the server with iptables, for example). It is possible to forward public IPv4 in a similar way. The benefit of doing this is you do not need NAT on the server-side for port forwarding.
+If you want IPv6 support, you will also need to add the client's IPv6 address to the server configuration under the peer's AllowedIPs. Each server gets a `/64` so you can allocate an individual IP in there to your client (or a smaller subnet). Keep in mind when forwarding a public IPv6 you will need to firewall it correctly, which is outside the scope of this tutorial (it can either be firewalled on the client with windows firewall or the server with `iptables`, for example). It is possible to forward public IPv4 in a similar way. The benefit of doing this is you do not need NAT on the server-side for port forwarding.
 
 ## Step 4 - Further server configuration in special cases
 
-The AllowedIPs parameter on the client will specify what IP ranges go through the tunnel and what do not. You will need to configure iptables on the server like so to enable external internet access if forwarding all traffic (ie the `0.0.0.0/0` configuration):
+The AllowedIPs parameter on the client will specify what IP ranges go through the tunnel and what do not. You will need to configure `iptables` on the server like so to enable external internet access if forwarding all traffic (ie the `0.0.0.0/0` configuration):
 
-```
+```bash
 echo 1 > /proc/sys/net/ipv4/ip_forward
-
 nano /etc/sysctl.conf
 ```
 
@@ -170,16 +169,16 @@ to
 
 Install package `iptables` and `iptables-persistent`, then `iptables-save > /etc/iptables/rules.v4` to save the config across reboots:
 
-```
+```bash
 iptables -t nat -A POSTROUTING -s 10.0.0.0/24 -o enp1s0 -j SNAT --to-source 1.2.3.4
 iptables -t nat -A POSTROUTING -s 10.0.0.0/24 -j MASQUERADE
 ```
 
-Replace enp1s0 with the main interface (you can check this with `ifconfig`).
+Replace `enp1s0` with the main interface (you can check this with `ifconfig`).
 
 If you want to port forward, consider:
 
-```
+```bash
 iptables -t NAT -A PREROUTING -d 1.2.3.4/32 -i enp1s0 -p tcp -m tcp --dport 45000 -j DNAT --to-destination 10.0.0.2:48000
 ```
 
@@ -212,35 +211,35 @@ peer: removed
 
 If your client has connected correctly, you will see last handshake and total transfer.
 
-You can now ping your server/client through the tunnel (ping 10.0.0.1). Any services bound to `0.0.0.0` or `10.0.0.1` will also be accessible from your clients over the VPN. Finally, with the `AllowedIPs = 0.0.0.0/0` configuration, all internet traffic will be tunnelled over the VPN connection too.
+You can now ping your server/client through the tunnel: `ping 10.0.0.1`. Any services bound to `0.0.0.0` or `10.0.0.1` will also be accessible from your clients over the VPN. Finally, with the `AllowedIPs = 0.0.0.0/0` configuration, all internet traffic will be tunnelled over the VPN connection too.
 
-To secure services to the VPN, either set their bind address to the VPN IP (10.0.0.1), or limit the access to `10.0.0.0/24` (for example, the AllowUsers directive in sshd_config: AllowUsers `root@10.0.0.*`). Avoid locking yourself completely out of the server doing this, and always leave a service open to all IPs while making changes in case something goes wrong. If you do lock yourself out, you will need to request a KVM console in robot and fix your mistakes.
+To secure services to the VPN, either set their bind address to the VPN IP (`10.0.0.1`), or limit the access to `10.0.0.0/24` (for example, the `AllowUsers` directive in sshd_config: `AllowUsers root@10.0.0.*`). Avoid locking yourself completely out of the server doing this, and always leave a service open to all IPs while making changes in case something goes wrong. If you do lock yourself out, you will need to request a KVM console in robot and fix your mistakes.
 
 ## Step 6 - Reloading config file (Optional)
 
 To reload the configuration file completely, you will need to restart the server (this will kill current connections):
-```systemctl restart wg-quick@wg0```
+`systemctl restart wg-quick@wg0`
 
 If you just want to add a client after updating the configuration file, you can instead run:
-```wg addconf wg0 <(wg-quick strip wg0)```
+`wg addconf wg0 <(wg-quick strip wg0)`
 
 This will not break existing connections.
 
 ## Step 7 - Troubleshooting
 
 * Can you connect to the server at all? Type `sudo wg`. Do you see a handshake having taken place recently? If so, you are connected. If not, check your public and private keys, as well as firewall rules.
-* Can you connect to the server but not access the internet in a `0.0.0.0/0` configuration? If you can ping the server itself (`10.0.0.1`), it may be an iptables issue. Make sure you added the rule correctly, and `cat /proc/sys/net/ipv4/ip_forward` returns 1.
+* Can you connect to the server but not access the internet in a `0.0.0.0/0` configuration? If you can ping the server itself (`10.0.0.1`), it may be an `iptables` issue. Make sure you added the rule correctly, and `cat /proc/sys/net/ipv4/ip_forward` returns 1.
 * Can you not ping a windows client? Windows blocks ICMP by default on the `10.0.0.0/8` range, so you will need to enable it in windows firewall. The same applies to any service running on a windows client.
-* Slow speeds? Check your CPU usage on the client and server. If your CPU is maxing out, that is the problem, but you should have no issue with multi-gigabit speeds on a modern 4-core processor. Try killing or renicing other applications that might be using the CPU. You will not see wireguard as a process as it runs in the kernel, but you will see its CPU usage as red bars in `htop`.
-* Cannot access a service at https://10.0.0.1:port? Type `netstat -tulpn` and check it is listening on `0.0.0.0` or `10.0.0.1`, not `127.0.0.1` or `1.2.3.4`.
+* Slow speeds? Check your CPU usage on the client and server. If your CPU is maxing out, that is the problem, but you should have no issue with multi-gigabit speeds on a modern 4-core processor. Try killing or renicing other applications that might be using the CPU. You will not see WireGuard as a process as it runs in the kernel, but you will see its CPU usage as red bars in `htop`.
+* Cannot access a service at `https://10.0.0.1:PORT`? Type `netstat -tulpn` and check it is listening on `0.0.0.0` or `10.0.0.1`, not `127.0.0.1` or `1.2.3.4`.
 * TunSafe may need you to reboot your computer.
-* As a client, cannot access something running on another client? Ensure server allows `FORWARD` between the two clients in iptables/ufw. Also ensure `/proc/sys/net/ipv4/ip_forward` = 1.
+* As a client, cannot access something running on another client? Ensure server allows `FORWARD` between the two clients in `iptables` / `ufw`. Also ensure `/proc/sys/net/ipv4/ip_forward = 1`.
 
 ## Conclusion and further reading
 
 By now you should have a working VPN server running WireGuard, congratulations!
 
-The [Wireguard page](https://wiki.debian.org/Wireguard) on the Debian wiki has alternatives to wg-quick and is useful for further reading, if you wish to use systemd or /etc/network/interfaces for configuration.
+The [WireGuard page](https://wiki.debian.org/Wireguard) on the Debian wiki has alternatives to `wg-quick` and is useful for further reading, if you wish to use systemd or /etc/network/interfaces for configuration.
 
 ##### License: MIT
 

--- a/tutorials/install-and-configure-wireguard-vpn-debian/01.en.md
+++ b/tutorials/install-and-configure-wireguard-vpn-debian/01.en.md
@@ -218,10 +218,16 @@ To secure services to the VPN, either set their bind address to the VPN IP (`10.
 ## Step 6 - Reloading config file (Optional)
 
 To reload the configuration file completely, you will need to restart the server (this will kill current connections):
-`systemctl restart wg-quick@wg0`
+
+```bash
+systemctl restart wg-quick@wg0
+```
 
 If you just want to add a client after updating the configuration file, you can instead run:
-`wg addconf wg0 <(wg-quick strip wg0)`
+
+```bash
+wg addconf wg0 <(wg-quick strip wg0)
+```
 
 This will not break existing connections.
 

--- a/tutorials/install-and-secure-nginx-lets-encrypt-debian-10/01.en.md
+++ b/tutorials/install-and-secure-nginx-lets-encrypt-debian-10/01.en.md
@@ -40,13 +40,13 @@ Let’s Encrypt is an SSL or CA security certificate issuer that is free to inst
 
 Before that, we need to update the local packages index using the following command.
 
-```console
+```bash
 apt update
 ```
 
 We can now install `nginx` using the following command.
 
-```console
+```bash
 apt install nginx
 ```
 
@@ -58,13 +58,13 @@ After installing nginx, the web server has already started and must work properl
 
 Using the following command, we can check the current state of nginx.
 
-```console
+```bash
 systemctl status nginx
 ```
 
 Sample output:
 
-```text
+```
 ● nginx.service - A high-performance web server and a reverse proxy server
    Loaded: loaded (/lib/systemd/system/nginx.service; enabled; vendor preset: enabled)
    Active: active (running) since Wed 2022-11-30 13:56:28 UTC; 27s ago
@@ -90,13 +90,13 @@ This configuration is suitable for using a site on the server, but if we need to
 
 Create a directory using the following command.
 
-```console
+```bash
 mkdir -v -p /var/www/example.com/html
 ```
 
 Then use your favourite editor to create a `/var/www/example.com/html/index.html` file with the following content:
 
-```text
+```
 Success! Welcome to "example.com".
 ```
 
@@ -105,25 +105,23 @@ To not change the default configuration, we create a new configuration file with
 
 Add the following contents and settings to the created file.
 
-```text
+```nginx
 server {
-        listen 80;
-        listen [::]:80;
+    listen 80;
+    listen [::]:80;
+    server_name example.com www.example.com;
+    root /var/www/example.com/html;
+    index index.php index.html index.htm;
 
-        root /var/www/example.com/html;
-        index index.php index.html index.htm;
-
-        server_name example.com www.example.com;
-
-        location / {
-                try_files $uri $uri/ =404;
-        }
+    location / {
+        try_files $uri $uri/ =404;
+    }
 }
 ```
 
 In the following, we will add a link from the config file created to the active directories.
 
-```console
+```bash
 ln -v -s /etc/nginx/sites-available/example.com /etc/nginx/sites-enabled/
 ```
 
@@ -131,20 +129,20 @@ Now the created server block has been activated and configured.
 
 Using the following command, we make sure that there is no error in making changes and configurations.
 
-```console
+```bash
 nginx -t
 ```
 
 If the settings are done correctly, we will encounter the following output.
 
-```text
+```
 nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
 nginx: configuration file /etc/nginx/nginx.conf test is successful
 ```
 
 After configuring, reload nginx to apply the changes.
 
-```console
+```bash
 systemctl reload nginx
 ```
 
@@ -158,7 +156,7 @@ The `python3-certbot-nginx` installation package, which is located on the Debian
 
 By running the following command, we install the desired packages:
 
-```console
+```bash
 apt install python3-certbot-nginx
 ```
 
@@ -168,7 +166,7 @@ Certbot offers a variety of ways to get an SSL certificate, the nginx plugin is 
 
 To get the SSL certificate, we use the following command.
 
-```console
+```bash
 certbot run --nginx -d example.com,www.example.com
 ```
 
@@ -182,7 +180,7 @@ If this connection is successful, Certbot will ask how to configure HTTPS.
 
 Sample output:
 
-```text
+```
 Please choose whether or not to redirect HTTP traffic to HTTPS, removing HTTP access.
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 1: No redirect - Make no further changes to the webserver configuration.
@@ -199,7 +197,7 @@ With the following message, Certbot will confirm the correct installation of the
 
 Sample output:
 
-```text
+```
 IMPORTANT NOTES:
  - Congratulations! Your certificate and chain have been saved at:
    /etc/letsencrypt/live/example.com/fullchain.pem
@@ -231,7 +229,7 @@ For this purpose, by adding the extension script to `/etc/cron.d`, we can perfor
 
 After receiving the SSL in Step 5, the `/etc/cron.d/certbot` file is created to renew the SSL security certificate with the following contents.
 
-```text
+```bash
 # /etc/cron.d/certbot: crontab entries for the certbot package
 #
 # Upstream recommends attempting renewal twice a day
@@ -255,7 +253,7 @@ The script runs twice a day and renews certificates that will expire within 30 d
 
 To check the renewal process, we can execute the following command manually.
 
-```console
+```bash
 certbot renew --dry-run
 ```
 

--- a/tutorials/install-mattermost-on-managed-server/01.en.md
+++ b/tutorials/install-mattermost-on-managed-server/01.en.md
@@ -87,8 +87,8 @@ Next you need to connect Mattermost with your MySQL Database (please replace the
 
 ```json
 "SqlSettings": {
-	"DriverName": "mysql",
-	"DataSource": "holu:dbpassword@tcp(localhost:3306)/mattermost?charset=utf8mb4,utf8\u0026writeTimeout=30s",
+    "DriverName": "mysql",
+    "DataSource": "holu:dbpassword@tcp(localhost:3306)/mattermost?charset=utf8mb4,utf8\u0026writeTimeout=30s",
 ```
 
 This is everything that you need to change in the default configuration, to get Mattermost up and running. You can save and close the file.
@@ -108,7 +108,7 @@ If your configuration is correct, mattermost should now start normally. If there
 The basic installation is now finished. You can start Mattermost in the background with:
 
 ```bash
-nohup /<path-to-mattermost/bin/mattermost &
+nohup /<path-to-mattermost>/bin/mattermost &
 ```
 
 The output of the process will get logged in a `nohup.out` file.
@@ -125,15 +125,15 @@ If Mattermost is running, you have multiple ways to access it:
 
 **Using the Port in the Browser directly**
 
-For this to work, you need to open the port of your mattermost installation (default: `8065`) via konsoleH. After that, you can access it directly through the browser. For example ```http://example.com:8065```
+For this to work, you need to open the port of your mattermost installation (default: `8065`) via konsoleH. After that, you can access it directly through the browser. For example `http://example.com:8065`
 
 ![port](images/port.png)
 
 **Using Apache as a proxy**
 
-Using Apache as a poxy enables you to reach mattermost without directly supplying the port in the address bar of your browser. To do this, please send a support request and ask for the installation of ```mod_proxy_wstunnel``` and the activation of the following VHost configuration:
+Using Apache as a poxy enables you to reach mattermost without directly supplying the port in the address bar of your browser. To do this, please send a support request and ask for the installation of `mod_proxy_wstunnel` and the activation of the following VHost configuration:
 
-```bash
+```apacheconf
 #Mattermost
 ProxyPreserveHost On
 

--- a/tutorials/install-mattermost-on-managed-server/01.en.md
+++ b/tutorials/install-mattermost-on-managed-server/01.en.md
@@ -89,6 +89,8 @@ Next you need to connect Mattermost with your MySQL Database (please replace the
 "SqlSettings": {
     "DriverName": "mysql",
     "DataSource": "holu:dbpassword@tcp(localhost:3306)/mattermost?charset=utf8mb4,utf8\u0026writeTimeout=30s",
+    ...
+  },
 ```
 
 This is everything that you need to change in the default configuration, to get Mattermost up and running. You can save and close the file.

--- a/tutorials/install-nagios-core-on-managed-server/01.en.md
+++ b/tutorials/install-nagios-core-on-managed-server/01.en.md
@@ -129,9 +129,9 @@ The main Apache configuration file can be found under
 
 ### Step 2.1 - Change the default Apache Port
 
-Open the httpd.conf, search for "Listen 80" and replace the Port with any free Port >1024 (In this tutorial we use 8080). 
+Open the httpd.conf, search for `Listen 80` and replace the Port with any free Port > 1024 (In this tutorial we use 8080). 
 
-```
+```apacheconf
 Listen 8080
 ```
 
@@ -139,13 +139,13 @@ Listen 8080
 
 Search and uncomment the line below to load the cgid module.
 
-```
+```apacheconf
 LoadModule cgid_module modules/mod_cgid.so
 ```
 
 Extend the DirectoryIndex directive with index.php.
 
-```
+```apacheconf
 #
 # DirectoryIndex: sets the file that Apache will serve if a directory
 # is requested.
@@ -157,7 +157,7 @@ Extend the DirectoryIndex directive with index.php.
 
 Add the following directive to the end of the file.
 
-```
+```apacheconf
 <FilesMatch \.php$>
     SetHandler application/x-httpd-php
 </FilesMatch>
@@ -167,7 +167,7 @@ Add the following directive to the end of the file.
 
 The following include enables the Nagios webconfig. Add it to the end of the file.
 
-```
+```apacheconf
 Include conf/nagios.conf
 ```
 
@@ -189,7 +189,7 @@ Unfortunately the default Alias directive in the Nagios webconfig does not work 
 
 Comment out the Alias directive and change the Directory directive for "/usr/home/holu/nagios/nagios/share" like the content below.
 
-```
+```apacheconf
 #Alias /nagios/ "/usr/home/holu/nagios/nagios/share"
 
 <Directory "/usr/home/holu/nagios/htdocs/nagios">
@@ -256,7 +256,7 @@ ssh holu@dediX.your-server.de -p222 -L 8080:localhost:8080
 
 Alternatively you can add a proxy rewrite rule to the .htaccess of the managed Apache.
 
-```
+```apacheconf
 RewriteEngine on
 RewriteRule   ^(.*)  http://localhost:8080/$1 [P]
 ```

--- a/tutorials/install-windows/01.de.md
+++ b/tutorials/install-windows/01.de.md
@@ -29,7 +29,7 @@ In diesem Tutorial geht es um die Installation eines Windows Betriebssystems auf
 
 Sobald sich der Server im Rescue System befindet (Linux x64), muss folgende Software installiert werden.
 
-```console
+```bash
 apt update && apt install qemu-kvm
 ```
 
@@ -48,35 +48,35 @@ Als nächstes muss eine Windows ISO auf den Server übertragen werden. Mögliche
 > Windows Server 2016 (ENG): https://mirror.hetzner.de/bootimages/windows/SW_DVD9_Win_Server_STD_CORE_2016_64Bit_English_-4_DC_STD_MLF_X21-70526.ISO
 
 Sie können das Image mit wget oder curl herunterladen:
-```console
+
+```bash
 wget <image>
 ```
-
 
 Anschließend muss die Systemfestplatte noch vorbereitet werden. Hier muss eine Partitionstabelle angelegt werden.
 > **Achtung** bei folgenden Schritten werden alle Daten der Festplatte gelöscht.
 
 Starten von `parted` auf der gewünschten Festplatte:
 
-```console
+```bash
 parted /dev/sdb
 ```
 
 Erstellen der Partitionstabelle bei Festplatten kleiner 2 TB:
 
-```console
+```bash
 mklabel msdos
 ```
 
 Erstellen der Partitionstabelle bei Festplatten größer 2 TB:
 
-```console
+```bash
 mklabel gpt
 ```
 
 Das ganze sollte dann in etwa so aussehen:
 
-```console
+```shellsession
 root@rescue ~ # parted /dev/sda
 GNU Parted 3.2
 Using /dev/sda
@@ -98,7 +98,7 @@ Andernfalls ist die installation frei im Internet aufrufbar.
 
 Unter Linux und Windows mit installiertem OpenSSH genügt es den folgende Befehl lokal auszuführen und sich am Server anzumelden.
 
-```console
+```bash
 ssh -L 8888:127.0.0.1:5901 root@your_host
 ```
 
@@ -107,21 +107,21 @@ ssh -L 8888:127.0.0.1:5901 root@your_host
 Jetzt kann mit der eigentlichen Windows Installation gestartet werden.
 Dazu muss nun folgender Befehl (entsprechend abgeändert) auf dem Server ausgeführt werden.
 
-```console
+```bash
 qemu-system-x86_64 -enable-kvm -smp 4 -m 4096 -boot d -cdrom en_windows_server_2019_updated_sept_2019_x64_dvd_199664ce.iso -drive file=/dev/sda,format=raw,media=disk -vnc 127.0.0.1:1
 ```
 
-|  Optionen |   |
+| Optionen ||
 |---|---|
-| -smp  | Anzahl der CPU Kerne
-|  -m |  Große des verwendeten RAMs
-|  -cdrom |  Pfad zum ISO Image
-|  -drive | Festplatte auf der das System installiert werden soll
-|  -vnc |  VNC Server Einstellungen
+| -smp   | Anzahl der CPU Kerne
+| -m     | Große des verwendeten RAMs
+| -cdrom | Pfad zum ISO Image
+| -drive | Festplatte auf der das System installiert werden soll
+| -vnc   | VNC Server Einstellungen
 
 Als nächstes kann die Installation per VNC gestartet werden, dazu muss man sich mit einem VNC Viewer der wahl zur folgenden Adresse verbinden.
 
-```console
+```
 127.0.0.1:8888
 ```
 
@@ -142,23 +142,23 @@ Die Einrichtung des Scheduled Tasks erfolgt anhand dieser Schritte:
 
 1. Startoptionen festlegen.
 
-![Task 1](images/task01.png)
+    ![Task 1](images/task01.png)
 
 2. Aktion Festlegen.
 
-![Task 2](images/task02.png)
+    ![Task 2](images/task02.png)
 
 3. PowerShell optionen eintragen `-ExecutionPolicy Bypass -File C:\script.ps1`.
 
-![Task 3](images/task03.png)
+    ![Task 3](images/task03.png)
 
 4. Task optionen Übersicht.
 
-![Task 4](images/task04.png)
+    ![Task 4](images/task04.png)
 
 5. Sicherheitsoptionen hier sollte Eingestellt werden, dass das Script auch ohne eine Benutzeranmeldung startet.
 
-![Task](images/task.png)
+    ![Task](images/task.png)
 
 ## Schritt 5 - RDP Aktivieren & Firewall Deaktivieren
 

--- a/tutorials/install-windows/01.en.md
+++ b/tutorials/install-windows/01.en.md
@@ -29,7 +29,7 @@ This tutorial covers the installation of a Windows operating system on dedicated
 
 Once the server is in the Rescue System (Linux x64), the following software must be installed:
 
-```console
+```bash
 apt update && apt install qemu-kvm
 ```
 
@@ -46,7 +46,8 @@ Next, a Windows ISO must be transferred to the server. Possible options are:
 > Windows Server 2016 (ENG): https://mirror.hetzner.de/bootimages/windows/SW_DVD9_Win_Server_STD_CORE_2016_64Bit_English_-4_DC_STD_MLF_X21-70526.ISO
 
 You can download the image with wget or curl for example:
-```console
+
+```bash
 wget <image>
 ```
 
@@ -56,25 +57,25 @@ The system drive still has to be prepared after connecting the ISO. A partition 
 
 Start `parted` on the desired drive:
 
-``` console
+```bash
 parted /dev/sdb
 ```
 
 Creating the partition table for drives smaller than 2 TB:
 
-``` console
+```bash
 mklabel msdos
 ```
 
 Creating the partition table for drives larger than 2 TB:
 
-``` console
+```bash
 mklabel gpt
 ```
 
 The whole thing should look something like this:
 
-``` console
+```shellsession
 root@rescue ~ # parted /dev/sda
 GNU Parted 3.2
 Using /dev/sda
@@ -95,7 +96,7 @@ For later installation via VNC an SSH tunnel is required. Otherwise the installa
 
 On Linux and Windows with OpenSSH installed, simply run the following command locally and log on to the server:
 
-```console
+```bash
 ssh -L 8888:127.0.0.1:5901 root@your_host
 ```
 
@@ -103,23 +104,19 @@ ssh -L 8888:127.0.0.1:5901 root@your_host
 
 Now you can start with the actual Windows installation. To do this, the following command (modified accordingly) must be executed on the server.
 
-```console
+```bash
 qemu-system-x86_64 -enable-kvm -smp 4 -m 4096 -boot d -cdrom en_windows_server_2019_updated_sept_2019_x64_dvd_199664ce.iso -drive file=/dev/sda,format=raw,media=disk -vnc 127.0.0.1:1
 ```
 
-| Options | |
+| Option | Meaning |
 |---|---|
-| -smp | Number of CPU cores
-| -m | Size of the used RAM
+| -smp   | Number of CPU cores
+| -m     | Size of the used RAM
 | -cdrom | Path to ISO image
 | -drive | hard disk on which the system is to be installed
-| -vnc | VNC Server Settings
+| -vnc   | VNC Server Settings
 
-Next, the installation can be started via VNC. You can connect to a VNC viewer of your choice at the following address:
-
-```console
-127.0.0.1:8888
-```
+Next, the installation can be started via VNC. You can connect to a VNC viewer of your choice at the following address: `127.0.0.1:8888`.
 
 ## Step 4 - Automatic IP configuration
 
@@ -138,23 +135,23 @@ Use these steps to set up the scheduled task:
 
 1. Set startup options
 
-![Task 1](images/task01.png)
+    ![Task 1](images/task01.png)
 
 2. Define actions
 
-![Task 2](images/task02.png)
+    ![Task 2](images/task02.png)
 
 3. Enter PowerShell options `-ExecutionPolicy Bypass -File C:\script.ps1`
 
-![Task 3](images/task03.png)
+    ![Task 3](images/task03.png)
 
 4. Task options overview
 
-![Task 4](images/task04.png)
+    ![Task 4](images/task04.png)
 
 5. Security options here should be set that the script also starts without a user login.
 
-![Task](images/task.png)
+    ![Task](images/task.png)
 
 ## Step 5 - Enable RDP & Disable Firewall
 

--- a/tutorials/linux-setup-gre-tunnel/01.en.md
+++ b/tutorials/linux-setup-gre-tunnel/01.en.md
@@ -34,7 +34,7 @@ First of all, you must have two servers with root access. In this tutorial they 
 
 ## Step 1 - Module loading
 
-For setting up a GRE tunnel on Linux you must have ```ip_gre``` module loaded in your kernel.
+For setting up a GRE tunnel on Linux you must have `ip_gre` module loaded in your kernel.
 To make sure it's loaded just do:
 
 ```bash
@@ -182,13 +182,13 @@ We must do it for each port we are using.
 
 ## Step 6 - Persistence
 
-On a server restart all the things we did will be wiped out. To make sure the GRE tunnel and everything else is going to work after a restart we have to edit the file ```/etc/rc.local``` and add all the commands we did (except for the echo ones!) before the ```exit 0```.
+On a server restart all the things we did will be wiped out. To make sure the GRE tunnel and everything else is going to work after a restart we have to edit the file `/etc/rc.local` and add all the commands we did (except for the echo ones!) before the `exit 0`.
 
 ## Conclusions
 
 Now, if we connect to Server A using the ports we configured (Port TCP 80 for example) we're going instead to connect to Server B without knowing it.
 
-Note: if you use CSF to manage iptables you may have to put all the iptables commands in your ```/etc/csf/csfpost.sh``` and insert both servers' IP (also the GRE one) in your ```/etc/csf/csf.allow```.
+Note: if you use CSF to manage iptables you may have to put all the iptables commands in your `/etc/csf/csfpost.sh` and insert both servers' IP (also the GRE one) in your `/etc/csf/csf.allow`.
 
 ##### License: MIT
 

--- a/tutorials/linux-setup-gre-tunnel/01.it.md
+++ b/tutorials/linux-setup-gre-tunnel/01.it.md
@@ -34,7 +34,7 @@ Prima di tutto, dovremo avere due server con accesso amministrativo. I due serve
   
 ## 1 - Caricamento del modulo
 
-Per creare un tunnel GRE su Linux dovremo avere il modulo ```ip_gre``` caricato nel kernel.
+Per creare un tunnel GRE su Linux dovremo avere il modulo `ip_gre` caricato nel kernel.
 Per essere sicuri che sia caricato utilizziamo:
 
 ```bash
@@ -182,13 +182,13 @@ Dobbiamo farlo per tutte le porte che vorremo utilizzare.
 
 ## 6 - Rendere il tunnel persistente
 
-Al riavvio del server la maggior parte delle cose che abbiamo fatto verrà cancellata. Per assicurarsi che il tunnel GRE continui a funzionare anche dopo un riavvio dovremo modificare il file ```/etc/rc.local``` aggiungendo tutti i comandi che abbiamo fatto (ad eccezione del comando "echo"!) prima del ```exit 0```.
+Al riavvio del server la maggior parte delle cose che abbiamo fatto verrà cancellata. Per assicurarsi che il tunnel GRE continui a funzionare anche dopo un riavvio dovremo modificare il file `/etc/rc.local` aggiungendo tutti i comandi che abbiamo fatto (ad eccezione del comando "echo"!) prima del `exit 0`.
 
 ## Conclusione
 
 Ora, se ci connettiamo al Server A utilizzando le porte che abbiamo configurato (ad esempio la porta TCP 80) andremo in realtà a connetterci al Server B senza rendercene conto.
 
-Nota: se utilizzi CSF per gestire iptables potrebbe essere necessario inserire tutti i comandi realtivi a iptables che abbiamo fatto nel file ```/etc/csf/csfpost.sh``` e inserire entrambi gli IP dei server (sia quello pubblico che quello interno del tunnel) nel file ```/etc/csf/csf.allow```.
+Nota: se utilizzi CSF per gestire iptables potrebbe essere necessario inserire tutti i comandi realtivi a iptables che abbiamo fatto nel file `/etc/csf/csfpost.sh` e inserire entrambi gli IP dei server (sia quello pubblico che quello interno del tunnel) nel file `/etc/csf/csf.allow`.
 
 ##### License: MIT
 


### PR DESCRIPTION
* ```` ```bash ```` or ```` ```shell ```` looks like this:

    ![bash](https://github.com/hetzneronline/community-content/assets/85058595/952ae387-a034-4ad8-8d81-7f77a11fa431)

* ```` ```shellsession ```` looks like this:

    ![shellsession](https://github.com/hetzneronline/community-content/assets/85058595/dec80c9a-f9bd-4761-8190-c022340d0cff)

Some text in the GitHub diff-viewer is highlighted with red background. This is because [install-mattermost-on-managed-server](https://github.com/hetzneronline/community-content/blob/d70b26f68d12d1cf5f5294540d0447da69dd8276/tutorials/install-mattermost-on-managed-server/01.en.md?plain=1#L88) contains invalid json in the code block.