### PR TITLE
Point to storage box documentation ssh key in bogmatic tutorial

### DIFF
--- a/tutorials/install-and-configure-borgbackup/01.de.md
+++ b/tutorials/install-and-configure-borgbackup/01.de.md
@@ -45,9 +45,17 @@ Falls SSH auf der Storage Box nicht verfügbar ist, müssen sie beispielsweise [
 
 Für Borg können Sie zum einen Passwort-Authentifizierung verwenden, empfohlen ist aber die Authentifizierung über den Public Key. Dies ist besonders auch dann empfohlen, wenn Sie die Backups mit Cronjobs automatisieren möchten.
 
-Für die Verwendung von Borg wird ihr SSH Key nicht(!) im RFC4716 Format wie bei SFTP/SCP benötigt. Sie müssen Ihren normalen Public Key hinterlegen. Sollten Sie sowohl Borg, also auch SFTP/SCP verwenden, müssen beide Keys (RFC4716 Format und normal) hinterlegt werden.
+Für die Verwendung von Borg wird ihr SSH Key nicht(!) im RFC4716 Format wie bei SFTP/SCP benötigt. Sie müssen Ihren normalen Public Key hinterlegen. Sollten Sie sowohl Borg, also auch SFTP/SCP verwenden, müssen beide Keys (RFC4716 Format und normal) hinterlegt werden. 
 
-Befolgen Sie die Anweisungen [zum Installieren eines SSH Keys](https://docs.hetzner.com/de/robot/storage-box/backup-space-ssh-keys) aus der Storage Box Dokumentation. Relevant ist hierbei die Installation über Port 23.
+Erstellen Sie in Ihrer Storage Box den Ordner `.ssh` und legen darin die Datei `authorized_keys` ab. Diese muss Ihren Public Key enthalten:
+
+```bash
+ssh-rsa AAAAB3NzaC1yc2EAAAA.......rdj7eitNUjlIV8ovvAH/6SAsKD6
+```
+
+Setzen Sie die Berechtigungen für den `.ssh`-Ordner auf `0700` und für die `authorized_keys` auf `0600`.
+
+Genauere Informationen [zum Einrichten eines SSH-Keys](https://docs.hetzner.com/de/robot/storage-box/backup-space-ssh-keys) finden Sie in der offiziellen Storage Box Dokumentation. Relevant sind hierbei die Anweisungen zu Port 23.
 
 Ihr Homeverzeichnis auf Ihrer Storage Box / Backup Space darf für Group und Others keine Schreibrechte haben, da sonst eine Authentifizierung über Keyfile nicht möglich ist. Standardmäßig ist dies so gesetzt, kann von Ihnen jedoch verändert werden.
 

--- a/tutorials/install-and-configure-borgbackup/01.de.md
+++ b/tutorials/install-and-configure-borgbackup/01.de.md
@@ -47,7 +47,7 @@ Für Borg können Sie zum einen Passwort-Authentifizierung verwenden, empfohlen 
 
 Für die Verwendung von Borg wird ihr SSH Key nicht(!) im RFC4716 Format wie bei SFTP/SCP benötigt. Sie müssen Ihren normalen Public Key hinterlegen. Sollten Sie sowohl Borg, also auch SFTP/SCP verwenden, müssen beide Keys (RFC4716 Format und normal) hinterlegt werden.
 
-Befolgen Sie die Anweisungen [zum installieren eines SSH Keys](https://docs.hetzner.com/de/robot/storage-box/backup-space-ssh-keys) aus der Storage Box Dokumentation. Relevant ist hierbei die Installation über Port 23.
+Befolgen Sie die Anweisungen [zum Installieren eines SSH Keys](https://docs.hetzner.com/de/robot/storage-box/backup-space-ssh-keys) aus der Storage Box Dokumentation. Relevant ist hierbei die Installation über Port 23.
 
 Ihr Homeverzeichnis auf Ihrer Storage Box / Backup Space darf für Group und Others keine Schreibrechte haben, da sonst eine Authentifizierung über Keyfile nicht möglich ist. Standardmäßig ist dies so gesetzt, kann von Ihnen jedoch verändert werden.
 

--- a/tutorials/install-and-configure-borgbackup/01.de.md
+++ b/tutorials/install-and-configure-borgbackup/01.de.md
@@ -47,7 +47,7 @@ Für Borg können Sie zum einen Passwort-Authentifizierung verwenden, empfohlen 
 
 Für die Verwendung von Borg wird ihr SSH Key nicht(!) im RFC4716 Format wie bei SFTP/SCP benötigt. Sie müssen Ihren normalen Public Key hinterlegen. Sollten Sie sowohl Borg, also auch SFTP/SCP verwenden, müssen beide Keys (RFC4716 Format und normal) hinterlegt werden.
 
-Befolgen Sie den Anweisungen [zum Installieren eines SSH Keys](https://docs.hetzner.com/de/robot/storage-box/backup-space-ssh-keys) aus der Storage Box Dokumentation. Relevant ist hierbei die Installation über Port 23.
+Befolgen Sie die Anweisungen [zum installieren eines SSH Keys](https://docs.hetzner.com/de/robot/storage-box/backup-space-ssh-keys) aus der Storage Box Dokumentation. Relevant ist hierbei die Installation über Port 23.
 
 Ihr Homeverzeichnis auf Ihrer Storage Box / Backup Space darf für Group und Others keine Schreibrechte haben, da sonst eine Authentifizierung über Keyfile nicht möglich ist. Standardmäßig ist dies so gesetzt, kann von Ihnen jedoch verändert werden.
 

--- a/tutorials/install-and-configure-borgbackup/01.de.md
+++ b/tutorials/install-and-configure-borgbackup/01.de.md
@@ -47,13 +47,7 @@ Für Borg können Sie zum einen Passwort-Authentifizierung verwenden, empfohlen 
 
 Für die Verwendung von Borg wird ihr SSH Key nicht(!) im RFC4716 Format wie bei SFTP/SCP benötigt. Sie müssen Ihren normalen Public Key hinterlegen. Sollten Sie sowohl Borg, also auch SFTP/SCP verwenden, müssen beide Keys (RFC4716 Format und normal) hinterlegt werden.
 
-Erstellen Sie in Ihrer Storage Box den Ordner `.ssh`und legen darin die Datei `authorized_keys` ab. Diese muss Ihren Public Key enthalten:
-
-```bash
-ssh-rsa AAAAB3NzaC1yc2EAAAA.......rdj7eitNUjlIV8ovvAH/6SAsKD6
-```
-
-Setzen Sie die Berechtigungen für den `.ssh` Ordner auf `0700` und für die `authorized_keys` auf `0600`.
+Befolgen Sie den Anweisungen [zum Installieren eines SSH Keys](https://docs.hetzner.com/de/robot/storage-box/backup-space-ssh-keys) aus der Storage Box Dokumentation. Relevant ist hierbei die Installation über Port 23.
 
 Ihr Homeverzeichnis auf Ihrer Storage Box / Backup Space darf für Group und Others keine Schreibrechte haben, da sonst eine Authentifizierung über Keyfile nicht möglich ist. Standardmäßig ist dies so gesetzt, kann von Ihnen jedoch verändert werden.
 

--- a/tutorials/install-and-configure-borgbackup/01.en.md
+++ b/tutorials/install-and-configure-borgbackup/01.en.md
@@ -45,7 +45,7 @@ If SSH is not available on the Storage Box, you must use [SFTP](https://docs.het
 
 For Borg, you can use password authentication, but authentication via the public key is recommended. This is especially recommended if you want to automate the backups with cronjobs.
 
-To use Borg your SSH key is not (!) required in the RFC4716 format, like with SFTP/SCP. You need to store your normal public key. If you use both Borg and SFTP/SCP, then both keys (RFC4716 format and normal) need to be stored.
+To use Borg, your SSH key is not (!) required in the RFC4716 format like with SFTP/SCP. You need to store your normal public key. If you use both Borg and SFTP/SCP, then both keys (RFC4716 format and normal) need to be stored.
 
 Create the folder `.ssh` in your Storage Box and store the file `authorized_keys` in it. This must contain your public key:
 
@@ -55,7 +55,9 @@ ssh-rsa AAAAB3NzaC1yc2EAAAA.......rdj7eitNUjlIV8ovvAH/6SAsKD6
 
 Set the permissions for the `.ssh` folder to `0700` and for the `authorized_keys` to `0600`.
 
-Your home directory on your Storage Box / backup space is not allowed to have write permissions for Group and Others, otherwise authenticating via keyfile is not possible. By default this is set, but it can be changed.
+For more explanation, check out the official Storage Box documentation on [setting up an SSH key](https://docs.hetzner.com/robot/storage-box/backup-space-ssh-keys). You will need to follow the instructions on port 23.
+
+Your home directory on your Storage Box / backup space is not allowed to have write permissions for Group and Others, otherwise authenticating via keyfile is not possible. This is set by default, but it can be changed.
 
 Now you have to create the directory for the backup repository in the Storage Box. For example, create a folder `backups`, and below that, a folder `server1`. The folder `server1` will then be initialized as a Borg repository in the next step. Under `backups` you could then create further directories for other servers you want to back up.
 


### PR DESCRIPTION
The old option was rather short and did not successfully explain what port to use. We should just point to the existing documentation that shows all options.