### PR TITLE
Update "How to install Ubuntu 20.04 with full disk encryption"

### DIFF
--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
@@ -65,6 +65,30 @@ SSHKEYS_URL /tmp/authorized_keys
 
 Diese Konfiguration installiert Ubuntu auf einem einzelnen Laufwerk (`/dev/sda`) mit einer separaten unverschlüsselten `/boot` Partition, das für die Entschlüsselung benötigt wird.
 
+<blockquote>
+
+<details>
+
+<summary>Beispiel für zwei Laufwerke (RAID1)</summary>
+
+```bash
+CRYPTPASSWORD secret
+DRIVE1 /dev/sda
+DRIVE2 /dev/sdb
+SWRAID 1
+SWRAIDLEVEL 1
+BOOTLOADER grub
+HOSTNAME host.example.com
+PART /boot ext4 1G
+PART /     ext4 all crypt
+IMAGE /root/images/Ubuntu-2004-focal-64-minimal.tar.gz
+SSHKEYS_URL /tmp/authorized_keys
+```
+
+</details>
+
+</blockquote>
+
 ## Schritt 3 - Post-Installations-Skript erstellen oder kopieren
 
 Um die verschlüsselte Partition über SSH zu entsperren, müssen wir den Dropbear-SSH-Server installieren und zum initramfs hinzufügen, das auf der unverschlüsselten `/boot`-Partition gespeichert ist. Dadurch wird auch die Einbindung von `dhclient` zur Konfiguration des Netzwerks ausgelöst, allerdings ohne jegliche Extras. Um die Unterstützung für die Hetzner Cloud zu aktivieren, müssen wir einen Hook hinzufügen, der die Unterstützung für RFC3442-Routen beinhaltet.

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
@@ -66,6 +66,30 @@ SSHKEYS_URL /tmp/authorized_keys
 
 This configuration will install Ubuntu on a single drive (`/dev/sda`) with a separate unencrypted `/boot` required for remote unlocking.
 
+<blockquote>
+
+<details>
+
+<summary>Example for two drives (RAID1)</summary>
+
+```bash
+CRYPTPASSWORD secret
+DRIVE1 /dev/sda
+DRIVE2 /dev/sdb
+SWRAID 1
+SWRAIDLEVEL 1
+BOOTLOADER grub
+HOSTNAME host.example.com
+PART /boot ext4 1G
+PART /     ext4 all crypt
+IMAGE /root/images/Ubuntu-2004-focal-64-minimal.tar.gz
+SSHKEYS_URL /tmp/authorized_keys
+```
+
+</details>
+
+</blockquote>
+
 ## Step 3 - Create or copy post-install script
 
 In order to remotely unlock the encrypted partition, we need to install and add the dropbear SSH server to the initramfs which is stored on the unencrypted `/boot` partition. This will also trigger the inclusion of `dhclient` to configure networking, but without any extras. To enable support for Hetzner Cloud, we need to add a hook which includes support for RFC3442 routes.


### PR DESCRIPTION
Add option for two drives

Fix #668 