### PR TITLE
Resoves #636 /  Install and Configure BorgBackup -- Minor mistake in shell script variables

### DIFF
--- a/tutorials/install-and-configure-borgbackup/01.de.md
+++ b/tutorials/install-and-configure-borgbackup/01.de.md
@@ -138,7 +138,7 @@ Zunächst muss ein Skript erstellt werden, welches die Backups ausführt. Dies k
 
 ## falls nicht der Standard SSH Key verwendet wird können
 ## Sie hier den Pfad zu Ihrem private Key angeben
-# export BORG_RSH="ssh -i /home/userXY/.ssh/id_ed25519"
+# export BORG_RSH='ssh -i /home/userXY/.ssh/id_ed25519'
 
 ## Damit das Passwort vom Repository nicht eingegeben werden muss
 ## kann es in der Umgepungsvariable gesetzt werden
@@ -148,14 +148,14 @@ Zunächst muss ein Skript erstellt werden, welches die Backups ausführt. Dies k
 ## Setzten von Variablen
 ##
 
-LOG="/var/log/borg/backup.log"
-BACKUP_USER="u602"
-REPOSITORY_DIR="server1"
+LOG='/var/log/borg/backup.log'
+export BACKUP_USER='u602'
+export REPOSITORY_DIR='server1'
 
 ## Hinweis: Für die Verwendung mit einem Backup-Account muss
 ## 'your-storagebox.de' in 'your-backup.de' geändert werden.
 
-REPOSITORY="ssh://${BACKUP_USER}@${BACKUP_USER}.your-storagebox.de:23/./backups/${REPOSITORY_DIR}"
+export REPOSITORY='ssh://${BACKUP_USER}@${BACKUP_USER}.your-storagebox.de:23/./backups/${REPOSITORY_DIR}'
 
 ##
 ## Ausgabe in Logdatei schreiben

--- a/tutorials/install-and-configure-borgbackup/01.en.md
+++ b/tutorials/install-and-configure-borgbackup/01.en.md
@@ -138,24 +138,24 @@ First, create a script which will execute the backups. This could look like the 
 
 ## if you don't use the standard SSH key,
 ## you have to specify the path to the key like this
-# export BORG_RSH="ssh -i /home/userXY/.ssh/id_ed25519"
+# export BORG_RSH='ssh -i /home/userXY/.ssh/id_ed25519'
 
 ## You can save your borg passphrase in an environment
 ## variable, so you don't need to type it in when using borg
-# export BORG_PASSPHRASE="top_secret_passphrase"
+# export BORG_PASSPHRASE='top_secret_passphrase'
 
 ##
 ## Set some variables
 ##
 
-LOG="/var/log/borg/backup.log"
-BACKUP_USER="u602"
-REPOSITORY_DIR="server1"
+LOG='/var/log/borg/backup.log'
+export BACKUP_USER='u602'
+export REPOSITORY_DIR='server1'
 
 ## Tip: If using with a Backup Space you have to use
 ## 'your-storagebox.de' instead of 'your-backup.de'
 
-REPOSITORY="ssh://${BACKUP_USER}@${BACKUP_USER}.your-storagebox.de:23/./backups/${REPOSITORY_DIR}"
+export REPOSITORY='ssh://${BACKUP_USER}@${BACKUP_USER}.your-storagebox.de:23/./backups/${REPOSITORY_DIR}'
 
 ##
 ## Output to a logfile

--- a/tutorials/install-and-configure-borgbackup/01.ru.md
+++ b/tutorials/install-and-configure-borgbackup/01.ru.md
@@ -136,24 +136,24 @@ $ mkdir -p /var/log/borg
 
 ## если используется нестандартный SSH-ключ,
 ## то его надо явно указать:
-# export BORG_RSH="ssh -i /home/userXY/.ssh/id_ed25519"
+# export BORG_RSH='ssh -i /home/userXY/.ssh/id_ed25519'
 
 ## пароль репозитория Borg можно указать в переменной
 ## окружения, чтобы не вводить его при каждом запуске
-# export BORG_PASSPHRASE="top_secret_passphrase"
+# export BORG_PASSPHRASE='top_secret_passphrase'
 
 ##
 ## Задание переменных окружения
 ##
 
-LOG="/var/log/borg/backup.log"
-BACKUP_USER="u602"
-REPOSITORY_DIR="server1"
+LOG='/var/log/borg/backup.log'
+export BACKUP_USER='u602'
+export REPOSITORY_DIR='server1'
 
 ## Совет: при использовании Backup Space следует использовать домен
 ## 'your-storagebox.de" вместо "your-backup.de'
 
-REPOSITORY="ssh://${BACKUP_USER}@${BACKUP_USER}.your-storagebox.de:23/./backups/${REPOSITORY_DIR}"
+export REPOSITORY='ssh://${BACKUP_USER}@${BACKUP_USER}.your-storagebox.de:23/./backups/${REPOSITORY_DIR}'
 
 ##
 ## Вывод в файл журнала


### PR DESCRIPTION
What changed:
* In the example bash scripts: I put variables that are used in BorgBackup commands in single quotes and exported them according to BorgBackup manual.