### PR TITLE
Correction to deploy nicegui

### DIFF
--- a/tutorials/deploy-nicegui/01.en.md
+++ b/tutorials/deploy-nicegui/01.en.md
@@ -194,9 +194,9 @@ server `uvicorn` under the hood. Our part of the work is to configure
 the `systemd` service `nicegui-test`. 
 The service `nicegui-test` will automatically run after restarts.
 
-Moreover, we will split the application and its deployment
-by using a little script `asgi.py`.
-The purpose of this script is to define the port.
+Moreover, we will split the application and its deployment by using a little script `asgi.py`.
+The script defines the port and splits the incoming requests (from different browsers or tabs)
+serving separate responses.
 
 - Create the file `nicegui-test/asgi.py` (next to `main.py`). The file `asgi.py` should contain
   

--- a/tutorials/deploy-nicegui/01.en.md
+++ b/tutorials/deploy-nicegui/01.en.md
@@ -204,7 +204,10 @@ The purpose of this script is to define the port.
   from main import main
   from nicegui import ui
   
-  main()
+  @ui.page('/')
+  def main_page() -> None:
+      main()
+  
   ui.run(port=5129)
   ```
 

--- a/tutorials/deploy-nicegui/01.en.md
+++ b/tutorials/deploy-nicegui/01.en.md
@@ -138,7 +138,7 @@ We will create a simple application with NiceGUI and see how it runs in developm
       with ui.scene(width=320, height=240) as scene:
           scene.spot_light(distance=100, intensity=0.6).move(-10, 0, 10)
           with scene.group() as group:
-              scene.sphere().move(-1.0, 0.0, 0.0)
+              scene.sphere().move(-1.0, 0.0, 0.0).draggable()
               scene.sphere().move(+2.0, 0.0, 0.0)
               group.rotate(30.0, 0.0, 0.0)
   
@@ -182,8 +182,9 @@ browser to see the screen.
 
 ![Development deployment in browser](images/dev.en.png)
 
-Note the `settings` icon, the matplotlib figure, and the interactive 3D scene with two unadorned spheres.
-You can interact with the scene (rotate, zoom, pan) with your mouse.  
+Note the `settings` icon, the matplotlib figure, and the interactive 3D scene with
+two unadorned spheres. One of the spheres (left) could be dragged with the mouse.
+Moreover, you could interact with the whole scene (rotate, zoom, pan) with your mouse. 
 
 ## Step 3 - Create the system service
 


### PR DESCRIPTION
This is a correction to my NiceGUI tutorial. The accepted version had a hidden deficiency in the script `asgi.py`. Namely, the served page is the same across different machines, browsers or browser tabs. As a matter of fact, the usual way of serving pages in NiceGUI is by using the `@ui.page` decorator, similarly to other web frameworks. I think it is worth to correct this unfortunate oversight on my part. The little correction will improve user experience.
