### PR TITLE
Fix typo in ai-chatbot-with-ollama-and-open-webui/de

### DIFF
--- a/tutorials/ai-chatbot-with-ollama-and-open-webui/01.de.md
+++ b/tutorials/ai-chatbot-with-ollama-and-open-webui/01.de.md
@@ -53,7 +53,7 @@ Um Ollama selbst zu installieren, folge diesen Schritten:
 
 <br>
 
-* Lade Ollana herunter und erstelle einen neuen Benutzer namens "ollama".
+* Lade Ollama herunter und erstelle einen neuen Benutzer namens "ollama".
   ```bash
   sudo curl -L https://ollama.ai/download/ollama-linux-amd64 -o /usr/bin/ollama
   sudo chmod +x /usr/bin/ollama


### PR DESCRIPTION
There is a wrong spelling of Ollama in the German version.