### PR TITLE
Darft: Remove certbot-auto (deprecacted) from existing tutorials

### DIFF
--- a/tutorials/install-turn-stun-server-on-debian-ubuntu-with-coturn/01.en.md
+++ b/tutorials/install-turn-stun-server-on-debian-ubuntu-with-coturn/01.en.md
@@ -93,13 +93,14 @@ Theoretically you could also deploy a second A and AAAA record for `turn.example
 
 ## Step 2 - Installation
 
-First we will need to install `coturn` on our server.
+First, we will need to install `coturn` on our server:
 
 ```bash
+apt-get update
 apt-get install coturn
 ```
 
-For the moment we will stop `coturn`
+For the moment, we will stop `coturn`:
 
 ```bash
 systemctl stop coturn
@@ -109,7 +110,7 @@ systemctl stop coturn
 
 In order to enable the TURN server, open the file `/etc/default/coturn` and remove the `#` in front of `TURNSERVER_ENABLED=1`.
 
-The configuration file is located at `/etc/turnserver.conf`. First we move the original version of this file using:
+The configuration file is located at `/etc/turnserver.conf`. First, we move the original version of this file using:
 
 ```bash
 mv /etc/turnserver.conf /etc/turnserver.conf.orig
@@ -165,17 +166,15 @@ sed -i "s/replace-this-secret/$(openssl rand -hex 32)/" /etc/turnserver.conf
 We will use [certbot](https://certbot.eff.org/) from [EFF](https://www.eff.org/) for the Let's Encrypt certificates.
 
 ```bash
-wget https://dl.eff.org/certbot-auto
-wget -N https://dl.eff.org/certbot-auto.asc
-gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
+apt-get install snapd
+snap install --classic certbot
+ln -s /snap/bin/certbot /usr/bin/certbot
 ```
 
-The last line should be the following: `gpg: Good signature from "Let's Encrypt Client Team <letsencrypt-client@eff.org>" [ultimate]`. If not, please check again if you have downloaded the correct key. Do *NOT* use the downloaded file if they key does not match.
+With certbot installed, you can now create your certificate.
 
 ```bash
-chmod a+x ./certbot-auto
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d turn.example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d turn.example.com
 ```
 
 You will get an email 30 (and 7) days before the certificates expire to holu@example.com.

--- a/tutorials/install-turn-stun-server-on-debian-ubuntu-with-coturn/01.ru.md
+++ b/tutorials/install-turn-stun-server-on-debian-ubuntu-with-coturn/01.ru.md
@@ -165,17 +165,10 @@ sed -i "s/replace-this-secret/$(openssl rand -hex 32)/" /etc/turnserver.conf
 Для Let's Encrypt сертификатов будем использовать [certbot](https://certbot.eff.org/) от [EFF](https://www.eff.org/).
 
 ```bash
-wget https://dl.eff.org/certbot-auto
-wget -N https://dl.eff.org/certbot-auto.asc
-gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
-```
-
-Последняя строка должна быть такой: `gpg: Good signature from "Let's Encrypt Client Team <letsencrypt-client@eff.org>" [ultimate]`. Если это не так, пожалуйста, проверьте еще раз, загрузили ли вы правильный ключ. *Не* используйте загруженный файл, если ключ не совпадает.
-
-```bash
-chmod a+x ./certbot-auto
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d turn.example.com
+apt-get install snapd
+snap install --classic certbot
+ln -s /snap/bin/certbot /usr/bin/certbot
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d turn.example.com
 ```
 
 За 30 (и 7) дней до истечения срока действия сертификатов вы получите электронное письмо на holu@example.com.

--- a/tutorials/jitsi-meet-on-debian-ubuntu/01.en.md
+++ b/tutorials/jitsi-meet-on-debian-ubuntu/01.en.md
@@ -41,18 +41,20 @@ talk.example.com. 14400 IN AAAA 2001:db8:1234::1
 
 Jitsi ships pre-built packages for jitsi-meet in its own repository. Since these packages are signed with their own key, we also need to add the GPG from Jitsi to our keyring.
 
-```console
+```bash
 echo 'deb https://download.jitsi.org stable/' > /etc/apt/sources.list.d/jitsi-stable.list
-wget -qO - https://download.jitsi.org/jitsi-key.gpg.key | apt-key add -
+wget -qO - https://download.jitsi.org/jitsi-key.gpg.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/jitsi.gpg
 ```
 
 Then update your package list:
 
-`apt-get update`
+```bash
+apt-get update
+```
 
-Depending on how simple and minimal your operating system is, you may receive an error from this repository. You need an additional package to support https repositories. After that update your package list again:
+Depending on how simple and minimal your operating system is, you may receive an error from this repository. You need an additional package to support HTTPS repositories. After that, update your package list again:
 
-```console
+```bash
 apt-get install apt-transport-https
 apt-get update
 ```
@@ -61,111 +63,112 @@ apt-get update
 
 If this server is for jitsi-meet only, then you should set the hostname with `hostnamectl set-hostname talk`.  Also edit the hosts file under `/etc/hosts` and replace the default with the chosen FQDN, in this tutorial `talk.example.com`.
 
-## Automatic Installation
+## Step 4 - Jitsi Installation
+
+Choose one of the following installation options:
+
+* [Automatic installation](#step-41---automatic-installation)
+* [Manual installation](#step-42---manual-installation)
+
+### Step 4.1 - Automatic Installation
 
 Jitsi Meet can install and configure a webserver and certificates itself. If you do not have any existing setup on this machine yet, you can use these steps.  
 Otherwise scroll down to the manual installation.
 
-### Step 4 - Install Jitsi Meet
+* **Install Jitsi Meet**
+  
+  Perform the jitsi-meet installation:
+  ```bash
+  apt-get install jitsi-meet -y
+  ```
+  During the installation process you need to enter your chosen domain name (not the example `talk.example.com`!). It will be used to configure the virtual host.
 
-Perform the jitsi-meet installation:
+<br>
 
-`apt-get install jitsi-meet -y`
+* **Register a certificate**
+  
+  Next we register Let's Encrypt certificates for TLS encryption.
+  Jitsi Meet also offers a script for this task. Simply run it:
+  ```bash
+  /usr/share/jitsi-meet/scripts/install-letsencrypt-cert.sh
+  ```
 
-During the installation process you need to enter your chosen domain name (not the example talk.example.com!). It will be used to configure the virtual host.
+Next, continue with "[Step 5](#step-5---additional-configuration)" below.
 
-### Step 5 - Register a certificate
-
-Next we register Let's Encrypt certificates for TLS encryption.
-Jitsi Meet also offers a script for this task. Simply run it:
-
-`/usr/share/jitsi-meet/scripts/install-letsencrypt-cert.sh`
-
-Continue now with Step 8 below.
-
-## Manual Installation
+### Step 4.2 - Manual Installation
 
 These steps describe the manual installation process.
 
-### Step 4 - Install a webserver
+<br>
 
-In case you already have a webserver installed you can skip this step. For performance reasons we install a webserver otherwise jitsi-meet will use a builtin java webserver called jetty.
+* **Install a webserver**
+  
+  In case you already have a webserver installed you can skip this step. For performance reasons we install a webserver otherwise jitsi-meet will use a builtin java webserver called jetty.
+  ```bash
+  apt-get install nginx -y
+  ```
 
-`apt-get install nginx -y`
+<br>
 
-### Step 5 - Register a certificate
+* **Register a certificate**
+  
+  Next we register Let's Encrypt certificates for TLS encryption. ork with this script at the moment).
+  
+  We will use [certbot](https://certbot.eff.org/) from [EFF](https://www.eff.org/) for the Let's Encrypt certificates.
+  ```bash
+  apt-get install snapd
+  snap install --classic certbot
+  ln -s /snap/bin/certbot /usr/bin/certbot
+  ```
+  Time to register your certificate (don't forget to replace the email and domain with your certificate):
+  ```bash
+  certbot certonly --nginx --rsa-key-size 4096 -m holu@example.com -d talk.example.com
+  ```
 
-Next we register Let's Encrypt certificates for TLS encryption. ork with this script at the moment).
+<br>
 
-We will use [certbot](https://certbot.eff.org/) from [EFF](https://www.eff.org/) for the Let's Encrypt certificates.
+* **Install Jitsi Meet**
+  
+  Finally we can install jitsi-meet on our server.
+  ```bash
+  apt-get install jitsi-meet -y
+  ```
+  During the installation process you need to enter your chosen domain name (not the example `talk.example.com`!) and select the option to generate a self-signed certificate.
+  
+  We let the installer generate the certificate but won't use it.
 
-```console
-wget https://dl.eff.org/certbot-auto
-wget -N https://dl.eff.org/certbot-auto.asc
+<br>
 
-apt-get install gnupg2 -y # needed to receive and validate the certificate
+* **Modify shipped nginx configuration**
+  
+  The jitsi-meet package ships with an nginx configuration. It is located under `/etc/nginx/sites-available/talk.example.com.conf`.
+  
+  What do we need to change? Please note that the steps below are only minimal required changes, you can tweak a lot more in this nginx configuration.
+  
+  <br>
+  
+  **SSL certificate**<br>
+  Remove the lines starting with ssl_certificate and ssl_certificate_key and add the following lines instead:
+  ```nginx
+  ssl_certificate /etc/letsencrypt/live/talk.example.com/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/talk.example.com/privkey.pem;
+  ssl_trusted_certificate /etc/letsencrypt/live/talk.example.com/chain.pem;
+  ```
+    
+  <br>
+  
+  **IPv6 Support** (optional)<br>
+  Depending on your operating system and the Jitsi Meet version you install, the shipped nginx configuration does not support IPv6. If your server does, you can add IPv6 support with the following:<br>
+  First add `listen [::]:80;` below `listen 80;`.<br>
+  Then add `listen [::]:443 ssl;` below `listen 443 ssl;`.
+    
+  <br>
+  
+  **TLS configuration** (optional)<br>
+  If your operating system is a recent and up-to-date version, you should also modify the TLS configuration.<br>
+  Replace the line starting with `ssl_protocols` with `ssl_protocols TLSv1.2 TLSv1.3;`
 
-gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
-```
-
-The last line should be the following: `gpg: Good signature from "Let's Encrypt Client Team <letsencrypt-client@eff.org>" [ultimate]`. If not, please check again if you have downloaded the correct key. Do *NOT* use the downloaded file if the signature is not valid.
-
-Mark certbot executable and install it:
-
-```console
-chmod a+x ./certbot-auto
-mv ./certbot-auto /usr/local/bin/certbot
-```
-
-Time to register your certificate (don't forget to replace the email and domain with your certificate):
-
-`certbot certonly --nginx --rsa-key-size 4096 -m holu@example.com -d talk.example.com`
-
-### Step 6 - Install Jitsi Meet
-
-Finally we can install jitsi-meet on our server.
-
-`apt-get install jitsi-meet -y`
-
-During the installation process you need to enter your chosen domain name (not the example talk.example.com!) and select the option to generate a self-signed certificate.
-
-We let the installer generate the certificate but won't use it.
-
-### Step 7 - Modify shipped nginx configuration
-
-The jitsi-meet package ships with an nginx configuration. It is located under `/etc/nginx/sites-available/talk.example.com.conf`.
-
-What do we need to change? Please note that the steps below are only minimal required changes, you can tweak a lot more in this nginx configuration.
-
-#### Step 7.1 SSL certificate
-
-Remove the lines starting with ssl_certificate and ssl_certificate_key and add the following lines instead:
-
-```nginx
-ssl_certificate /etc/letsencrypt/live/talk.example.com/fullchain.pem;
-ssl_certificate_key /etc/letsencrypt/live/talk.example.com/privkey.pem;
-ssl_trusted_certificate /etc/letsencrypt/live/talk.example.com/chain.pem;
-```
-
-#### Step 7.2 IPv6 Support (optional)
-
-Depending on your operating system and the Jitsi Meet version you install, the shipped nginx configuration does not support IPv6. If your server does, you can add IPv6 support with the following:
-
-First add `listen [::]:80;` below `listen 80;`.  
-Then add `listen [::]:443 ssl;` below `listen 443 ssl;`.
-
-#### Step 7.3 TLS configuration (optional)
-
-If your operating system is a recent and up to date version you should also modify the TLS configuration.
-
-Replace the line starting with `ssl_protocols` with
-
-```nginx
-ssl_protocols TLSv1.2 TLSv1.3;
-```
-
-### Step 8 - Additional configuration
+## Step 5 - Additional configuration
 
 Open `/etc/jitsi/meet/talk.example.com-config.js`:
 
@@ -181,10 +184,13 @@ You should add more than one STUN server under `stunServers:` in case one of the
 
 Of course the best solution would be to [host your own STUN server](https://community.hetzner.com/tutorials/install-turn-stun-server-on-debian-ubuntu-with-coturn).
 
-## Step 9 - Restart all services
+## Step 6 - Restart all services
 
 Restart all services to be sure all configuration changes are applied:
-`systemctl restart nginx.service jicofo.service jitsi-videobridge2.service`
+
+```bash
+systemctl restart nginx.service jicofo.service jitsi-videobridge2.service
+```
 
 In case you get an error during room creation, reboot your server and try again.
 

--- a/tutorials/prosody-on-debian9/01.en.md
+++ b/tutorials/prosody-on-debian9/01.en.md
@@ -35,32 +35,24 @@ What you will need at least:
 
 All commands are executed by default as root user.
 
-You should have a basic installation and SSH access. Make sure your SSH Login is secured.
+You should have a basic installation and SSH access. Make sure your SSH login is secured.
 We do *not* setup any firewall in this tutorial. After the installation you can find open ports with `netstat -tulpen` and restrict them if you want.
 
-The server will be for real on xmpp.example.com. The XMPP-IDs are still user@example.com.
-To make it more easier later we will also point example.com to the server. You do not have to do this, just note the steps during certificate creation.
+The server will be for real on xmpp.example.com. The XMPP-IDs are still `user@example.com`.
+To make it easier later we will also point example.com to the server. You do not have to do this, just note the steps during certificate creation.
 
-In this tutorial the server has following IP addresses:
-IPv4: `10.0.0.1`
-IPv6: `2001:db8:1234::1`
+**Example terminology**
 
-Your XMPP-ID (username) will be `holu`.
-
-File Upload: xmpp.example.com
-
-MUC (Multi User Chat): conference.example.com (others also use muc. or chat.)
-
-Pubsub: pubsub.example.com
-
-Proxy: proxy.example.com
-
-User Directory (VJUD): vjud.example.com
-
-E-Mail addresses or aliases used as abuse, contact and security
-abuse@example.com, support@example.com, security@example.com
-
-Your admin E-Mail address will be: holu@example.com
+* Server IPv4: `10.0.0.1`
+* Server IPv6: `2001:db8:1234::1`
+* XMPP-ID (username): `holu`.
+* File Upload: `xmpp.example.com`
+* MUC (Multi User Chat): `conference.example.com` (others also use `muc.` or `chat.`)
+* Pubsub: `pubsub.example.com`
+* Proxy: `proxy.example.com`
+* User Directory (VJUD): `vjud.example.com`
+* Email addresses or aliases: `abuse@example.com`, `support@example.com`, `security@example.com`
+* Admin email address: `holu@example.com`
 
 ## Step 1 - Setup DNS Records
 
@@ -98,7 +90,7 @@ _xmpp-server._tcp.conference.example.com. 14400 IN SRV 10 10 5269 xmpp.example.c
 First we add the official repository to get the latest ("trunk") versions
 
 ```bash
-wget https://prosody.im/files/prosody-debian-packages.key -O- | apt-key add -
+wget https://prosody.im/files/prosody-debian-packages.key -O- | gpg --dearmor | tee /etc/apt/trusted.gpg.d/prosody.gpg
 echo deb http://packages.prosody.im/debian $(lsb_release -sc) main | tee -a /etc/apt/sources.list.d/prosody.list
 ```
 
@@ -413,23 +405,18 @@ Component "vjud.example.com" "vjud"
 We will use [certbot](https://certbot.eff.org/) from [EFF](https://www.eff.org/) for the Let's Encrypt certificates.
 
 ```bash
-wget https://dl.eff.org/certbot-auto
-wget -N https://dl.eff.org/certbot-auto.asc
-gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
+apt-get install snapd
+snap install --classic certbot
+ln -s /snap/bin/certbot /usr/bin/certbot
 ```
 
-The last line should be the following: `gpg: Good signature from "Let's Encrypt Client Team <letsencrypt-client@eff.org>" [ultimate]`.
-If not, please check again if you have downloaded the correct key. Do *NOT* use the downloaded file if they key does not match.
-
 ```bash
-chmod a+x ./certbot-auto
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d example.com
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d xmpp.example.com
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d conference.example.com
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d proxy.example.com
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d pubsub.example.com
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d vjud.example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d xmpp.example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d conference.example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d proxy.example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d pubsub.example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d vjud.example.com
 ```
 
 You will get an email 30 (and 7) days before the certificates expire to holu@example.com. You will also get a notification via XMPP 7 days before the certificates expire.

--- a/tutorials/prosody-on-debian9/01.it.md
+++ b/tutorials/prosody-on-debian9/01.it.md
@@ -44,26 +44,18 @@ In questo tutorial non impostiamo alcun firewall. Dopo l'installazione è possib
 Il server sarà reale su xmpp.example.example.com. Gli XMPP-ID sono ancora user@example.com.
 Per rendere più facile in seguito, punteremo anche example.com al server. Non c'è bisogno di farlo, basta annotare i passaggi durante la creazione del certificato.
 
-In questo tutorial il server ha i seguenti indirizzi IP:
-IPv4: `10.0.0.1`
-IPv6: `2001:db8:1234::1`
+**Esempio di terminologia:**
 
-Il tuo XMPP-ID (nome utente) sarà `holu`.
-
-Caricamento dei file: xmpp.example.com
-
-MUC (Multi User Chat): conference.example.com (altri usano anche muc. o chat.)
-
-Pubsub: pubsub.example.com
-
-Proxy: proxy.example.com
-
-Elenco utenti (VJUD): vjud.example.com
-
-Indirizzi e-mail o pseudonimi utilizzati come abuso, contatto e sicurezza
-abuse@example.com, support@example.com, security@example.com
-
-Il tuo indirizzo e-mail dell'amministratore sarà: holu@example.com
+* Server IPv4: `10.0.0.1`
+* Server IPv6: `2001:db8:1234::1`
+* XMPP-ID (nome utente): `holu`
+* Caricamento dei file: `xmpp.example.com`
+* MUC (Multi User Chat): `conference.example.com` (altri usano anche `muc.` o `chat.`)
+* Pubsub: `pubsub.example.com`
+* Proxy: `proxy.example.com`
+* Elenco utenti (VJUD): `vjud.example.com`
+* Indirizzi e-mail o pseudonimi: `abuse@example.com`, `support@example.com`, `security@example.com`
+* E-mail dell'amministratore: `holu@example.com`
 
 ## Passo 1 - Impostazione dei record DNS
 
@@ -101,7 +93,7 @@ _xmpp-server._tcp.conference.example.com. 14400 IN SRV 10 10 5269 xmpp.example.c
 Per prima cosa aggiungiamo il repository ufficiale per ottenere le ultime versioni ("trunk")
 
 ```bash
-wget https://prosody.im/files/prosody-debian-packages.key -O- | apt-key add -
+wget https://prosody.im/files/prosody-debian-packages.key -O- | gpg --dearmor | tee /etc/apt/trusted.gpg.d/prosody.gpg
 echo deb http://packages.prosody.im/debian $(lsb_release -sc) main | tee -a /etc/apt/sources.list.d/prosody.list
 ```
 
@@ -409,23 +401,18 @@ Component "vjud.example.com" "vjud"
 Utilizzeremo [certbot](https://certbot.eff.org/) da [EFF](https://www.eff.org/) per i certificati Let's Encrypt.
 
 ```bash
-wget https://dl.eff.org/certbot-auto
-wget -N https://dl.eff.org/certbot-auto.asc
-gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
+apt-get install snapd
+snap install --classic certbot
+ln -s /snap/bin/certbot /usr/bin/certbot
 ```
 
-L'ultima riga dovrebbe essere la seguente: `gpg: Good signature from "Let's Encrypt Client Team <letsencrypt-client@eff.org>" [ultimate]`.
-In caso contrario, controlla nuovamente se hai scaricato la chiave corretta. Non utilizzare il file scaricato se la chiave non corrisponde.
-
 ```bash
-chmod a+x ./certbot-auto
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d example.com
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d xmpp.example.com
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d conference.example.com
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d proxy.example.com
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d pubsub.example.com
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d vjud.example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d xmpp.example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d conference.example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d proxy.example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d pubsub.example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d vjud.example.com
 ```
 
 Riceverai un'e-mail 30 (e 7) giorni prima della scadenza dei certificati a holu@example.com. Riceverai anche una notifica via XMPP 7 giorni prima della scadenza dei certificati.

--- a/tutorials/prosody-on-debian9/01.ru.md
+++ b/tutorials/prosody-on-debian9/01.ru.md
@@ -41,26 +41,18 @@ Prosody это современный и широко известный xmpp-с
 Сервер будет доступен по адресу xmpp.example.com. Идентификаторы пользователей будут выглядеть так: user@example.com.
 Чтобы немного облегчить предстоящую работу мы также направим example.com на сервер. Вы не обязаны это делать, просто обратите внимание на действия во время создания сертификата.
 
-В этом руководстве сервер имеет следующие IP-адреса:
-IPv4: `10.0.0.1`
-IPv6: `2001:db8:1234::1`
+**Пример терминологии**
 
-Ваш XMPP-ID (имя пользователя) будет `holu`.
-
-Загрузка файлов: xmpp.example.com
-
-MUC (Multi User Chat — многопользовательский чат): conference.example.com (другие также используют muc. или chat.)
-
-Pubsub: pubsub.example.com
-
-Прокси: proxy.example.com
-
-Каталог пользователей (VJUD): vjud.example.com
-
-Адреса электронной почты или псевдонимы, используемые для связи на тему жалоб, контактов и  безопасности
-abuse@example.com, support@example.com, security@example.com
-
-Адрес электронной почты администратора: holu@example.com
+* Cервер IPv4: `10.0.0.1`
+* Cервер IPv6: `2001:db8:1234::1`
+* Ваш XMPP-ID (имя пользователя) будет `holu`
+* Загрузка файлов: `xmpp.example.com`
+* MUC (Multi User Chat — многопользовательский чат): `conference.example.com` (другие также используют `muc.` или `chat.`)
+* Pubsub: `pubsub.example.com`
+* Прокси: `proxy.example.com`
+* Каталог пользователей (VJUD): `vjud.example.com`
+* Адреса электронной почты или псевдонимы: `abuse@example.com`, `support@example.com`, `security@example.com`
+* Адрес электронной почты администратора: `holu@example.com`
 
 ## Шаг 1 — Настройка DNS-записей
 
@@ -98,7 +90,7 @@ _xmpp-server._tcp.conference.example.com. 14400 IN SRV 10 10 5269 xmpp.example.c
 Сначала добавьте официальный репозиторий, чтобы получить наиболее свежую версию («trunk»)
 
 ```bash
-wget https://prosody.im/files/prosody-debian-packages.key -O- | apt-key add -
+wget https://prosody.im/files/prosody-debian-packages.key -O- | gpg --dearmor | tee /etc/apt/trusted.gpg.d/prosody.gpg
 echo deb http://packages.prosody.im/debian $(lsb_release -sc) main | tee -a /etc/apt/sources.list.d/prosody.list
 ```
 
@@ -413,23 +405,18 @@ Component "vjud.example.com" "vjud"
 Для Let's Encrypt сертификатов будем использовать [certbot](https://certbot.eff.org/) от [EFF](https://www.eff.org/).
 
 ```bash
-wget https://dl.eff.org/certbot-auto
-wget -N https://dl.eff.org/certbot-auto.asc
-gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
+apt-get install snapd
+snap install --classic certbot
+ln -s /snap/bin/certbot /usr/bin/certbot
 ```
 
-Последняя строка должна быть такой: `gpg: Good signature from "Let's Encrypt Client Team <letsencrypt-client@eff.org>" [ultimate]`.
-Если это не так, пожалуйста, проверьте еще раз, загрузили ли вы правильный ключ. *Не* используйте загруженный файл, если ключ не совпадает.
-
 ```bash
-chmod a+x ./certbot-auto
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d example.com
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d xmpp.example.com
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d conference.example.com
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d proxy.example.com
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d pubsub.example.com
-./certbot-auto certonly --standalone --rsa-key-size 4096 -m holu@example.com -d vjud.example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d xmpp.example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d conference.example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d proxy.example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d pubsub.example.com
+certbot certonly --standalone --rsa-key-size 4096 -m holu@example.com -d vjud.example.com
 ```
 
 За 30 (и 7) дней до истечения срока действия сертификатов вы получите электронное письмо на holu@example.com. Кроме этого, вы также получите уведомление через XMPP за 7 дней до истечения срока действия сертификатов.


### PR DESCRIPTION
Fix #771 
Fix #772 