### PR TITLE
new tutorial: Installing freebsd with qemu via linux rescue (not needing UEFI)

### DIFF
--- a/tutorials/freebsd-with-qemu-via-linux-rescue/01.en.md
+++ b/tutorials/freebsd-with-qemu-via-linux-rescue/01.en.md
@@ -27,20 +27,27 @@ For older servers that only have minimal UEFI support and require legacy BIOS bo
 **Prerequisites:**
 
 * Hetzner dedicated server booted in Linux [rescue](https://docs.hetzner.com/cloud/servers/getting-started/rescue-system) mode with working SSH access
-* Network configuration parameters:
- * IPv4 assigned address and network length
- * IPv4 gateway address
+* IPv6 Network configuration parameters:
+ * IPv6 assigned address
+
+**Optional:**
+
+* IPv4 Network configuration parameters:
+ * IP Address and Network length
+ * Default Gateway
 
 *Note: dedicated servers without an IPv4 address must be configured correctly since DHCP and autodetect does not work*
 
 **Example terminology**
 
-
-* IP: (none)
+* IPv4: 192.168.0.2/27
+* IPv4 Gateway: 192.168.0.1
 * IPv6: 2a01:4f8:0:0::2/64
 * NIC: Intel(R) PRO/1000 Network Driver
-* Drive 1: `/dev/nvme0n1` or `/dev/sda` when using SATA disks
-* Drive 2: `/dev/nvme1n1` or `/dev/sdb` when using SATA disks
+* Drive 1: `/dev/nvme0n1`
+* Drive 2: `/dev/nvme1n1`
+ 
+Use `/dev/sda` and `/dev/sdb` on systems with SATA drives.
 
 We will install FreeBSD 14.0-RELEASE in our example.
 
@@ -129,9 +136,9 @@ Install FreeBSD with the [zfsinstall](https://github.com/mmatuska/mfsbsd/blob/ma
 zfsinstall -d /dev/da0 -d /dev/da1 -r mirror -p zroot -s 16G -u .
 ```
 
-This will install FreeBSD on a ZFS pool `zroot` using RAID-1 (mirror) on both disks with 16GiByte swap on each drive.
+This will install FreeBSD on a ZFS pool `zroot` using RAID-1 (`mirror`) on both disks with 16GiByte swap space on each disk.
 
-The installed FreeBSD root filesystem will be mounted on /mnt. Since we are running the current version of FreeBSD already we can now just chroot:
+The installed FreeBSD root filesystem will be mounted on /mnt. Since we are running the current version of FreeBSD inside the VM already we can now just use chroot to configure the new installation:
 
 ```bash
 mount -t devfs devfs /mnt/dev
@@ -139,6 +146,8 @@ chroot /mnt
 ```
 
 ## Step 7 - Configure FreeBSD
+
+Once we used chroot to get a shell running inside the installed FreeBSD environment, we can complete the configuration.
 
 Set a root password
 
@@ -153,55 +162,7 @@ echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
 echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config
 ```
 
-*Note: you may want to disable this again later after you created user accounts*
-
-### Only if you have an IPv4 address: Create /etc/rc.d/autodhcp
-
-If you don't know the name of the network interface yet, you need to configure all interfaces to `DHCP`. If you know the network interface name (e.g. `igb0`), you can skip this step and "Step 6.3" and directly use the `rc.conf` code from "Step 7".
-
-Create the file `/etc/rc.d/autodhcp` with the following content:
-
-```bash
-cat << EOF > /etc/rc.d/autodhcp
-#!/bin/sh
-
-# PROVIDE: autodhcp
-# BEFORE: NETWORKING netif routing hostname
-# REQUIRE: mountcritlocal mdinit
-# KEYWORD: FreeBSD
-
-. /etc/rc.subr
-
-name=autodhcp
-rcvar=autodhcp_enable
-
-load_rc_config $name
-
-: \${autodhcp_enable:="NO"}
-
-start_cmd="autodhcp_start"
-stop_cmd=":"
-
-autodhcp_start()
-{
-        _dif=\$(/sbin/ifconfig -l | /usr/bin/sed -E 's/lo[0-9]+//g')
-        for i in \$_dif; do
-                echo "ifconfig_\$i=\"DHCP\"" >> /etc/rc.conf.d/network
-        done
-}
-
-load_rc_config \$name
-run_rc_command "\$1"
-EOF
-```
-
-Now make the file executable:
-
-```bash
-chmod +x /etc/rc.d/autodhcp
-```
-
-#### Edit /etc/rc.conf
+*Note: you may want to disable this later after you created user accounts*
 
 We need to set the hostname, and enable sshd & our newly created autodhcpd script.
 
@@ -212,23 +173,26 @@ cat << EOF > /etc/rc.conf
 zfs_enable="YES"
 hostname="myhost.mydomain"
 sshd_enable="YES"
-autodhcp_enable="YES"
 EOF
 ```
 
-### If you do not have an IPv4 address you must configure the network interface manually:
+### configure the network settings
 
 If your server uses a RealTec based network card, the name of your interface is most likely `re0`.
 If your server uses an Intel based network card, the name is either `em0` or `igb0`.
 If in doubt use Google to find out what your NIC would be called in FreeBSD.
 
-In our example we will use `em0` as the name of our network card.
+In our example we need to use `em0` as the name of our network card.
 
 Add the following lines to the `/etc/rc.conf` file:
 
 ```bash
 cat <<EOF >>/etc/rc.conf
-ifconfig_em0="inet6 2a01:4f9:0:0::2"
+ifconfig_em0="192.168.0.2/27"
+static_routes="gateway default"
+route_gateway="-host 192.168.0.1 -interface em0"
+route_default="default 192.168.0.1"
+ifconfig_em0_ipv6="inet6 2a01:4f8:0:0::2/64"
 ipv6_defaultrouter="fe80::1%em0"
 EOF
 ```
@@ -245,15 +209,15 @@ umount /mnt/dev
 umount /mnt/var
 umount /mnt/tmp
 umount /mnt
-exit
 ```
 
-When everything is setup, you can reboot the server into the FreeBSD distribution:
+You can either shut down the qemu virtual machine or terminate the qemu process.
+
+With everthing set up, you can reboot the server into the FreeBSD distribution:
 
 ```bash
 reboot
 ```
-
 
 ## Conclusion
 

--- a/tutorials/freebsd-with-qemu-via-linux-rescue/01.en.md
+++ b/tutorials/freebsd-with-qemu-via-linux-rescue/01.en.md
@@ -4,16 +4,17 @@ path: "/tutorials/freebsd-with-qemu-via-linux-rescue"
 slug: "freebsd-with-qemu-via-linux-rescue"
 date: "2024-01-20"
 title: "Installing FreeBSD on older dedicated Servers via the Linux rescue system"
-short_description: "This tutorial explains how to install FreeBSD on a Hetzner dedicated server with any (legacy or UEFI) boot mode."
+short_description: "This tutorial explains how to install FreeBSD on a Hetzner dedicated server with legacy boot loaders."
 tags: ["FreeBSD", "Server Setup"]
-author: "Jor"
+author: "Juergen Meier"
 author_link: "https://github.com/Jor"
 author_description: "Jor"
 language: "en"
 available_languages: ["en"]
-header_img: "header-4"
+header_img: "header-x"
 cta: "dedicated"
 ---
+
 
 ## Introduction
 

--- a/tutorials/freebsd-with-qemu-via-linux-rescue/01.en.md
+++ b/tutorials/freebsd-with-qemu-via-linux-rescue/01.en.md
@@ -1,0 +1,345 @@
+---
+SPDX-License-Identifier: MIT
+path: "/tutorials/freebsd-with-qemu-via-linux-rescue"
+slug: "freebsd-with-qemu-via-linux-rescue"
+date: "2024-01-20"
+title: "Installing FreeBSD on older dedicated Servers via the Linux rescue system"
+short_description: "This tutorial explains how to install FreeBSD on a Hetzner dedicated server with any (legacy or UEFI) boot mode."
+tags: ["FreeBSD", "Server Setup"]
+author: "Jor"
+author_link: "https://github.com/Jor"
+author_description: "Jor"
+language: "en"
+available_languages: ["en"]
+header_img: "header-4"
+cta: "dedicated"
+---
+
+## Introduction
+
+Hetzner no longer offers a FreeBSD rescue system.
+For dedicated servers with full UEFI support there is a tutorial showing how to install FreeBSD with OpenZFS from the Linux rescue system.
+https://community.hetzner.com/tutorials/freebsd-openzfs-via-linux-rescue
+
+For older servers that only have minimal UEFI support and require legacy BIOS boot there is a different way to install FreeBSD.
+
+**Prerequisites:**
+
+* Hetzner dedicated server booted in Linux [rescue](https://docs.hetzner.com/cloud/servers/getting-started/rescue-system) mode with working SSH access
+* Network configuration parameters:
+ * IPv4 assigned address and network length
+ * IPv4 gateway address
+
+*Note: dedicated servers without an IPv4 address must be configured correctly since DHCP and autodetect does not work*
+
+**Example terminology**
+
+
+* IP: (none)
+* IPv6: 2a01:4f8:0:0::2/64
+* NIC: Intel(R) PRO/1000 Network Driver
+* Drive 1: `/dev/nvme0n1` or `/dev/sda` when using SATA disks
+* Drive 2: `/dev/nvme1n1` or `/dev/sdb` when using SATA disks
+
+We will install FreeBSD 14.0-RELEASE in our example.
+
+## Step 1 - Download the FreeBSD distribution archives
+
+Download `base.txz` and `kernel.txz` from a FreeBSD mirror:
+
+```bash
+curl -O http://ftp2.de.freebsd.org/pub/FreeBSD/releases/amd64/14.0-RELEASE/base.txz
+curl -O http://ftp2.de.freebsd.org/pub/FreeBSD/releases/amd64/14.0-RELEASE/kernel.txz
+```
+
+## Step 2 - Download the mfsBSD installation VM container
+
+We use [mfsBSD](https://mfsbsd.vx.sk/) virtual machine to install FreeBSD on the system drives.
+
+Download the ISO image:
+```bash
+curl -O https://mfsbsd.vx.sk/files/iso/14/amd64/mfsbsd-14.0-RELEASE-amd64.iso
+```
+
+## Step 3 - launch the mfsBSD virtual machine from the ISO image
+
+The server disks are passed through to the VM as SCSI devices using virtio.
+
+```bash
+qemu-system-x86_64 -net nic -net user,hostfwd=tcp::1022-:22 -m 2048M -enable-kvm \
+ -cpu host,+nx -M pc -smp 2 -vga std -k en-us \
+ -cdrom ./mfsbsd-14.0-RELEASE-amd64.iso \
+ -device virtio-scsi-pci,id=scsi0 \
+ -drive file=/dev/nvme0n1,if=none,format=raw,discard=unmap,aio=native,cache=none,id=n0 \
+ -device scsi-hd,drive=n0,bus=scsi0.0 \
+ -drive file=/dev/nvme1n1,if=none,format=raw,discard=unmap,aio=native,cache=none,id=n1 \
+ -device scsi-hd,drive=n1,bus=scsi0.0 \
+ -boot once=d -vnc 127.0.0.1:0,password -monitor stdio
+```
+
+The SSH service inside the VM is made available on port 1022 of the rescue system
+
+*Note*
+The disk devices of the servers will be attached as SCSI disks in the VM no matter what they are on the host.
+This means that inside the VM the disks are always mapped to `/dev/da0` and `/dev/da1`.
+
+### Optional set a VNC password to allow VNC access
+
+You need to forward port 5900 using ssh to connect to VNC!
+
+```
+(qemu) set_password vnc mfsroot
+(qemu) 
+```
+
+## Step 4 - copy the distribution files to the VM
+
+On a root shell of the rescue linux system issue the following command:
+
+```bash
+scp -o Port=1022 base.txz kernel.txz root@localhost:
+```
+The root password inside the virtual machine is `mfsroot`.
+
+## Step 5 - Login to the VM
+
+Use ssh to log into the VM from a shell on the rescue system
+
+```bash
+ssh -p 1022 root@localhost
+```
+
+The password is `mfsroot`
+
+Verify that the drives are visible:
+
+```bash
+dmesg | grep QEMU
+cd0: <QEMU QEMU DVD-ROM 2.5+> Removable CD-ROM SCSI device
+da0: <QEMU QEMU HARDDISK 2.5+> Fixed Direct Access SPC-3 SCSI device
+da1: <QEMU QEMU HARDDISK 2.5+> Fixed Direct Access SPC-3 SCSI device
+```
+
+## Step 6 - Install FreeBSD
+
+Install FreeBSD with the [zfsinstall](https://github.com/mmatuska/mfsbsd/blob/master/tools/zfsinstall) script
+
+```bash
+zfsinstall -d /dev/da0 -d /dev/da1 -r mirror -p zroot -s 16G -u .
+```
+
+This will install FreeBSD on a ZFS pool `zroot` using RAID-1 (mirror) on both disks with 16GiByte swap on each drive.
+
+The installed FreeBSD root filesystem will be mounted on /mnt. Since we are running the current version of FreeBSD already we can now just chroot:
+
+```bash
+mount -t devfs devfs /mnt/dev
+chroot /mnt
+```
+
+## Step 7 - Configure FreeBSD
+
+Set a root password
+
+```bash
+passwd
+```
+
+and enable root login with password:
+
+```bash
+echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config
+```
+
+*Note: you may want to disable this again later after you created user accounts*
+
+### Only if you have an IPv4 address: Create /etc/rc.d/autodhcp
+
+If you don't know the name of the network interface yet, you need to configure all interfaces to `DHCP`. If you know the network interface name (e.g. `igb0`), you can skip this step and "Step 6.3" and directly use the `rc.conf` code from "Step 7".
+
+Create the file `/etc/rc.d/autodhcp` with the following content:
+
+```bash
+cat << EOF > /etc/rc.d/autodhcp
+#!/bin/sh
+
+# PROVIDE: autodhcp
+# BEFORE: NETWORKING netif routing hostname
+# REQUIRE: mountcritlocal mdinit
+# KEYWORD: FreeBSD
+
+. /etc/rc.subr
+
+name=autodhcp
+rcvar=autodhcp_enable
+
+load_rc_config $name
+
+: \${autodhcp_enable:="NO"}
+
+start_cmd="autodhcp_start"
+stop_cmd=":"
+
+autodhcp_start()
+{
+        _dif=\$(/sbin/ifconfig -l | /usr/bin/sed -E 's/lo[0-9]+//g')
+        for i in \$_dif; do
+                echo "ifconfig_\$i=\"DHCP\"" >> /etc/rc.conf.d/network
+        done
+}
+
+load_rc_config \$name
+run_rc_command "\$1"
+EOF
+```
+
+Now make the file executable:
+
+```bash
+chmod +x /etc/rc.d/autodhcp
+```
+
+#### Edit /etc/rc.conf
+
+We need to set the hostname, and enable sshd & our newly created autodhcpd script.
+
+Create the file `/etc/rc.conf` with the following content:
+
+```bash
+cat << EOF > /etc/rc.conf
+zfs_enable="YES"
+hostname="myhost.mydomain"
+sshd_enable="YES"
+autodhcp_enable="YES"
+EOF
+```
+
+### If you do not have an IPv4 address you must configure the network interface manually:
+
+If your server uses a RealTec based network card, the name of your interface is most likely `re0`.
+If your server uses an Intel based network card, the name is either `em0` or `igb0`.
+If in doubt use Google to find out what your NIC would be called in FreeBSD.
+
+In our example we will use `em0` as the name of our network card.
+
+Add the following lines to the `/etc/rc.conf` file:
+
+```bash
+cat <<EOF >>/etc/rc.conf
+ifconfig_em0="inet6 2a01:4f9:0:0::2"
+ipv6_defaultrouter="fe80::1%em0"
+EOF
+```
+
+
+## Clean up
+
+Exit the chroot environment and unmount the filesystems
+
+```bash
+exit
+sync
+umount /mnt/dev
+umount /mnt/var
+umount /mnt/tmp
+umount /mnt
+exit
+```
+
+When everything is setup, you can reboot the server into the FreeBSD distribution:
+
+```bash
+reboot
+```
+
+
+## Conclusion
+
+Congratulations! You now have a working FreeBSD installation that does not require full UEFI support.
+
+-------------
+
+**Additional note:**
+
+If your installation gets broken and doesn't boot anymore, you can use the Linux rescue system to access it:
+
+#### The vKVM way:
+
+Use QEMU to boot your system
+
+1. Boot into the Linux rescue system
+2. Boot your FreeBSD system inside a QEMU VM:
+   ```bash
+   qemu-system-x86_64 -net nic -net user,hostfwd=tcp::1022-:22 -m 2048M -enable-kvm \
+    -cpu host,+nx -M pc -smp 2 -vga std -k en-us \
+    -device virtio-scsi-pci,id=scsi0 \
+    -drive file=/dev/nvme0n1,if=none,format=raw,discard=unmap,aio=native,cache=none,id=n0 \
+    -device scsi-hd,drive=n0,bus=scsi0.0 \
+    -drive file=/dev/nvme1n1,if=none,format=raw,discard=unmap,aio=native,cache=none,id=n1 \
+    -device scsi-hd,drive=n1,bus=scsi0.0 \
+    -boot once=d -vnc 127.0.0.1:0,password -monitor stdio
+   ```
+3. Use either VNC or ssh to connect to the VM and make your changes
+4. Shutdown your VM guest
+   ```bash
+   poweroff
+   ```
+5. Reboot the rescue system
+   ```bash
+   reboot
+   ```
+
+#### The OpenZFS way:
+
+Use the Linux rescue system to access the file system:
+
+1. Boot into the Linux rescue system
+2. Install OpenZFS using `zfs`
+   ```bash
+   zfs
+   ```
+3. Import your root pool without mounting its datasets
+   ```bash
+   zpool import -o cachefile=none -f -N zroot
+   ```
+4. Mount your root dataset
+   ```bash
+   mount -t zfs zroot/root /mnt
+   ```
+5. Make any modifications you need and reboot
+   ```bash
+   reboot
+   ```
+
+
+##### License: MIT
+
+<!--
+
+Contributor's Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it under the license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate license and I have the
+    right under that license to submit that work with modifications,
+    whether created in whole or in part by me, under the same license
+    (unless I am permitted to submit under a different license), as
+    indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are
+    public and that a record of the contribution (including all personal
+    information I submit with it, including my sign-off) is maintained
+    indefinitely and may be redistributed consistent with this project
+    or the license(s) involved.
+
+Signed-off-by: Juergen Meier <jpm@jors.net>
+
+-->

--- a/tutorials/freebsd-with-qemu-via-linux-rescue/01.en.md
+++ b/tutorials/freebsd-with-qemu-via-linux-rescue/01.en.md
@@ -2,47 +2,46 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/freebsd-with-qemu-via-linux-rescue"
 slug: "freebsd-with-qemu-via-linux-rescue"
-date: "2024-01-20"
-title: "Installing FreeBSD on older dedicated Servers via the Linux rescue system"
+date: "2024-01-26"
+title: "Installing FreeBSD on older dedicated servers via the Linux rescue system"
 short_description: "This tutorial explains how to install FreeBSD on a Hetzner dedicated server with legacy boot loaders."
 tags: ["FreeBSD", "Server Setup"]
 author: "Juergen Meier"
 author_link: "https://github.com/Jor"
+author_img: "https://avatars3.githubusercontent.com/u/94262"
 author_description: "Jor"
 language: "en"
 available_languages: ["en"]
-header_img: "header-x"
+header_img: "header-4"
 cta: "dedicated"
 ---
-
 
 ## Introduction
 
 Hetzner no longer offers a FreeBSD rescue system.
-For dedicated servers with full UEFI support there is a tutorial showing how to install FreeBSD with OpenZFS from the Linux rescue system.
-https://community.hetzner.com/tutorials/freebsd-openzfs-via-linux-rescue
+For dedicated servers with full UEFI support there is a tutorial showing how to install FreeBSD with OpenZFS from the Linux rescue system: [Installing FreeBSD with OpenZFS via the Linux rescue system](https://community.hetzner.com/tutorials/freebsd-openzfs-via-linux-rescue)
 
-For older servers that only have minimal UEFI support and require legacy BIOS boot there is a different way to install FreeBSD.
+For older servers that only have minimal UEFI support and require legacy BIOS boot, there is a different way to install FreeBSD.
 
 **Prerequisites:**
 
-* Hetzner dedicated server booted in Linux [rescue](https://docs.hetzner.com/cloud/servers/getting-started/rescue-system) mode with working SSH access
-* IPv6 Network configuration parameters:
- * IPv6 assigned address
+* Hetzner dedicated server booted in Linux [rescue](https://docs.hetzner.com/robot/dedicated-server/troubleshooting/hetzner-rescue-system) mode with working SSH access
+* IPv6 network configuration parameters:
+  * IPv6 address assigned
 
 **Optional:**
 
-* IPv4 Network configuration parameters:
- * IP Address and Network length
- * Default Gateway
+* IPv4 network configuration parameters:
+  * IP address and network length
+  * Default gateway
 
-*Note: dedicated servers without an IPv4 address must be configured correctly since DHCP and autodetect does not work*
+> **Note:** Dedicated servers without an IPv4 address must be configured correctly since DHCP and autodetect does not work.
 
 **Example terminology**
 
-* IPv4: 192.168.0.2/27
-* IPv4 Gateway: 192.168.0.1
-* IPv6: 2a01:4f8:0:0::2/64
+* IPv4: `192.168.0.2/27`
+* IPv4 Gateway: `192.168.0.1`
+* IPv6: `2a01:4f8:0:0::2/64`
 * NIC: Intel(R) PRO/1000 Network Driver
 * Drive 1: `/dev/nvme0n1`
 * Drive 2: `/dev/nvme1n1`
@@ -65,13 +64,16 @@ curl -O http://ftp2.de.freebsd.org/pub/FreeBSD/releases/amd64/14.0-RELEASE/kerne
 We use [mfsBSD](https://mfsbsd.vx.sk/) virtual machine to install FreeBSD on the system drives.
 
 Download the ISO image:
+
 ```bash
 curl -O https://mfsbsd.vx.sk/files/iso/14/amd64/mfsbsd-14.0-RELEASE-amd64.iso
 ```
 
-## Step 3 - launch the mfsBSD virtual machine from the ISO image
+## Step 3 - Launch the mfsBSD virtual machine from the ISO image
 
 The server disks are passed through to the VM as SCSI devices using virtio.
+
+> In the command below, replace `/dev/nvme0n1` and `/dev/nvme1n1` as needed.
 
 ```bash
 qemu-system-x86_64 -net nic -net user,hostfwd=tcp::1022-:22 -m 2048M -enable-kvm \
@@ -82,42 +84,43 @@ qemu-system-x86_64 -net nic -net user,hostfwd=tcp::1022-:22 -m 2048M -enable-kvm
  -device scsi-hd,drive=n0,bus=scsi0.0 \
  -drive file=/dev/nvme1n1,if=none,format=raw,discard=unmap,aio=native,cache=none,id=n1 \
  -device scsi-hd,drive=n1,bus=scsi0.0 \
- -boot once=d -vnc 127.0.0.1:0,password -monitor stdio
+ -boot once=d -vnc 127.0.0.1:0,password=on -monitor stdio
 ```
 
-The SSH service inside the VM is made available on port 1022 of the rescue system
+The SSH service inside the VM is made available on port 1022 of the rescue system.
 
-*Note*
+**Note:**<br>
 The disk devices of the servers will be attached as SCSI disks in the VM no matter what they are on the host.
 This means that inside the VM the disks are always mapped to `/dev/da0` and `/dev/da1`.
 
-### Optional set a VNC password to allow VNC access
+### Set a VNC password to allow VNC access (Optional)
 
-You need to forward port 5900 using ssh to connect to VNC!
+You need to forward port 5900 using SSH to connect to VNC!
 
 ```
 (qemu) set_password vnc mfsroot
 (qemu) 
 ```
 
-## Step 4 - copy the distribution files to the VM
+## Step 4 - Copy the distribution files to the VM
 
-On a root shell of the rescue linux system issue the following command:
+On a root shell of the rescue Linux system, run the following command:
 
 ```bash
 scp -o Port=1022 base.txz kernel.txz root@localhost:
 ```
+
 The root password inside the virtual machine is `mfsroot`.
 
 ## Step 5 - Login to the VM
 
-Use ssh to log into the VM from a shell on the rescue system
+Use SSH to log into the VM from a shell on the rescue system:
 
 ```bash
 ssh -p 1022 root@localhost
 ```
 
-The password is `mfsroot`
+The password is `mfsroot`.
 
 Verify that the drives are visible:
 
@@ -130,7 +133,7 @@ da1: <QEMU QEMU HARDDISK 2.5+> Fixed Direct Access SPC-3 SCSI device
 
 ## Step 6 - Install FreeBSD
 
-Install FreeBSD with the [zfsinstall](https://github.com/mmatuska/mfsbsd/blob/master/tools/zfsinstall) script
+Install FreeBSD with the [zfsinstall](https://github.com/mmatuska/mfsbsd/blob/master/tools/zfsinstall) script:
 
 ```bash
 zfsinstall -d /dev/da0 -d /dev/da1 -r mirror -p zroot -s 16G -u .
@@ -138,7 +141,7 @@ zfsinstall -d /dev/da0 -d /dev/da1 -r mirror -p zroot -s 16G -u .
 
 This will install FreeBSD on a ZFS pool `zroot` using RAID-1 (`mirror`) on both disks with 16GiByte swap space on each disk.
 
-The installed FreeBSD root filesystem will be mounted on /mnt. Since we are running the current version of FreeBSD inside the VM already we can now just use chroot to configure the new installation:
+The installed FreeBSD root filesystem will be mounted on `/mnt`. Since we are running the current version of FreeBSD inside the VM, we can now already just use chroot to configure the new installation:
 
 ```bash
 mount -t devfs devfs /mnt/dev
@@ -149,42 +152,38 @@ chroot /mnt
 
 Once we used chroot to get a shell running inside the installed FreeBSD environment, we can complete the configuration.
 
-Set a root password
+* Set a root password
+  ```bash
+  passwd
+  ```
+* Enable root login with password
+  ```bash
+  echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+  echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config
+  ```
+  > **Note:** You may want to disable this later after you created user accounts
+* Set the hostname, and enable sshd & our newly created autodhcpd script
+  
+  Create the file `/etc/rc.conf` with the following content:
+  ```bash
+  cat << EOF > /etc/rc.conf
+  zfs_enable="YES"
+  hostname="myhost.mydomain"
+  sshd_enable="YES"
+  EOF
+  ```
 
-```bash
-passwd
-```
+## Step 8 - Configure the network settings
 
-and enable root login with password:
-
-```bash
-echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
-echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config
-```
-
-*Note: you may want to disable this later after you created user accounts*
-
-We need to set the hostname, and enable sshd & our newly created autodhcpd script.
-
-Create the file `/etc/rc.conf` with the following content:
-
-```bash
-cat << EOF > /etc/rc.conf
-zfs_enable="YES"
-hostname="myhost.mydomain"
-sshd_enable="YES"
-EOF
-```
-
-### configure the network settings
-
-If your server uses a RealTec based network card, the name of your interface is most likely `re0`.
-If your server uses an Intel based network card, the name is either `em0` or `igb0`.
-If in doubt use Google to find out what your NIC would be called in FreeBSD.
+If your server uses a RealTec based network card, the name of your interface is most likely `re0`.<br>
+If your server uses an Intel based network card, the name is either `em0` or `igb0`.<br>
+If in doubt, use Google to find out what your NIC would be called in FreeBSD.
 
 In our example we need to use `em0` as the name of our network card.
 
 Add the following lines to the `/etc/rc.conf` file:
+
+> In the command below, replace `em0`, `192.168.0.2/27`, `192.168.0.1`, and `2a01:4f8:0:0::2/64` as needed.
 
 ```bash
 cat <<EOF >>/etc/rc.conf
@@ -197,8 +196,7 @@ ipv6_defaultrouter="fe80::1%em0"
 EOF
 ```
 
-
-## Clean up
+## Step 9 - Clean up
 
 Exit the chroot environment and unmount the filesystems
 
@@ -213,7 +211,7 @@ umount /mnt
 
 You can either shut down the qemu virtual machine or terminate the qemu process.
 
-With everthing set up, you can reboot the server into the FreeBSD distribution:
+With everything set up, you can reboot the server into the FreeBSD distribution:
 
 ```bash
 reboot
@@ -229,12 +227,14 @@ Congratulations! You now have a working FreeBSD installation that does not requi
 
 If your installation gets broken and doesn't boot anymore, you can use the Linux rescue system to access it:
 
-#### The vKVM way:
+<details>
+<summary>The vKVM way</summary>
 
 Use QEMU to boot your system
 
 1. Boot into the Linux rescue system
 2. Boot your FreeBSD system inside a QEMU VM:
+   > In the command below, replace `/dev/nvme0n1` and `/dev/nvme1n1` as needed.
    ```bash
    qemu-system-x86_64 -net nic -net user,hostfwd=tcp::1022-:22 -m 2048M -enable-kvm \
     -cpu host,+nx -M pc -smp 2 -vga std -k en-us \
@@ -245,7 +245,7 @@ Use QEMU to boot your system
     -device scsi-hd,drive=n1,bus=scsi0.0 \
     -boot once=d -vnc 127.0.0.1:0,password -monitor stdio
    ```
-3. Use either VNC or ssh to connect to the VM and make your changes
+3. Use either VNC or SSH to connect to the VM and make your changes
 4. Shutdown your VM guest
    ```bash
    poweroff
@@ -255,7 +255,10 @@ Use QEMU to boot your system
    reboot
    ```
 
-#### The OpenZFS way:
+</details>
+
+<details>
+<summary>The OpenZFS way</summary>
 
 Use the Linux rescue system to access the file system:
 
@@ -277,6 +280,7 @@ Use the Linux rescue system to access the file system:
    reboot
    ```
 
+</details>
 
 ##### License: MIT
 


### PR DESCRIPTION
I have read and understood the Contributor's Certificate of Origin available at the end of 
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Juergen Meier <jpm@jors.net>

My tutorial allows installation of FreeBSD without requiring a server with UEFI support as https://community.hetzner.com/tutorials/freebsd-openzfs-via-linux-rescue does.
I also noted that ZFS support in linux rescue disk seems to be broken in Helsinki DC. This method was tested in Falkenstein and Helsinki on older dedicated servers.