### PR TITLE
tutorials/how-to-install-archlinux-on-a-hetzner-cloud-server: update bootstrap tarball extension

### DIFF
--- a/tutorials/how-to-install-archlinux-on-a-hetzner-cloud-server/01.en.md
+++ b/tutorials/how-to-install-archlinux-on-a-hetzner-cloud-server/01.en.md
@@ -40,21 +40,21 @@ This will provide us with the necessary tools for an arch installation.
 While we are at it we will also get the corresponding signature and verify the image before continuing our installation.
 
 ```shell
-root@rescue ~ # curl -LO 'https://geo.mirror.pkgbuild.com/iso/latest/archlinux-bootstrap-x86_64.tar.gz'
+root@rescue ~ # curl -LO 'https://geo.mirror.pkgbuild.com/iso/latest/archlinux-bootstrap-x86_64.tar.zst'
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100  164M  100  164M    0     0   115M      0  0:00:01  0:00:01 --:--:--  115M
 ```
 
 ```shell
-root@rescue ~ # curl -LO 'https://archlinux.org/iso/latest/archlinux-bootstrap-x86_64.tar.gz.sig'
+root@rescue ~ # curl -LO 'https://archlinux.org/iso/latest/archlinux-bootstrap-x86_64.tar.zst.sig'
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100   331  100   331    0     0   4728      0 --:--:-- --:--:-- --:--:--  4728
 ```
 
 ```shell
-root@rescue ~ # gpg --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify archlinux-bootstrap-x86_64.tar.gz.sig
+root@rescue ~ # gpg --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify archlinux-bootstrap-x86_64.tar.zst.sig
 gpg: Signature made Tue 01 Mar 2022 04:54:14 PM CET
 gpg:                using RSA key 4AA4767BBC9C4B1D18AE28B77F2D434B9741E8AC
 gpg:                issuer "pierre@archlinux.de"
@@ -71,7 +71,7 @@ Primary key fingerprint: 4AA4 767B BC9C 4B1D 18AE  28B7 7F2D 434B 9741 E8AC
 When no error occurs we can move on to unpacking the image.
 
 ```shell
-root@rescue ~ # tar xzf archlinux-bootstrap-x86_64.tar.gz
+root@rescue ~ # tar xf archlinux-bootstrap-x86_64.tar.zst
 tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.security.capability'
 tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.security.capability'
 ```

--- a/tutorials/how-to-install-archlinux-on-a-hetzner-cloud-server/01.ru.md
+++ b/tutorials/how-to-install-archlinux-on-a-hetzner-cloud-server/01.ru.md
@@ -40,21 +40,21 @@ cta: "cloud"
 Пока мы это делаем, мы также получим соответствующую подпись и проверим образ, прежде чем продолжить установку.
 
 ```shell
-root@rescue ~ # curl -LO 'https://geo.mirror.pkgbuild.com/iso/latest/archlinux-bootstrap-x86_64.tar.gz'
+root@rescue ~ # curl -LO 'https://geo.mirror.pkgbuild.com/iso/latest/archlinux-bootstrap-x86_64.tar.zst'
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100  164M  100  164M    0     0   115M      0  0:00:01  0:00:01 --:--:--  115M
 ```
 
 ```shell
-root@rescue ~ # curl -LO 'https://archlinux.org/iso/latest/archlinux-bootstrap-x86_64.tar.gz.sig'
+root@rescue ~ # curl -LO 'https://archlinux.org/iso/latest/archlinux-bootstrap-x86_64.tar.zst.sig'
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100   331  100   331    0     0   4728      0 --:--:-- --:--:-- --:--:--  4728
 ```
 
 ```shell
-root@rescue ~ # gpg --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify archlinux-bootstrap-x86_64.tar.gz.sig
+root@rescue ~ # gpg --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify archlinux-bootstrap-x86_64.tar.zst.sig
 gpg: Signature made Tue 01 Mar 2022 04:54:14 PM CET
 gpg:                using RSA key 4AA4767BBC9C4B1D18AE28B77F2D434B9741E8AC
 gpg:                issuer "pierre@archlinux.de"
@@ -71,7 +71,7 @@ Primary key fingerprint: 4AA4 767B BC9C 4B1D 18AE  28B7 7F2D 434B 9741 E8AC
 Если ошибок не обнаруженно мы можем приступить к распаковке архива.
 
 ```shell
-root@rescue ~ # tar xzf archlinux-bootstrap-x86_64.tar.gz
+root@rescue ~ # tar xf archlinux-bootstrap-x86_64.tar.zst
 tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.security.capability'
 tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.security.capability'
 ```


### PR DESCRIPTION
Starting with the 2024.05.01 release, the Arch Linux bootstrap tarball uses zstd compression.

Related to https://gitlab.archlinux.org/archlinux/archiso/-/issues/130