### PR TITLE
Tutorial for Install ERPNext v15 on Ubuntu 22.04 LTS

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "master"
+    ]
+}

--- a/tutorials/install-erpnext-v15-on-ubuntu-22.04-lts/01.en.md
+++ b/tutorials/install-erpnext-v15-on-ubuntu-22.04-lts/01.en.md
@@ -11,14 +11,31 @@ author_link: "https://github.com/xrpsystems"
 author_img: "https://avatars.githubusercontent.com/u/156489091?s=400&u=5d43322bdbb8561ea2ee00651b5483f0b723c2d4&v=4"
 author_description: "Enthusiastic technologist with expertise in ERP systems and a passion for modern development tools. Follow for insightful tutorials and innovative solutions. Connect with me on GitHub."
 language: "en"
-available_languages: ["en", "Enter all other available languages of the tutorial using ISO 639-1 codes"]
 header_img: "header-x"
 cta: "product"
 ---
 
 ## Introduction
 
-Embark on a journey to seamlessly install ERPNext version 15 on Ubuntu 22.04 LTS. This comprehensive tutorial guides developers and system administrators through the step-by-step process, ensuring a smooth deployment of the latest ERPNext version on the robust Ubuntu platform. Elevate your business management capabilities with ERPNext – join us on the path to a streamlined and efficient ERP setup.
+Learn how to set up ERPNext version 15 on Ubuntu 22.04 LTS with this comprehensive tutorial. Whether you are a developer or a system administrator, this step-by-step guide will walk you through the installation process, ensuring a smooth deployment of the latest ERPNext version on the robust Ubuntu platform.
+
+Key Steps Covered:
+
+User Setup: Create a new user with the necessary privileges for the ERPNext installation.
+
+Package Installation: Install required packages, including Python 3.11+, Node.js, MariaDB, and other dependencies.
+
+Database Configuration: Set up the MariaDB database environment, securing it and optimizing the configuration.
+
+ERPNext Environment: Install Frappe Bench, initialize the ERPNext environment, and install necessary apps.
+
+Production Configuration: Configure ERPNext for production with scheduling, maintenance mode, NGINX setup, and Supervisor restart.
+
+Multitenancy Setup (Optional): Optionally set up DNS-based multitenancy for hosting multiple sites.
+
+SSL Certificate Integration: Add a domain to your site and install Let's Encrypt SSL certificates for secure communication.
+
+By following this tutorial, you'll empower your business with the latest ERPNext features and enhance your management capabilities. Join us on this journey to a streamlined and efficient ERP setup.
 
 **Prerequisites**
 

--- a/tutorials/install-erpnext-v15-on-ubuntu-22.04-lts/01.en.md
+++ b/tutorials/install-erpnext-v15-on-ubuntu-22.04-lts/01.en.md
@@ -2,10 +2,10 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/install-erpnext-v15-on-ubuntu-22.04-lts"
 slug: "install-erpnext-v15-on-ubuntu-22.04-lts"
-date: "2024-01-23"
+date: "2024-01-25"
 title: "Install ERPNext v15 on Ubuntu 22.04 LTS"
 short_description: "Learn how to set up ERPNext version 15 on Ubuntu 22.04 LTS in this comprehensive tutorial. Follow step-by-step instructions to install the required dependencies, configure the environment, and deploy ERPNext for effective business management. Perfect for developers and system administrators looking to implement the latest version of ERPNext on Ubuntu."
-tags: ["Development", "Lang:Go", "Lang:JS"]
+tags: ["ERPNext", "Frappe", "ERPNext 15"]
 author: "XRP Systems"
 author_link: "https://github.com/xrpsystems"
 author_img: "https://avatars.githubusercontent.com/u/156489091?s=400&u=5d43322bdbb8561ea2ee00651b5483f0b723c2d4&v=4"
@@ -22,7 +22,7 @@ Embark on a journey to seamlessly install ERPNext version 15 on Ubuntu 22.04 LTS
 
 **Prerequisites**
 
-Before you begin the installation process, make sure you have the following prerequisites in place:
+Ensure that your system meets these prerequisites to ensure a successful installation of ERPNext version 15:
 
 * Hetzner Cloud [API token](https://docs.hetzner.com/cloud/api/getting-started/generating-api-token) in the [Cloud Console](https://console.hetzner.cloud/)
 
@@ -31,87 +31,314 @@ Operating System:
 
 Software Dependencies:
 * Python 3.11+
-*Node.js 20+
-*MariaDB 10.3.x
+* Node.js 20+
+* MariaDB 10.3.x
+* wkhtmltopdf 0.12.6 (with patched qt)
 
 User Privileges:
 * A user account with sudo privileges on the Ubuntu system.
 * [SSH key](https://community.hetzner.com/tutorials/howto-ssh-key)
 
-Ensure that your system meets these prerequisites to ensure a successful installation of ERPNext version 15 on Ubuntu 22.04 LTS.
 
-**Example terminology**
+## Step 1 - Create a New User
 
-Many tutorials will need to include example usernames, hostnames, domains, and IPs. To simplify this, all tutorials should use the same default examples, as outlined below.
+sudo adduser [frappe-user]
+sudo usermod -aG sudo [frappe-user]
+su [frappe-user]
+cd /home/[frappe-user]
+* Ensure you have replaced [frappe-user] with your username. eg. sudo adduser frappe
 
-* Username: `holu` (short for Hetzner OnLine User)
-* Hostname: `<your_host>`
-* Domain: `<example.com>`
-* Subdomain: `<sub.example.com>`
-* IP addresses (IPv4 and IPv6):
-   * Server: `<10.0.0.1>` and `<2001:db8:1234::1>`
-   * Gateway `<192.0.2.254>` and `<2001:db8:1234::ffff>`
-   * Client private: `<198.51.100.1>` and `<2001:db8:9abc::1>`
-   * Client public: `<203.0.113.1>` and `<2001:db8:5678::1>`
 
-Do **not** use actual IPs in your tutorial.
+## Step 2 - Install Required Packages
 
-## Step 1 - Summary of Step
+* For setting up ERPNext 15, we need to install several software packages first.
 
-Steps are the actual steps users will be taking to complete your tutorial.
 
-Each step should build on the previous one, until the final step that finishes the tutorial.
-
-It is important not to skip any steps, no matter how obvious or self-explanatory they may seem.
-
-Feel free to include screenshots, to show exactly what the user should be seeing. Please put screenshots in a separate "images" folder.
-
-The amount of steps will depend entirely on how long/complicated the tutorial is.
-
-## Step 2 - Summary of Step
-
-Quick introduction.
-
-Start by...
-
-![Screenshot Description](images/screenshot_description.png)
-
-Then...
-
-Finally...
-
-### Step 2.1 - Summary of Step
-
-You can create code examples in nearly every programming language.
-Just state the language after the first three backticks in your Markdown file.
-
-Here is a code example
-
-```javascript
-var s = "JavaScript syntax highlighting";
-alert(s);
+### Step 2.1 - Update and Upgrade Packages
+```shell
+sudo apt-get update -y
+```
+```shell
+sudo apt-get upgrade -y
 ```
 
-### Step 2.2 - Summary of Step
+### Step 2.2 - ERPNext version 15 requires Python version 3.11+
 
-Another code example
-
-```python
-s = "Python syntax highlighting"
-print s
+* Adding PPA repository and Install Python 3.11
+```shell
+sudo add-apt-repository ppa:deadsnakes/ppa
+```
+```shell
+sudo apt-get install python3-dev python3.11-dev python3-setuptools python3-pip python3-distutils python-is-python3
 ```
 
-## Step 3 - Summary of Step (Optional)
+### Step 2.3 - Install Python Virtual Environment
 
-Instructions for a step that is not necessary to complete the tutorial, but can be helpful.
+```shell
+sudo apt install python3.10-venv python3.11-venv 
+```
 
-## Step N - Summary of Step
 
-Yet more instructions.
+### Step 2.4 - Set Default Python Version to 3.11
+
+```shell
+sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+```
+
+
+### Step 2.5 - Install Redis Server
+
+```shell
+sudo apt-get install redis-server
+```
+
+
+### Step 2.6 - Install and Setup MariaDB
+
+```shell
+sudo apt-get install software-properties-common
+sudo apt install mariadb-server mariadb-client
+```
+
+
+### Step 2.7 - Install other packages
+
+```shell
+sudo apt-get install xvfb libfontconfig
+sudo apt-get install libmysqlclient-dev
+sudo apt-get install fontconfig libxrender1 xfonts-75dpi 
+
+wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb && sudo dpkg --install wkhtmltox_0.12.6.1-2.jammy_amd64.deb;
+sudo cp /usr/local/bin/wkhtmlto* /usr/bin/
+sudo chmod a+x /usr/bin/wk*
+sudo rm wk*
+
+wkhtmltopdf --version  #Test the install: wkhtmltopdf 0.12.6 (with patched qt)
+```
+
+
+### Step 2.8 - Install CURL, Node.js, NPM, and Yarn
+
+* CURL
+```shell
+sudo apt install curl
+```
+
+* Node.js
+```shell
+sudo apt install curl 
+curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
+source ~/.profile
+nvm install 20
+```
+
+* npm
+```shell
+sudo apt-get install npm
+```
+
+* Yarn
+```shell
+sudo npm install -g yarn
+```
+
+
+## Step 3 - Set Database environment
+
+* Secure MariaDB
+```shell
+sudo mariadb-secure-installation
+```
+
+* Upon running the last command, you’ll encounter a series of prompts on the server. Make sure to follow the subsequent Steps carefully to ensure the setup is configured properly.
+
+* Enter current password for root: (Enter your SSH root user password)
+* (Press blank Enter if for the first time)
+
+Switch to unix_socket authentication [Y/n]: Y
+
+Change the root password? [Y/n]: Y
+
+Remove anonymous users? [Y/n] Y
+
+Disallow root login remotely? [Y/n] Y
+
+Remove test database and access to it? [Y/n] Y
+
+Reload privilege tables now? [Y/n] Y
+
+
+
+* Create my.cnf MYSQL config file
+
+```shell
+sudo nano /etc/mysql/mariadb.conf.d/my.cnf
+```
+
+
+* Add these lines
+
+```shell
+[mysqld]
+innodb-file-format=barracuda
+innodb-file-per-table=1
+innodb-large-prefix=1
+character-set-client-handshake = FALSE
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci
+
+[mysql]
+default-character-set = utf8mb4
+```
+
+* Restart MariaDB to update my.cnf
+```shell
+systemctl restart mariadb
+```
+
+
+## Step 4 - Create and Install ERPNext Environment
+
+* Install Frappe Bench
+```shell
+sudo pip3 install frappe-bench
+```
+
+* Initialize Frappe Bench
+```shell
+bench init frappe-bench --frappe-branch version-15
+cd frappe-bech/
+```
+
+* Add the node-sass package
+```shell
+yarn add node-sass
+```
+
+* Change user directory permissions
+```shell
+sudo chmod -R o+rx /home/[frappe-user]
+```
+
+* Create a New Site
+```shell
+bench new-site [site-name]
+```
+
+* Install ERPNext and other Apps
+```shell
+bench get-app erpnext --branch version-15
+bench get-app payments --branch version-15    
+bench --site [site-name] install-app erpnext
+```
+
+* Lastly
+```shell
+bench use [site-name]
+bench start
+```
+
+
+## Step 5 - Setting ERPNext for Production
+
+* Enable Scheduler
+```shell
+bench --site [site-name] enable-scheduler
+```
+
+* Disable maintenance mode
+```shell
+bench --site [site-name] set-maintenance-mode off
+```
+
+* Setup production config
+```shell
+sudo bench setup production [frappe-user]
+```
+
+* Setup NGINX to apply the changes
+```shell
+bench setup nginx
+```
+
+* Restart Supervisor and Launch Production Mode
+```shell
+sudo supervisorctl restart all
+sudo bench setup production [frappe-user]
+```
+
+
+## Step 6 - Setup Multitenancy (Optional)
+
+* DNS based multitenancy
+
+You can name your sites as the hostnames that would resolve to it. Thus, all the sites you add to the bench would run on the same port and will be automatically selected based on the hostname.
+For example:
+DNS [A] record: [subdomain1].[domain] - it will forward to your desired [bench-site1] 
+DNS [A] record: [subdomain1].[domain] - it will forward to your desired [bench-site2] 
+
+To make a new site under DNS based multitenancy, perform the following Steps.
+
+* Switch on DNS based multitenancy (once)
+```shell
+bench config dns_multitenant on
+```
+
+* Create a new site
+```shell
+bench new-site [site2name]
+```
+
+* Regenerate nginx config
+```shell
+bench setup nginx
+```
+
+* Reload nginx
+```shell
+sudo service nginx reload
+```
+
+
+## Final Step 7 - Adding a Domain with SSL to your Site
+
+* Add Domain
+```shell
+bench setup add-domain [desired-domain]
+```
+
+
+* Install Let's Encrypt Certificate
+
+** Install snapd on your machine
+```shell
+sudo apt install snapd
+```
+
+** Update snapd
+```shell
+sudo snap install core;
+sudo snap refresh core
+```
+
+** Remove existing installations of certbot
+```shell
+sudo apt-get remove certbot
+```
+
+** Install certbot
+```shell
+sudo snap install --classic certbot
+sudo ln -s /snap/bin/certbot /usr/bin/certbot
+```
+
+** Get Certificate
+```shell
+sudo -H bench setup lets-encrypt [site-name]
+```
 
 ## Conclusion
-
-A short conclusion summarizing what the user has done, and maybe suggesting different courses of action they can now take.
+*** You will be faced with several prompts, respond to them accordingly. This command will also add an entry to the crontab of the root user (this requires elevated permissions), that will attempt to renew the certificate every month.
 
 ##### License: MIT
 

--- a/tutorials/install-erpnext-v15-on-ubuntu-22.04-lts/01.en.md
+++ b/tutorials/install-erpnext-v15-on-ubuntu-22.04-lts/01.en.md
@@ -1,0 +1,145 @@
+---
+SPDX-License-Identifier: MIT
+path: "/tutorials/install-erpnext-v15-on-ubuntu-22.04-lts"
+slug: "install-erpnext-v15-on-ubuntu-22.04-lts"
+date: "2024-01-23"
+title: "Install ERPNext v15 on Ubuntu 22.04 LTS"
+short_description: "Learn how to set up ERPNext version 15 on Ubuntu 22.04 LTS in this comprehensive tutorial. Follow step-by-step instructions to install the required dependencies, configure the environment, and deploy ERPNext for effective business management. Perfect for developers and system administrators looking to implement the latest version of ERPNext on Ubuntu."
+tags: ["Development", "Lang:Go", "Lang:JS"]
+author: "XRP Systems"
+author_link: "https://github.com/xrpsystems"
+author_img: "https://avatars.githubusercontent.com/u/156489091?s=400&u=5d43322bdbb8561ea2ee00651b5483f0b723c2d4&v=4"
+author_description: "Enthusiastic technologist with expertise in ERP systems and a passion for modern development tools. Follow for insightful tutorials and innovative solutions. Connect with me on GitHub."
+language: "en"
+available_languages: ["en", "Enter all other available languages of the tutorial using ISO 639-1 codes"]
+header_img: "header-x"
+cta: "product"
+---
+
+## Introduction
+
+Embark on a journey to seamlessly install ERPNext version 15 on Ubuntu 22.04 LTS. This comprehensive tutorial guides developers and system administrators through the step-by-step process, ensuring a smooth deployment of the latest ERPNext version on the robust Ubuntu platform. Elevate your business management capabilities with ERPNext – join us on the path to a streamlined and efficient ERP setup.
+
+**Prerequisites**
+
+Before you begin the installation process, make sure you have the following prerequisites in place:
+
+* Hetzner Cloud [API token](https://docs.hetzner.com/cloud/api/getting-started/generating-api-token) in the [Cloud Console](https://console.hetzner.cloud/)
+
+Operating System:
+* Ubuntu 22.04 LTS
+
+Software Dependencies:
+* Python 3.11+
+*Node.js 20+
+*MariaDB 10.3.x
+
+User Privileges:
+* A user account with sudo privileges on the Ubuntu system.
+* [SSH key](https://community.hetzner.com/tutorials/howto-ssh-key)
+
+Ensure that your system meets these prerequisites to ensure a successful installation of ERPNext version 15 on Ubuntu 22.04 LTS.
+
+**Example terminology**
+
+Many tutorials will need to include example usernames, hostnames, domains, and IPs. To simplify this, all tutorials should use the same default examples, as outlined below.
+
+* Username: `holu` (short for Hetzner OnLine User)
+* Hostname: `<your_host>`
+* Domain: `<example.com>`
+* Subdomain: `<sub.example.com>`
+* IP addresses (IPv4 and IPv6):
+   * Server: `<10.0.0.1>` and `<2001:db8:1234::1>`
+   * Gateway `<192.0.2.254>` and `<2001:db8:1234::ffff>`
+   * Client private: `<198.51.100.1>` and `<2001:db8:9abc::1>`
+   * Client public: `<203.0.113.1>` and `<2001:db8:5678::1>`
+
+Do **not** use actual IPs in your tutorial.
+
+## Step 1 - Summary of Step
+
+Steps are the actual steps users will be taking to complete your tutorial.
+
+Each step should build on the previous one, until the final step that finishes the tutorial.
+
+It is important not to skip any steps, no matter how obvious or self-explanatory they may seem.
+
+Feel free to include screenshots, to show exactly what the user should be seeing. Please put screenshots in a separate "images" folder.
+
+The amount of steps will depend entirely on how long/complicated the tutorial is.
+
+## Step 2 - Summary of Step
+
+Quick introduction.
+
+Start by...
+
+![Screenshot Description](images/screenshot_description.png)
+
+Then...
+
+Finally...
+
+### Step 2.1 - Summary of Step
+
+You can create code examples in nearly every programming language.
+Just state the language after the first three backticks in your Markdown file.
+
+Here is a code example
+
+```javascript
+var s = "JavaScript syntax highlighting";
+alert(s);
+```
+
+### Step 2.2 - Summary of Step
+
+Another code example
+
+```python
+s = "Python syntax highlighting"
+print s
+```
+
+## Step 3 - Summary of Step (Optional)
+
+Instructions for a step that is not necessary to complete the tutorial, but can be helpful.
+
+## Step N - Summary of Step
+
+Yet more instructions.
+
+## Conclusion
+
+A short conclusion summarizing what the user has done, and maybe suggesting different courses of action they can now take.
+
+##### License: MIT
+
+<!--
+
+Contributor's Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it under the license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate license and I have the
+    right under that license to submit that work with modifications,
+    whether created in whole or in part by me, under the same license
+    (unless I am permitted to submit under a different license), as
+    indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are
+    public and that a record of the contribution (including all personal
+    information I submit with it, including my sign-off) is maintained
+    indefinitely and may be redistributed consistent with this project
+    or the license(s) involved.
+
+Signed-off-by: [submitter's name and email address here]
+
+-->


### PR DESCRIPTION
Learn how to set up ERPNext version 15 on Ubuntu 22.04 LTS with this comprehensive tutorial. Whether you are a developer or a system administrator, this step-by-step guide will walk you through the installation process, ensuring a smooth deployment of the latest ERPNext version on the robust Ubuntu platform.

Key Steps Covered:

User Setup: Create a new user with the necessary privileges for the ERPNext installation.

Package Installation: Install required packages, including Python 3.11+, Node.js, MariaDB, and other dependencies.

Database Configuration: Set up the MariaDB database environment, securing it and optimizing the configuration.

ERPNext Environment: Install Frappe Bench, initialize the ERPNext environment, and install necessary apps.

Production Configuration: Configure ERPNext for production with scheduling, maintenance mode, NGINX setup, and Supervisor restart.

Multitenancy Setup (Optional): Optionally set up DNS-based multitenancy for hosting multiple sites.

SSL Certificate Integration: Add a domain to your site and install Let's Encrypt SSL certificates for secure communication.

By following this tutorial, you'll empower your business with the latest ERPNext features and enhance your management capabilities. Join us on this journey to a streamlined and efficient ERP setup.