### PR TITLE
Add IPv6 in "How to protect a website with Cloudflare without exposing ports to the Internet"

### DIFF
--- a/tutorials/cloudflare-website-protect/01.en.md
+++ b/tutorials/cloudflare-website-protect/01.en.md
@@ -138,8 +138,10 @@ import json
 
 HETZNER_API_TOKEN = "YOUR_HETZNER_API_TOKEN"
 HETZNER_FIREWALL_ID = "YOUR_HETZNER_FIREWALL_ID"
-def get_cloudflare_ips():
-    response = requests.get('https://www.cloudflare.com/ips-v4')
+def get_cloudflare_ips(version):
+    url = "https://www.cloudflare.com/ips-v" + version
+    print("Getting IPs from " + url)
+    response = requests.get(url)
     if response.status_code == 200:
         return response.text.strip().split('\n')
     else:
@@ -177,8 +179,13 @@ def whitelist_ips_in_hetzner(ip_ranges):
         print("Failed to whitelist IPs in Hetzner Firewall", response.json())
 
 if __name__ == "__main__":
-    cloudflare_ips = get_cloudflare_ips()
-    whitelist_ips_in_hetzner(cloudflare_ips)
+    cloudflare_ips_v4 = get_cloudflare_ips("4")
+    cloudflare_ips_v6 = get_cloudflare_ips("6")
+    combined_ips = cloudflare_ips_v4 + cloudflare_ips_v6
+    print("Whitelisting these IPs:")
+    for ip in combined_ips:
+        print(ip)
+    whitelist_ips_in_hetzner(combined_ips)
 ```
 
 ## Step 5 - Running and automating the script


### PR DESCRIPTION
Use the suggested fix from the issue #832 to include v6 IPs. 