### PR TITLE
Add note about needing to run borg compact to free disk space

### DIFF
--- a/tutorials/install-and-configure-borgbackup/01.de.md
+++ b/tutorials/install-and-configure-borgbackup/01.de.md
@@ -214,6 +214,8 @@ It is strongly recommended to always run <kbd>prune -v --list --dry-run ...</kbd
 
 </blockquote>
 
+Der `borg prune`-Befehl gibt keinen Speicher frei. Dazu führen Sie anschließend den `borg compact`-Befehl aus.
+
 --------
 
 </details>

--- a/tutorials/install-and-configure-borgbackup/01.en.md
+++ b/tutorials/install-and-configure-borgbackup/01.en.md
@@ -213,6 +213,8 @@ It is strongly recommended to always run <kbd>prune -v --list --dry-run ...</kbd
 
 </blockquote>
 
+The `borg prune` command doesn't free disk space. To do so, run the `borg compact` command afterwards.
+
 --------
 
 </details>


### PR DESCRIPTION
`borg prune` doesn't free disk space, so a user almost certainly wants to also run `borg compact` to free the disk space after a prune operation.