### PR TITLE
use double quotes to fix bash env substitution

### DIFF
--- a/tutorials/install-and-configure-borgbackup/01.de.md
+++ b/tutorials/install-and-configure-borgbackup/01.de.md
@@ -155,7 +155,7 @@ export REPOSITORY_DIR='server1'
 ## Hinweis: Für die Verwendung mit einem Backup-Account muss
 ## 'your-storagebox.de' in 'your-backup.de' geändert werden.
 
-export REPOSITORY='ssh://${BACKUP_USER}@${BACKUP_USER}.your-storagebox.de:23/./backups/${REPOSITORY_DIR}'
+export REPOSITORY="ssh://${BACKUP_USER}@${BACKUP_USER}.your-storagebox.de:23/./backups/${REPOSITORY_DIR}"
 
 ##
 ## Ausgabe in Logdatei schreiben

--- a/tutorials/install-and-configure-borgbackup/01.en.md
+++ b/tutorials/install-and-configure-borgbackup/01.en.md
@@ -155,7 +155,7 @@ export REPOSITORY_DIR='server1'
 ## Tip: If using with a Backup Space you have to use
 ## 'your-storagebox.de' instead of 'your-backup.de'
 
-export REPOSITORY='ssh://${BACKUP_USER}@${BACKUP_USER}.your-storagebox.de:23/./backups/${REPOSITORY_DIR}'
+export REPOSITORY="ssh://${BACKUP_USER}@${BACKUP_USER}.your-storagebox.de:23/./backups/${REPOSITORY_DIR}"
 
 ##
 ## Output to a logfile

--- a/tutorials/install-and-configure-borgbackup/01.ru.md
+++ b/tutorials/install-and-configure-borgbackup/01.ru.md
@@ -153,7 +153,7 @@ export REPOSITORY_DIR='server1'
 ## Совет: при использовании Backup Space следует использовать домен
 ## 'your-storagebox.de" вместо "your-backup.de'
 
-export REPOSITORY='ssh://${BACKUP_USER}@${BACKUP_USER}.your-storagebox.de:23/./backups/${REPOSITORY_DIR}'
+export REPOSITORY="ssh://${BACKUP_USER}@${BACKUP_USER}.your-storagebox.de:23/./backups/${REPOSITORY_DIR}"
 
 ##
 ## Вывод в файл журнала


### PR DESCRIPTION
In the example script, the `REPOSITORY` variable should be surrounded by double ticks `"` instead of single ones, since otherwise bash env substitution does not work. 