### PR TITLE
Add hint in "Build up a MariaDB Galera Cluster in the Hetzner Cloud"

### DIFF
--- a/tutorials/install-galera-cluster-with-cloud-servers/01.de.md
+++ b/tutorials/install-galera-cluster-with-cloud-servers/01.de.md
@@ -169,6 +169,18 @@ Um den Status des Clusters nach dem Start aller Members zu prüfen, setzt man in
 
 Nun fügen wir die Cloud Server als Ziel (Target) zum Load Balancer hinzu.
 
+<blockquote>
+
+<details>
+
+<summary>Hinweis zum Load Balancer Algorithmus</summary>
+
+Mit "Round Robin" können die Verbindungen gleichmäßig über das Cluster verteilt werden. Bei diesem Algorithmus wird die aktuelle Last der einzelnen Nodes allerdings nicht berücksichtigt. Dadurch kann es passieren, dass einzelne Nodes stärker ausgelastet sind als andere. "Least Connections" ist daher im Allgemeinen die bessere Wahl für die Lastverteilung in einem MariaDB Galera Cluster.
+
+</details>
+
+</blockquote>
+
 ![Load Balancer Targets](images/lb_targets.de.png)
 
 ## Schritt 8 - Hinzufügen des Service und Health Check am Load Balancer

--- a/tutorials/install-galera-cluster-with-cloud-servers/01.en.md
+++ b/tutorials/install-galera-cluster-with-cloud-servers/01.en.md
@@ -40,6 +40,7 @@ Terminology used in this tutorial:
 ## Step 1 - Prepare Cloud Servers
 
 After ordering a new cloud server (CX11) with a standard OS Debian 11, first log in to the shell as root user and update the repo lists:
+
 ```shell
 apt update
 apt upgrade
@@ -167,6 +168,18 @@ In the MySQL CLI, you can use this command to check the status of your cluster:
 ## Step 7 - Add nodes to the Load Balancer
 
 Now, add the cloud servers as targets to your Load Balancer.
+
+<blockquote>
+
+<details>
+
+<summary>Note about Load Balancer algorithm</summary>
+
+"Round Robin" can distribute connections evenly across the cluster but it does not consider the current load on each node. This can lead to imbalances if some nodes are handling heavier workloads than others. Therefore, "Least Connections" is generally the more suitable choice for load balancing in a MariaDB Galera Cluster.
+
+</details>
+
+</blockquote>
 
 ![Load Balancer Targets](images/lb_targets.en.png)
 


### PR DESCRIPTION
Fix #635

Add hint about Load Balancer algorithm in "[Build up a MariaDB Galera Cluster in the Hetzner Cloud](https://github.com/hetzneronline/community-content/blob/master/tutorials/install-galera-cluster-with-cloud-servers)" tutorial