### PR TITLE
Fixed installation of Ubuntu with full encryption

### DIFF
--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
@@ -114,10 +114,10 @@ remove_unwanted_netplan_config() {
 #!/bin/sh
 
 if [ -d "/run/netplan" ]; then
-  interface=$(ls /run/netplan/ | cut -d'.' -f1)
+  interface=\$(ls /run/netplan/ | cut -d'.' -f1)
 
-  if [ ${interface:+x} ]; then
-    rm -f /run/netplan/"${interface}".yaml
+  if [ \${interface:+x} ]; then
+    rm -f /run/netplan/"\${interface}".yaml
   fi
 fi
 EOF

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
@@ -131,7 +131,7 @@ chmod +x /tmp/post-install.sh
 
 Prüfen Sie vor dem Start der Installation nochmals den Inhalt der folgenden Dateien:
 
-* `/tmp/authorized_keys` - Ihr öffentlicher SSH-Schlüssel (RSA oder ECDSA)
+* `/tmp/authorized_keys` - Ihr öffentlicher SSH-Schlüssel (RSA, ECDSA or ED25565)
 * `/tmp/setup.conf` - die Installationskonfiguration
 * `/tmp/post-install.sh` - ist ausführbar und enthält das Post-Installations-Skript
 

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
@@ -18,7 +18,7 @@ cta: "dedicated"
 
 ## Introduction
 
-Das [installimage](https://docs.hetzner.com/robot/dedicated-server/operating-systems/installimage) Skript in dem [Hetzner Rescue System](https://docs.hetzner.com/robot/dedicated-server/troubleshooting/hetzner-rescue-system) bietet eine einfache Möglichkeit, verschiedene Linux-Distributionen zu installieren.
+Das [installimage](https://docs.hetzner.com/de/robot/dedicated-server/operating-systems/installimage/) Skript in dem [Hetzner Rescue System](https://docs.hetzner.com/de/robot/dedicated-server/troubleshooting/hetzner-rescue-system/) bietet eine einfache Möglichkeit, verschiedene Linux-Distributionen zu installieren.
 
 Dieses Tutorial zeigt, wie man mit `installimage` ein verschlüsseltes Ubuntu 20.04-System installiert und eine Entschlüsselung per SSH (dropbear) in initramfs hinzufügt, das in einer separaten `/boot`-Partition gespeichert ist.
 
@@ -52,7 +52,7 @@ Erstellen Sie eine Datei `/tmp/setup.conf` mit folgendem Inhalt oder kopieren Si
 
 Hinweis: Ersetzen Sie `secret` durch ein sicheres Passwort und passen Sie die Laufwerksnamen und die Partitionierung nach Bedarf an.
 
-```
+```bash
 CRYPTPASSWORD secret
 DRIVE1 /dev/sda
 BOOTLOADER grub
@@ -128,11 +128,11 @@ EOF
 # Hook installieren
 add_rfc3442_hook
 
-# Hinzufügen eines initramfs-tools Script um /run/netplan/{interface}.yaml,
-# zu entfernen, weile diese ungewollte Routen hinzufügt
+# Hinzufügen eines initramfs-tools Skript um /run/netplan/{interface}.yaml,
+# zu entfernen, weil diese ungewollte Routen hinzufügt
 remove_unwanted_netplan_config
 
-# Kopieren des SSH Keys für Dropbear
+# Kopieren des SSH-Schlüssels für Dropbear
 mkdir /etc/dropbear-initramfs/
 cp /root/.ssh/authorized_keys /etc/dropbear-initramfs/
 
@@ -141,7 +141,7 @@ apt-get update >/dev/null
 apt-get -y install cryptsetup-initramfs dropbear-initramfs
 ```
 
-Important note: make the post-install script executable:
+Wichtiger Hinweis: Das Post-Installations-Skript muss ausführbar gemacht werden:
 
 ```bash
 chmod +x /tmp/post-install.sh
@@ -170,6 +170,7 @@ Nach einiger Zeit sollte der Server auf einen Ping reagieren. Melden Sie sich nu
 
 Achtung: Im Falle von RSA, müssen wir explizit angeben, dass dieser Schlüssel akzeptiert wird.
 Sollten sie einen ED25519 oder ECDSA Schlüssel verwenden, wird der Parameter `-o` mit dem Wert nicht benötigt. Ebenfalls musst du den Pfad zu deinem Privat-Schlüssel ändern.
+
 ```
 $ ssh -o "PubkeyAcceptedKeyTypes +ssh-rsa" root@<your-host> -i .ssh/id_rsa
 
@@ -184,6 +185,6 @@ Wenn das Passwort korrekt ist, wird der Bootvorgang fortgesetzt und Sie werden a
 
 Nach ein paar Sekunden können Sie sich an Ihrem neuen System anmelden.
 
-**Hinweis: diese Anleitung ist explizit nur für Ubuntu 20.04 geschrieben. Es könnte sein, dass diese nicht auf anderen Distributionen funktioniert.**
+**Hinweis: Diese Anleitung ist explizit nur für Ubuntu 20.04 geschrieben. Es könnte sein, dass diese nicht auf anderen Distributionen funktioniert.**
 
 ##### License: MIT

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
@@ -35,12 +35,12 @@ Um das verschlüsselte System aus der Ferne entsperren zu können, wird ein SSH-
 **Wir empfehlen die Nutzung von ED25519 oder ECDSA Schlüsseln**
 
 Um z. B. einen 3072-Bit-RSA-SSH-Schlüssel SSH-Schlüssel zu erzeugen, führen sie den folgenden Befehl auf dem Client aus:
-```
+```bash
 ssh-keygen -t rsa -b 3072
 ```
 
 Kopieren Sie anschließend den öffentlichen Schlüssel auf das Rescue System, z. B. mit `scp`:	
-```
+```bash
 scp ~/.ssh/id_rsa.pub root@<your-host>:/tmp/authorized_keys
 ```
 
@@ -112,7 +112,7 @@ EOF
 # Hook installieren
 add_rfc3442_hook
 
-# Kopiere den SSH Key für Dropbear
+# Kopieren des SSH Keys für Dropbear
 mkdir /etc/dropbear-initramfs/
 cp /root/.ssh/authorized_keys /etc/dropbear-initramfs/
 
@@ -123,7 +123,7 @@ apt-get -y install cryptsetup-initramfs dropbear-initramfs
 
 Important note: make the post-install script executable:
 
-```
+```bash
 chmod +x /tmp/post-install.sh
 ```
 
@@ -136,7 +136,7 @@ Prüfen Sie vor dem Start der Installation nochmals den Inhalt der folgenden Dat
 * `/tmp/post-install.sh` - ist ausführbar und enthält das Post-Installations-Skript
 
 Jetzt können Sie die Installation mit dem folgenden Befehl starten:
-```
+```bash
 installimage -a -c /tmp/setup.conf -x /tmp/post-install.sh
 ```
 
@@ -149,7 +149,7 @@ Nachdem die Installation abgeschlossen ist und alle Fehler behoben wurden, könn
 Nach einiger Zeit sollte der Server auf einen Ping reagieren. Melden Sie sich nun per SSH an dropbear an und führen Sie `cryptroot-unlock` aus, um die verschlüsselte(n) Partition(en) zu entsperren.
 
 Achtung: Im Falle von RSA, müssen wir explizit angeben, dass dieser Schlüssel akzeptiert wird.
-Sollten sie einen ED25519 oder ECDSA Schlüssel verwenden, wird der Parameter `-o` mit dem Wert nicht benötigt.
+Sollten sie einen ED25519 oder ECDSA Schlüssel verwenden, wird der Parameter `-o` mit dem Wert nicht benötigt. Ebenfalls musst du den Pfad zu deinem Privat-Schlüssel ändern.
 ```
 $ ssh -o "PubkeyAcceptedKeyTypes +ssh-rsa" root@<your-host> -i .ssh/id_rsa
 

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
@@ -109,8 +109,26 @@ EOF
   chmod +x /etc/initramfs-tools/hooks/add-rfc3442-dhclient-hook
 }
 
+remove_unwanted_netplan_config() {
+  cat << EOF > /etc/initramfs-tools/scripts/init-bottom/remove_unwanted_netplan_config
+#!/bin/sh
+
+interface=$(ls /run/netplan/ | cut -d'.' -f1)
+
+if [ ${interface:+x} ]; then
+  rm -f /run/netplan/"${interface}".yaml
+fi
+EOF
+
+  chmod +x /etc/initramfs-tools/scripts/init-bottom/remove_unwanted_netplan_config
+}
+
 # Hook installieren
 add_rfc3442_hook
+
+# Hinzufügen eines initramfs-tools Script um /run/netplan/{interface}.yaml,
+# zu entfernen, weile diese ungewollte Routen hinzufügt
+remove_unwanted_netplan_config
 
 # Kopieren des SSH Keys für Dropbear
 mkdir /etc/dropbear-initramfs/

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
@@ -26,13 +26,13 @@ Dieses Tutorial zeigt, wie man mit `installimage` ein verschlüsseltes Ubuntu 20
 
 * Hetzner-Konto
 * Server welcher in das Rescue-System gebootet ist
-* Öffentlicher RSA, ECDSA oder ED25565 SSH-Schlüssel
+* Öffentlicher RSA, ECDSA oder ED25519 SSH-Schlüssel
 * Keine privaten Netzwerke über die Hetzner Cloud an den Servern angeschlossen
 
 ## Schritt 1 - Erstellen oder Kopieren des öffentlichen SSH-Schlüssels
 
-Um das verschlüsselte System aus der Ferne entsperren zu können, wird ein SSH-Schlüssel benötigt. Dieser Schlüssel wird auch für die spätere Anmeldung am gebooteten System verwendet. Der in Ubuntu 20.04 enthaltene SSH-Daemon dropbear unterstützt RSA, ED25565 und ECDSA-Schlüssel. Wenn Sie keinen solchen Schlüssel haben, müssen Sie einen generieren.
-**Wir empfehlen die Nutzung von ED25565 oder ECDSA Schlüsseln**
+Um das verschlüsselte System aus der Ferne entsperren zu können, wird ein SSH-Schlüssel benötigt. Dieser Schlüssel wird auch für die spätere Anmeldung am gebooteten System verwendet. Der in Ubuntu 20.04 enthaltene SSH-Daemon dropbear unterstützt RSA, ED25519 und ECDSA-Schlüssel. Wenn Sie keinen solchen Schlüssel haben, müssen Sie einen generieren.
+**Wir empfehlen die Nutzung von ED25519 oder ECDSA Schlüsseln**
 
 Um z. B. einen 3072-Bit-RSA-SSH-Schlüssel SSH-Schlüssel zu erzeugen, führen sie den folgenden Befehl auf dem Client aus:
 ```
@@ -131,7 +131,7 @@ chmod +x /tmp/post-install.sh
 
 Prüfen Sie vor dem Start der Installation nochmals den Inhalt der folgenden Dateien:
 
-* `/tmp/authorized_keys` - Ihr öffentlicher SSH-Schlüssel (RSA, ECDSA or ED25565)
+* `/tmp/authorized_keys` - Ihr öffentlicher SSH-Schlüssel (RSA, ECDSA or ED25519)
 * `/tmp/setup.conf` - die Installationskonfiguration
 * `/tmp/post-install.sh` - ist ausführbar und enthält das Post-Installations-Skript
 
@@ -149,7 +149,7 @@ Nachdem die Installation abgeschlossen ist und alle Fehler behoben wurden, könn
 Nach einiger Zeit sollte der Server auf einen Ping reagieren. Melden Sie sich nun per SSH an dropbear an und führen Sie `cryptroot-unlock` aus, um die verschlüsselte(n) Partition(en) zu entsperren.
 
 Achtung: Im Falle von RSA, müssen wir explizit angeben, dass dieser Schlüssel akzeptiert wird.
-Sollten sie einen ED25565 oder ECDSA Schlüssel verwenden, wird der Parameter `-o` mit dem Wert nicht benötigt.
+Sollten sie einen ED25519 oder ECDSA Schlüssel verwenden, wird der Parameter `-o` mit dem Wert nicht benötigt.
 ```
 $ ssh -o "PubkeyAcceptedKeyTypes +ssh-rsa" root@<your-host> -i .ssh/id_rsa
 

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
@@ -113,10 +113,12 @@ remove_unwanted_netplan_config() {
   cat << EOF > /etc/initramfs-tools/scripts/init-bottom/remove_unwanted_netplan_config
 #!/bin/sh
 
-interface=$(ls /run/netplan/ | cut -d'.' -f1)
+if [ -d "/run/netplan" ]; then
+  interface=$(ls /run/netplan/ | cut -d'.' -f1)
 
-if [ ${interface:+x} ]; then
-  rm -f /run/netplan/"${interface}".yaml
+  if [ ${interface:+x} ]; then
+    rm -f /run/netplan/"${interface}".yaml
+  fi
 fi
 EOF
 

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
@@ -26,22 +26,21 @@ Dieses Tutorial zeigt, wie man mit `installimage` ein verschlüsseltes Ubuntu 20
 
 * Hetzner-Konto
 * Server welcher in das Rescue-System gebootet ist
-* Öffentlicher RSA oder ECDSA SSH-Schlüssel
+* Öffentlicher RSA, ECDSA oder ED25565 SSH-Schlüssel
 * Keine privaten Netzwerke über die Hetzner Cloud an den Servern angeschlossen
 
 ## Schritt 1 - Erstellen oder Kopieren des öffentlichen SSH-Schlüssels
 
-Um das verschlüsselte System aus der Ferne entsperren zu können, wird ein SSH-Schlüssel benötigt. Dieser Schlüssel wird auch für die spätere Anmeldung am gebooteten System verwendet. Der in Ubuntu 20.04 enthaltene SSH-Daemon dropbear unterstützt nur RSA- und ECDSA-Schlüssel. Wenn Sie keinen solchen Schlüssel haben, müssen Sie einen generieren.
+Um das verschlüsselte System aus der Ferne entsperren zu können, wird ein SSH-Schlüssel benötigt. Dieser Schlüssel wird auch für die spätere Anmeldung am gebooteten System verwendet. Der in Ubuntu 20.04 enthaltene SSH-Daemon dropbear unterstützt RSA, ED25565 und ECDSA-Schlüssel. Wenn Sie keinen solchen Schlüssel haben, müssen Sie einen generieren.
+**Wir empfehlen die Nutzung von ED25565 oder ECDSA Schlüsseln**
 
-Um z. B. einen 4096-Bit-RSA-SSH-Schlüssel SSH-Schlüssel zu erzeugen, führen sie den folgenden Befehl auf dem Client aus:
-
-```bash
-ssh-keygen -t rsa -b 4096
+Um z. B. einen 3072-Bit-RSA-SSH-Schlüssel SSH-Schlüssel zu erzeugen, führen sie den folgenden Befehl auf dem Client aus:
+```
+ssh-keygen -t rsa -b 3072
 ```
 
 Kopieren Sie anschließend den öffentlichen Schlüssel auf das Rescue System, z. B. mit `scp`:	
-
-```bash
+```
 scp ~/.ssh/id_rsa.pub root@<your-host>:/tmp/authorized_keys
 ```
 
@@ -53,42 +52,16 @@ Erstellen Sie eine Datei `/tmp/setup.conf` mit folgendem Inhalt oder kopieren Si
 
 Hinweis: Ersetzen Sie `secret` durch ein sicheres Passwort und passen Sie die Laufwerksnamen und die Partitionierung nach Bedarf an.
 
-- Auf Servern mit `x86`-Architektur:
-  
-  ```
-  CRYPTPASSWORD secret
-  DRIVE1 /dev/sda
-  BOOTLOADER grub
-  HOSTNAME host.example.com
-  PART /boot ext4 1G
-  PART /     ext4 all crypt
-  IMAGE /root/images/Ubuntu-2004-focal-64-minimal.tar.gz
-  SSHKEYS_URL /tmp/authorized_keys
-  ```
-
-<blockquote>
-
-Um ein anderes Image zu verwenden, ersetzen Sie einfach `Ubuntu-2004-focal-amd64-base.tar.gz`. Zum Beispiel:
-
-<details>
-
-<summary>Ubuntu 22.04</summary>
-
-<ul><b>x86</b>: <kbd>Ubuntu-2204-jammy-amd64-base.tar.gz</kbd></ul>
-
-</details>
-
-<details>
-
-<summary>Debian 11</summary>
-
-<ul><b>x86</b>: <kbd>Debian-1106-bullseye-amd64-base.tar.gz</kbd></ul>
-
-------
-
-</details>
-
-</blockquote>
+```
+CRYPTPASSWORD secret
+DRIVE1 /dev/sda
+BOOTLOADER grub
+HOSTNAME host.example.com
+PART /boot ext4 1G
+PART /     ext4 all crypt
+IMAGE /root/images/Ubuntu-2004-focal-64-minimal.tar.gz
+SSHKEYS_URL /tmp/authorized_keys
+```
 
 Diese Konfiguration installiert Ubuntu auf einem einzelnen Laufwerk (`/dev/sda`) mit einer separaten unverschlüsselten `/boot` Partition, das für die Entschlüsselung benötigt wird.
 
@@ -136,22 +109,21 @@ EOF
   chmod +x /etc/initramfs-tools/hooks/add-rfc3442-dhclient-hook
 }
 
-
-# Install hook
+# Hook installieren
 add_rfc3442_hook
 
-# Copy SSH keys for dropbear
-mkdir -p /etc/dropbear/initramfs
-cp -a /root/.ssh/authorized_keys /etc/dropbear/initramfs/authorized_keys
+# Kopiere den SSH Key für Dropbear
+mkdir /etc/dropbear-initramfs/
+cp /root/.ssh/authorized_keys /etc/dropbear-initramfs/
 
-# Update system
+# System updaten
 apt-get update >/dev/null
 apt-get -y install cryptsetup-initramfs dropbear-initramfs
 ```
 
 Important note: make the post-install script executable:
 
-```bash
+```
 chmod +x /tmp/post-install.sh
 ```
 
@@ -164,8 +136,7 @@ Prüfen Sie vor dem Start der Installation nochmals den Inhalt der folgenden Dat
 * `/tmp/post-install.sh` - ist ausführbar und enthält das Post-Installations-Skript
 
 Jetzt können Sie die Installation mit dem folgenden Befehl starten:
-
-```bash
+```
 installimage -a -c /tmp/setup.conf -x /tmp/post-install.sh
 ```
 
@@ -173,12 +144,14 @@ Warten Sie, bis die Installation abgeschlossen ist, und prüfen Sie die `debug.t
 
 ## Schritt 5 - Installiertes System booten
 
-Nachdem die Installation abgeschlossen ist und alle Fehler behoben wurden, können Sie `reboot` ausführen, um den Server neu zu starten und das neu installierte System zu booten. Sie können den Boot-Vorgang beobachten, wenn Sie eine KVM angeschlossen haben oder über die [VNC-Konsole](https://docs.hetzner.com/de/cloud/servers/getting-started/vnc-console/) in der [Cloud Console](https://console.hetzner.cloud/).
+Nachdem die Installation abgeschlossen ist und alle Fehler behoben wurden, können Sie `reboot` ausführen, um den Server neu zu starten und das neu installierte System zu booten. Sie können den Boot-Vorgang beobachten, wenn Sie eine KVM angeschlossen haben oder über die Remote-Konsole einer jeweiligen Cloud-Instanz.
 
 Nach einiger Zeit sollte der Server auf einen Ping reagieren. Melden Sie sich nun per SSH an dropbear an und führen Sie `cryptroot-unlock` aus, um die verschlüsselte(n) Partition(en) zu entsperren.
 
-```bash
-$ ssh root@<your_host>
+Achtung: Im Falle von RSA, müssen wir explizit angeben, dass dieser Schlüssel akzeptiert wird.
+Sollten sie einen ED25565 oder ECDSA Schlüssel verwenden, wird der Parameter `-o` mit dem Wert nicht benötigt.
+```
+$ ssh -o "PubkeyAcceptedKeyTypes +ssh-rsa" root@<your-host> -i .ssh/id_rsa
 
 BusyBox v1.30.1 (Ubuntu 1:1.30.1-4ubuntu6.3) built-in shell (ash)
 Enter 'help' for a list of built-in commands.
@@ -190,5 +163,7 @@ Please unlock disk luks-80e097ad-c0ab-47ce-9302-02dd316dc45c:
 Wenn das Passwort korrekt ist, wird der Bootvorgang fortgesetzt und Sie werden automatisch von der temporären SSH-Sitzung getrennt.
 
 Nach ein paar Sekunden können Sie sich an Ihrem neuen System anmelden.
+
+**Hinweis: diese Anleitung ist explizit nur für Ubuntu 20.04 geschrieben. Es könnte sein, dass diese nicht auf anderen Distributionen funktioniert.**
 
 ##### License: MIT

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
@@ -114,9 +114,11 @@ remove_unwanted_netplan_config() {
   cat << EOF > /etc/initramfs-tools/scripts/init-bottom/remove_unwanted_netplan_config
 #!/bin/sh
 
-if=$(ls /run/netplan/ | cut -d'.' -f1)
+interface=$(ls /run/netplan/ | cut -d'.' -f1)
 
-rm -f /run/netplan/"${if}".yaml
+if [ ${interface:+x} ]; then
+  rm -f /run/netplan/"${interface}".yaml
+fi
 EOF
 
   chmod +x /etc/initramfs-tools/scripts/init-bottom/remove_unwanted_netplan_config

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
@@ -53,7 +53,7 @@ Create a file `/tmp/setup.conf` with the following content or copy it to the ser
 
 Note: Replace `secret` with a secure password and adjust drive names and partitioning as needed.
 
-```
+```bash
 CRYPTPASSWORD secret
 DRIVE1 /dev/sda
 BOOTLOADER grub
@@ -129,7 +129,7 @@ EOF
 # Install rfc3442 hook
 add_rfc3442_hook
 
-# Adding a initramfs-tools script to remove /run/netplan/{interface}.yaml,
+# Adding an initramfs-tools script to remove /run/netplan/{interface}.yaml,
 # because it is creating unwanted routes
 remove_unwanted_netplan_config
 
@@ -172,6 +172,7 @@ After some time the server should respond to ping. Now login via SSH into dropbe
 
 Attention: In case of RSA, we must explicitly specify that this key is accepted.
 If you use an ED25519 or ECDSA key, the parameter `-o` with the value is not needed and you need to adjust the path to your private key.
+
 ```
 $ ssh -o "PubkeyAcceptedKeyTypes +ssh-rsa" root@<your-host> -i .ssh/id_rsa
 

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
@@ -115,10 +115,10 @@ remove_unwanted_netplan_config() {
 #!/bin/sh
 
 if [ -d "/run/netplan" ]; then
-  interface=$(ls /run/netplan/ | cut -d'.' -f1)
+  interface=\$(ls /run/netplan/ | cut -d'.' -f1)
 
-  if [ ${interface:+x} ]; then
-    rm -f /run/netplan/"${interface}".yaml
+  if [ \${interface:+x} ]; then
+    rm -f /run/netplan/"\${interface}".yaml
   fi
 fi
 EOF

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
@@ -114,16 +114,17 @@ remove_unwanted_netplan_config() {
   cat << EOF > /etc/initramfs-tools/scripts/init-bottom/remove_unwanted_netplan_config
 #!/bin/sh
 
-interface=$(ls /run/netplan/ | cut -d'.' -f1)
+if [ -d "/run/netplan" ]; then
+  interface=$(ls /run/netplan/ | cut -d'.' -f1)
 
-if [ ${interface:+x} ]; then
-  rm -f /run/netplan/"${interface}".yaml
+  if [ ${interface:+x} ]; then
+    rm -f /run/netplan/"${interface}".yaml
+  fi
 fi
 EOF
 
   chmod +x /etc/initramfs-tools/scripts/init-bottom/remove_unwanted_netplan_config
 }
-
 
 # Install rfc3442 hook
 add_rfc3442_hook

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
@@ -31,17 +31,17 @@ This tutorial shows how to use `installimage` to install an encrypted Ubuntu 20.
 
 ## Step 1 - Create or copy SSH public key
 
-In order to remotely unlock the encrypted system, an SSH key is required. This key will also be used to later login to the booted system. The dropbear SSH daemon included in Ubuntu 20.04 only supports RSA and ECDSA keys. If you do not have such a key, you need to generate one.
+In order to remotely unlock the encrypted system SSH key is required. This key will also be used to later login to the booted system. The dropbear SSH daemon included in Ubuntu 20.04 only supports RSA and ECDSA keys. If you do not have such a key, you need to generate one.
+**We recommend the use of ED25565 or ECDSA keys**.
 
-For example, to generate a 4096 bit RSA SSH key run:
-
-```bash
-ssh-keygen -t rsa -b 4096
+For example to generate a 3072 bit RSA SSH key run:
+```
+ssh-keygen -t rsa -b 3072
 ```
 
 Copy the public key to the rescue system, e.g. using `scp`:
 
-```bash
+```
 scp ~/.ssh/id_rsa.pub root@<your-host>:/tmp/authorized_keys
 ```
 
@@ -53,42 +53,16 @@ Create a file `/tmp/setup.conf` with the following content or copy it to the ser
 
 Note: Replace `secret` with a secure password and adjust drive names and partitioning as needed.
 
-- On servers with `x86` architecture:
-  
-  ```shell
-  CRYPTPASSWORD secret
-  DRIVE1 /dev/sda
-  BOOTLOADER grub
-  HOSTNAME host.example.com
-  PART /boot ext4 1G
-  PART /     ext4 all crypt
-  IMAGE /root/images/Ubuntu-2004-focal-amd64-base.tar.gz
-  SSHKEYS_URL /tmp/authorized_keys
-  ```
-
-<blockquote>
-
-To install another image, replace `Ubuntu-2004-focal-amd64-base.tar.gz` with the one you'd prefer. For example:
-
-<details>
-
-<summary>Ubuntu 22.04</summary>
-
-<ul><b>x86</b>: <kbd>Ubuntu-2204-jammy-amd64-base.tar.gz</kbd></ul>
-  
-</details>
-
-<details>
-
-<summary>Debian 11</summary>
-
-<ul><b>x86</b>: <kbd>Debian-1106-bullseye-amd64-base.tar.gz</kbd></ul>
-
-------
-
-</details>
-
-</blockquote>
+```
+CRYPTPASSWORD secret
+DRIVE1 /dev/sda
+BOOTLOADER grub
+HOSTNAME host.example.com
+PART /boot ext4 1G
+PART /     ext4 all crypt
+IMAGE /root/images/Ubuntu-2004-focal-64-minimal.tar.gz
+SSHKEYS_URL /tmp/authorized_keys
+```
 
 This configuration will install Ubuntu on a single drive (`/dev/sda`) with a separate unencrypted `/boot` required for remote unlocking.
 
@@ -96,7 +70,7 @@ This configuration will install Ubuntu on a single drive (`/dev/sda`) with a sep
 
 In order to remotely unlock the encrypted partition, we need to install and add the dropbear SSH server to the initramfs which is stored on the unencrypted `/boot` partition. This will also trigger the inclusion of `dhclient` to configure networking, but without any extras. To enable support for Hetzner Cloud, we need to add a hook which includes support for RFC3442 routes.
 
-In order to run these additional steps, we need a post-install script for `installimage`
+In order to run these additional steps we need a post-install script for `installimage`
 
 Create a file `/tmp/post-install.sh` in the Rescue system with the following content:
 
@@ -141,8 +115,8 @@ EOF
 add_rfc3442_hook
 
 # Copy SSH keys for dropbear
-mkdir -p /etc/dropbear/initramfs
-cp -a /root/.ssh/authorized_keys /etc/dropbear/initramfs/authorized_keys
+mkdir /etc/dropbear-initramfs/
+cp /root/.ssh/authorized_keys /etc/dropbear-initramfs/
 
 # Update system
 apt-get update >/dev/null
@@ -151,7 +125,7 @@ apt-get -y install cryptsetup-initramfs dropbear-initramfs
 
 Important note: make the post-install script executable:
 
-```bash
+```
 chmod +x /tmp/post-install.sh
 ```
 
@@ -159,13 +133,13 @@ chmod +x /tmp/post-install.sh
 
 Before starting the installation check again the content of the following files:
 
-* `/tmp/authorized_keys` - your public SSH key (RSA or ECDSA)
+* `/tmp/authorized_keys` - your public SSH key (RSA, ECDSA or ED25565)
 * `/tmp/setup.conf` - installimage config
 * `/tmp/post-install.sh` - is executable and contains the post-install script
 
 Now you are ready to start the installation with the following command:
 
-```bash
+```
 installimage -a -c /tmp/setup.conf -x /tmp/post-install.sh
 ```
 
@@ -173,12 +147,14 @@ Wait until the installation completes and check the `debug.txt` for any errors.
 
 ## Step 5 - Boot installed system
 
-After the installation has finished and any errors are resolved, you can run `reboot` to restart the server and boot the newly installed system. You can watch the boot process if you have a KVM attached or via the [VNC console](https://docs.hetzner.com/cloud/servers/getting-started/vnc-console) in the [Cloud Console](https://console.hetzner.cloud/).
+After the installation has finished and any errors are resolved, you can run `reboot` to restart the server and boot the newly installed system. You can watch the boot process if you have a KVM attached or via remote console on a Cloud instance.
 
-After some time, the server should respond to ping. Now login via SSH into dropbear and run `cryptroot-unlock` to unlock the encrypted partition(s).
+After some time the server should respond to ping. Now login via SSH into dropbear and run `cryptroot-unlock` to unlock the encrypted partition(s).
 
-```bash
-$ ssh root@<your_host>
+Attention: In case of RSA, we must explicitly specify that this key is accepted.
+If you use an ED25565 or ECDSA key, the parameter `-o` with the value is not needed.
+```
+$ ssh -o "PubkeyAcceptedKeyTypes +ssh-rsa" root@<your-host> -i .ssh/id_rsa
 
 BusyBox v1.30.1 (Ubuntu 1:1.30.1-4ubuntu6.3) built-in shell (ash)
 Enter 'help' for a list of built-in commands.
@@ -190,5 +166,7 @@ Please unlock disk luks-80e097ad-c0ab-47ce-9302-02dd316dc45c:
 If the password is correct the boot will continue and you will automatically be disconnected from the temporary SSH session.
 
 After a few seconds you can login to your new system.
+
+**Note: this guide is explicitly written for Ubuntu 20.04 only. It might not work on other distributions.**
 
 ##### License: MIT

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
@@ -35,13 +35,13 @@ In order to remotely unlock the encrypted system SSH key is required. This key w
 **We recommend the use of ED25519 or ECDSA keys**.
 
 For example to generate a 3072 bit RSA SSH key run:
-```
+```bash
 ssh-keygen -t rsa -b 3072
 ```
 
 Copy the public key to the rescue system, e.g. using `scp`:
 
-```
+```bash
 scp ~/.ssh/id_rsa.pub root@<your-host>:/tmp/authorized_keys
 ```
 
@@ -125,7 +125,7 @@ apt-get -y install cryptsetup-initramfs dropbear-initramfs
 
 Important note: make the post-install script executable:
 
-```
+```bash
 chmod +x /tmp/post-install.sh
 ```
 
@@ -139,7 +139,7 @@ Before starting the installation check again the content of the following files:
 
 Now you are ready to start the installation with the following command:
 
-```
+```bash
 installimage -a -c /tmp/setup.conf -x /tmp/post-install.sh
 ```
 
@@ -152,7 +152,7 @@ After the installation has finished and any errors are resolved, you can run `re
 After some time the server should respond to ping. Now login via SSH into dropbear and run `cryptroot-unlock` to unlock the encrypted partition(s).
 
 Attention: In case of RSA, we must explicitly specify that this key is accepted.
-If you use an ED25519 or ECDSA key, the parameter `-o` with the value is not needed.
+If you use an ED25519 or ECDSA key, the parameter `-o` with the value is not needed and you need to adjust the path to your private key.
 ```
 $ ssh -o "PubkeyAcceptedKeyTypes +ssh-rsa" root@<your-host> -i .ssh/id_rsa
 

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
@@ -112,7 +112,9 @@ EOF
 
 
 # Install hook
-add_rfc3442_hook
+if [[ $(grep -q ^flags.*\ hypervisor\  /proc/cpuinfo && echo "1") == "1" ]]; then
+        add_rfc3442_hook
+fi
 
 # Copy SSH keys for dropbear
 mkdir /etc/dropbear-initramfs/

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
@@ -110,11 +110,25 @@ EOF
   chmod +x /etc/initramfs-tools/hooks/add-rfc3442-dhclient-hook
 }
 
+remove_unwanted_netplan_config() {
+  cat << EOF > /etc/initramfs-tools/scripts/init-bottom/remove_unwanted_netplan_config
+#!/bin/sh
 
-# Install hook
-if [[ $(grep -q ^flags.*\ hypervisor\  /proc/cpuinfo && echo "1") == "1" ]]; then
-        add_rfc3442_hook
-fi
+if=$(ls /run/netplan/ | cut -d'.' -f1)
+
+rm -f /run/netplan/"${if}".yaml
+EOF
+
+  chmod +x /etc/initramfs-tools/scripts/init-bottom/remove_unwanted_netplan_config
+}
+
+
+# Install rfc3442 hook
+add_rfc3442_hook
+
+# Adding a initramfs-tools script to remove /run/netplan/{interface}.yaml,
+# because it is creating unwanted routes
+remove_unwanted_netplan_config
 
 # Copy SSH keys for dropbear
 mkdir /etc/dropbear-initramfs/

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
@@ -26,13 +26,13 @@ This tutorial shows how to use `installimage` to install an encrypted Ubuntu 20.
 
 * Hetzner account
 * Server booted into the Rescue System
-* RSA or ECDSA SSH public key
+* RSA, ECDSA or ED25519 SSH public key
 * No private networks attached on Hetzner Cloud
 
 ## Step 1 - Create or copy SSH public key
 
 In order to remotely unlock the encrypted system SSH key is required. This key will also be used to later login to the booted system. The dropbear SSH daemon included in Ubuntu 20.04 only supports RSA and ECDSA keys. If you do not have such a key, you need to generate one.
-**We recommend the use of ED25565 or ECDSA keys**.
+**We recommend the use of ED25519 or ECDSA keys**.
 
 For example to generate a 3072 bit RSA SSH key run:
 ```
@@ -133,7 +133,7 @@ chmod +x /tmp/post-install.sh
 
 Before starting the installation check again the content of the following files:
 
-* `/tmp/authorized_keys` - your public SSH key (RSA, ECDSA or ED25565)
+* `/tmp/authorized_keys` - your public SSH key (RSA, ECDSA or ED25519)
 * `/tmp/setup.conf` - installimage config
 * `/tmp/post-install.sh` - is executable and contains the post-install script
 
@@ -152,7 +152,7 @@ After the installation has finished and any errors are resolved, you can run `re
 After some time the server should respond to ping. Now login via SSH into dropbear and run `cryptroot-unlock` to unlock the encrypted partition(s).
 
 Attention: In case of RSA, we must explicitly specify that this key is accepted.
-If you use an ED25565 or ECDSA key, the parameter `-o` with the value is not needed.
+If you use an ED25519 or ECDSA key, the parameter `-o` with the value is not needed.
 ```
 $ ssh -o "PubkeyAcceptedKeyTypes +ssh-rsa" root@<your-host> -i .ssh/id_rsa
 


### PR DESCRIPTION
- The tutorial unfortunately did not / no longer work, and therefore had to be adapted, because wrong paths were configured for dropbear, so that it did not find the authorized keys.

- Dropbear calls a function in initramfs, which places a netplan config in /run/netplan, which in turn creates routes which are not necessary or even make hosts in the network unreachable. 

- Also it was not possible to log in with a normal RSA SSH key, and therefore it is necessary to add the parameter `-o "PubkeyAcceptedKeyTypes +ssh-rsa"`.

These problems are fixed with this merge request

Also smaller things were adapted. 