### PR TITLE
shopware: update php and use composer instead of webinstaller

### DIFF
--- a/tutorials/install-shopware-6/01.en.md
+++ b/tutorials/install-shopware-6/01.en.md
@@ -231,48 +231,49 @@ sudo -u www-data php bin/console cache:clear
 
 Now we can create a new systemd unit which interacts as worker. For that we have to create these two new files:
 
-* `/etc/systemd/system/shopware_consumer.service` - Consumes messages from queue.
-* `/etc/systemd/system/shopware_scheduled_task.service` - Runs scheduled tasks
+| File name                                             | Description                  |
+| ----------------------------------------------------- | ---------------------------- |
+| `/etc/systemd/system/shopware_consumer.service`       | Consumes messages from queue |
+| `/etc/systemd/system/shopware_scheduled_task.service` | Runs scheduled tasks         |
 
-```bash
-sudo nano /etc/systemd/system/shopware_consumer.service
-```
+* Add the first file:
+  ```bash
+  sudo nano /etc/systemd/system/shopware_consumer.service
+  ```
+  Add the following unit there:
+  ```ini
+  [Unit]
+  Description=Shopware Consumer
+  After=mysql.service
+  
+  [Service]
+  Type=simple
+  User=www-data
+  Restart=always
+  ExecStart=/usr/bin/php /var/www/html/bin/console messenger:consume --time-limit=60 --memory-limit=512M
+  ```
 
-Add the following unit there:
+<br>
 
-```ini
-[Unit]
-Description=Shopware Consumer
-After=mysql.service
-
-[Service]
-Type=simple
-User=www-data
-Restart=always
-ExecStart=/usr/bin/php /var/www/html/bin/console messenger:consume --time-limit=60 --memory-limit=512M
-```
-
-Now we set up the shopware scheduled tasks runner:
-
-```bash
-sudo nano /etc/systemd/system/shopware_scheduled_task.service
-```
-
-Add the following unit there:
-
-```ini
-[Unit]
-Description=Shopware Scheduled Task
-After=mysql.service
-
-[Service]
-Type=simple
-User=www-data
-Restart=always
-ExecStart=/usr/bin/php /var/www/html/bin/console scheduled-task:run --time-limit=60 --memory-limit=512M
-```
+* Now we set up the shopware scheduled tasks runner:
+  ```bash
+  sudo nano /etc/systemd/system/shopware_scheduled_task.service
+  ```
+  Add the following unit there:
+  ```ini
+  [Unit]
+  Description=Shopware Scheduled Task
+  After=mysql.service
+  
+  [Service]
+  Type=simple
+  User=www-data
+  Restart=always
+  ExecStart=/usr/bin/php /var/www/html/bin/console scheduled-task:run --time-limit=60 --memory-limit=512M
+  ```
 
 The processes will have a time limit of 60s and memory limit of 512m. After reaching a limit it will stop and the unit will restart the process.
+
 Now we can start the workers with following commands:
 
 ```bash

--- a/tutorials/install-shopware-6/01.en.md
+++ b/tutorials/install-shopware-6/01.en.md
@@ -32,7 +32,7 @@ Shopware is a trendsetting ecommerce platform to power your online business. It 
 
 ## Step 1 - Installing Nginx, MySQL and PHP-FPM
 
-Before begin installation of packages, we will add the [Ubuntu PPA](https://launchpad.net/~ondrej/+archive/ubuntu/php) to install newer PHP versions:
+Before we begin with the installation of packages, we will add the [Ubuntu PPA](https://launchpad.net/~ondrej/+archive/ubuntu/php) to install newer PHP versions:
 
 ```bash
 sudo add-apt-repository ppa:ondrej/php
@@ -48,7 +48,7 @@ To confirm the installation, press enter and then all related packages will be i
 
 ## Step 2 - Creating a database and user for the Shopware database
 
-Shopware will need credentials to connect to the database. We will create a new MySQL user and a new MySQL Database. With the command `mysql` we start a new mysql session. In this MySQL session we create a new database named `shopware` using the following query:
+Shopware will need credentials to connect to the database. We will create a new MySQL user and a new MySQL Database. With the command `sudo mysql` we start a new mysql session. In this MySQL session we create a new database named `shopware` using the following query:
 
 ```sql
 CREATE DATABASE shopware;
@@ -66,6 +66,8 @@ As a last step we will need to give the new user privilege to access our new dat
 GRANT ALL PRIVILEGES ON shopware.* TO 'shopware'@'localhost';
 ```
 
+We can end the mysql session by entering `exit`.
+
 ## Step 3 - Configuring PHP/PHP-FPM
 
 To match the requirements of Shopware 6, we will need to adjust some `php.ini` settings. The `php.ini` used by PHP-FPM can be found under `/etc/php/8.3/fpm/php.ini`. We can open it with an editor like `nano`:
@@ -80,7 +82,7 @@ Next we will change the upload limits for files. Search again, this time for `po
 
 This will allow us to upload larger files to the media manager. We can save the file with `STRG` + `O` and leave the editor with `STRG` + `X`.
 
-After configuring we can restart the PHP-FPM server using the command:
+After configuring, we can restart the PHP-FPM server using the command:
 
 ```bash
 sudo systemctl restart php8.3-fpm
@@ -102,6 +104,8 @@ sudo nano /etc/nginx/sites-enabled/default
 
 Replace the content with:
 
+> Replace `example.com` with your own domain.
+
 ```nginx
 server {
     listen 80;
@@ -116,7 +120,7 @@ server {
     client_max_body_size 32M;
 
     # Where the code is located
-    root /var/www/html;
+    root /var/www/html/public;
 
     location /recovery/update/ {
         location /recovery/update/assets {
@@ -159,8 +163,8 @@ After configuring MySQL, PHP and Nginx we start the installation of Shopware. We
 First we install the Composer package manager by downloading it to `/usr/local/bin`:
 
 ```bash
-wget https://getcomposer.org/download/latest-stable/composer.phar -O /usr/local/bin/composer
-chmod +x /usr/local/bin/composer
+sudo wget https://getcomposer.org/download/latest-stable/composer.phar -O /usr/local/bin/composer
+sudo chmod +x /usr/local/bin/composer
 ```
 
 After installing Composer, we switch to the `www-data` user to install Shopware using Composer.
@@ -187,7 +191,7 @@ composer create-project shopware/production .
 
 Now we can access the installation wizard using our domain. For example:
 
-```
+```http
 https://example.com/
 ```
 
@@ -197,13 +201,13 @@ In the Database Configuration we can use the configured credentials:
 
 ![Database Configuration](images/db_config.png)
 
-After finishing the wizard and the first run wizard the Shop is ready for use.
+After finishing the wizard and the first run wizard, the Shop is ready for use.
 
 ![Administration](images/admin.png)
 
 ## Step 6 - Configuring background queue worker
 
-In the default configuration Shopware 6 will run a browser worker to consume all background tasks. This will block PHP-FPM processes for 30s. When multiple tabs / users are working at the same time in the administration, it will slow down page speed. To fix these issues we will configure a background worker using systemd.
+In the default configuration, Shopware 6 will run a browser worker to consume all background tasks. This will block PHP-FPM processes for 30s. When multiple tabs / users are working at the same time in the administration, it will slow down page speed. To fix these issues, we will configure a background worker using systemd.
 
 To disable the current browser worker, we will create a new file `config/packages/shopware.yaml`:
 
@@ -219,7 +223,7 @@ shopware:
         enable_admin_worker: false
 ```
 
-To activate the config we need to clear the cache:
+To activate the config, we need to clear the cache:
 
 ```bash
 sudo -u www-data php bin/console cache:clear
@@ -284,7 +288,7 @@ To configure Let's Encrypt for our new virtual host in Nginx, please follow the 
 
 ## Conclusion
 
-By following this tutorial you will have a shop running with Shopware 6. The next steps would be to start adding products and configuring payment providers.
+By following this tutorial you will have a shop running with Shopware 6. The next steps would be to start adding products and configuring payment providers. To login as admin, you can go to `example.com/admin`.
 
 <!---
 

--- a/tutorials/install-shopware-6/01.en.md
+++ b/tutorials/install-shopware-6/01.en.md
@@ -32,16 +32,16 @@ Shopware is a trendsetting ecommerce platform to power your online business. It 
 
 ## Step 1 - Installing Nginx, MySQL and PHP-FPM
 
-Before begin installation of packages, we will update the local packages index using the following command:
+Before begin installation of packages, we will add the [Ubuntu PPA](https://launchpad.net/~ondrej/+archive/ubuntu/php) to install newer PHP versions:
 
 ```bash
-sudo apt update
+sudo add-apt-repository ppa:ondrej/php
 ```
 
 We can now install Nginx, MySQL and PHP-FPM with the following command:
 
 ```bash
-sudo apt install unzip nginx php8.1-fpm php8.1-mysql php8.1-curl php8.1-gd php8.1-xml php8.1-zip php8.1-opcache php8.1-mbstring php8.1-intl php8.1-cli mysql-server-8.0
+sudo apt install unzip nginx php8.3-fpm php8.3-mysql php8.3-curl php8.3-gd php8.3-xml php8.3-zip php8.3-opcache php8.3-mbstring php8.3-intl php8.3-cli mysql-server-8.0
 ```
 
 To confirm the installation, press enter and then all related packages will be installed.
@@ -68,10 +68,10 @@ GRANT ALL PRIVILEGES ON shopware.* TO 'shopware'@'localhost';
 
 ## Step 3 - Configuring PHP/PHP-FPM
 
-To match the requirements of Shopware 6, we will need to adjust some `php.ini` settings. The `php.ini` used by PHP-FPM can be found under `/etc/php/8.1/fpm/php.ini`. We can open it with an editor like `nano`:
+To match the requirements of Shopware 6, we will need to adjust some `php.ini` settings. The `php.ini` used by PHP-FPM can be found under `/etc/php/8.3/fpm/php.ini`. We can open it with an editor like `nano`:
 
 ```bash
-sudo nano /etc/php/8.1/fpm/php.ini
+sudo nano /etc/php/8.3/fpm/php.ini
 ```
 
 We then search with `CTRL` + `W` for `memory_limit =` and set the value from 128 to 512.
@@ -83,13 +83,13 @@ This will allow us to upload larger files to the media manager. We can save the 
 After configuring we can restart the PHP-FPM server using the command:
 
 ```bash
-sudo systemctl restart php8.1-fpm
+sudo systemctl restart php8.3-fpm
 ```
 
 It should be also marked to start on boot:
 
 ```bash
-sudo systemctl enable php8.1-fpm
+sudo systemctl enable php8.3-fpm
 ```
 
 ## Step 4 - Configuring Nginx
@@ -140,7 +140,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_read_timeout 300s;
         client_body_buffer_size 128k;
-        fastcgi_pass unix:/run/php/php8.1-fpm.sock;
+        fastcgi_pass unix:/run/php/php8.3-fpm.sock;
     }
 }
 ```
@@ -156,26 +156,31 @@ sudo systemctl enable nginx
 
 After configuring MySQL, PHP and Nginx we start the installation of Shopware. We will install it to `/var/www/html`.
 
+First we install the Composer package manager by downloading it to `/usr/local/bin`:
+
 ```bash
+wget https://getcomposer.org/download/latest-stable/composer.phar -O /usr/local/bin/composer
+chmod +x /usr/local/bin/composer
+```
+
+After installing Composer, we switch to the `www-data` user to install Shopware using Composer.
+
+```bash
+sudo chown -R www-data:www-data /var/www/html
+sudo -u www-data bash
 cd /var/www/html
 ```
 
 Remove default file in this folder:
 
 ```bash
-sudo rm index.nginx-debian.html
+rm index.nginx-debian.html
 ```
 
-Download Shopware 6 (see [https://www.shopware.com/en/changelog/](https://www.shopware.com/en/changelog/) for latest versions):
+Download Shopware 6 :
 
 ```bash
-sudo wget https://github.com/shopware/web-installer/releases/latest/download/shopware-installer.phar.php
-```
-
-Correct permissions:
-
-```bash
-sudo chown -R www-data:www-data .
+composer create-project shopware/production .
 ```
 
 ---------
@@ -183,16 +188,8 @@ sudo chown -R www-data:www-data .
 Now we can access the installation wizard using our domain. For example:
 
 ```
-https://example.com/shopware-installer.phar.php
+https://example.com/
 ```
-
-After you downloaded a Shopware version, change the root from `/var/www/html;` to `/var/www/html/public;`:
-
-```bash
-sudo nano /etc/nginx/sites-enabled/default
-```
-
-Use `sudo systemctl restart nginx` to restart nginx and go back to the installation wizard.
 
 ![Wizard Start Page](images/wizard.png)
 


### PR DESCRIPTION
- Updated PHP to 8.3
- Using Composer to create the project, is much easier than using web installer