### PR TITLE
Show Markdown in the language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable


### PR DESCRIPTION
Markdown files are [ignored by default](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#detectable) in the language stats, but for this repository it's a main language. This will include `*.md` files to the language stats. 

I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: wpdevelopment11 wpdevelopment11@gmail.com