### PR TITLE
Small adjustments to workflow script

### DIFF
--- a/.github/workflows/check-annual-update.yml
+++ b/.github/workflows/check-annual-update.yml
@@ -29,36 +29,33 @@ jobs:
           echo "| ------- | ------- | ------- |" >> summary-authors.md
           
           # Get all Markdown files
-          md_files=$(find ./tutorials -type f -name "*.en.md")
+          md_files=$(find ./tutorials -type f -name "*.en.md" | sort)
+
+          touch orphaned
 
           # Run the commands below for each individual file
           for file in $md_files; do 
-            
             # Extract metadata from Markdown file
-            echo §file
-            metadata=$(head -n 20 "$file" | awk '/^---$/{f=!f;next}f' | yq eval -o=json -)
-            echo $metadata
+            metadata=$(head -n 20 "$file" | awk '/^---$/{f=!f;next}f' | yq -o=json)
 
-            # Extract date/path/title/author from the metadata
-            tutorial_date=$(echo "$metadata" | yq eval '.date' -)
-            path=$(echo "$metadata" | yq eval '.slug' -)
-            title=$(echo "$metadata" | yq eval '.title' -)
-            author=$(echo "$metadata" | yq eval '.author_link' - | sed 's|^https://github.com/||')
+            # Extract month/path/title/author from the metadata
+            tutorial_month=$(echo "$metadata" | yq '.date' | cut -d '-' -f2)
+            path=$(echo "$metadata" | yq '.slug')
+            title=$(echo "$metadata" | yq '.title')
+            author=$(echo "$metadata" | yq '.author_link' | sed 's|https://github.com/|@|')
             
             # Compare CURRENT_MONTH with tutorial_month
-            tutorial_month=$(echo $tutorial_date | cut -d'-' -f2)
             if [ "$CURRENT_MONTH" == "$tutorial_month" ]; then
-                # Check if the author is "hetzneronline"
-                if [ "$author" == "hetzneronline" ]; then
-                    echo "| $path | $title | Hetzner |" >> summary-authors.md
+                if [ "$author" == '@hetzneronline' ]; then author=Hetzner; fi
+                row="| [$path](https://github.com/hetzneronline/community-content/tree/master/tutorials/$path/01.en.md) | $title | $author |"
+                if [ -z "$author" ]; then
+                    echo "$row" >> orphaned
                 else
-                    echo "| $path | $title | @$author |" >> summary-authors.md
+                    echo "$row" >> summary-authors.md
                 fi
-            else
-              continue
             fi
           done
-
+          cat orphaned >> summary-authors.md
           cat summary-authors.md >> $GITHUB_STEP_SUMMARY
 
       - name: Create a new issue


### PR DESCRIPTION
* The table is sorted by path column.
* The path is clickable now.
* If the author doesn't have GitHub account `@` will not be present.
* The tutorials without an author will be always at the bottom.

You can run this script locally, but you need to run `rm summary-authors.md orphaned` after each run and provide `CURRENT_MONTH` variable.

I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: wpdevelopment11 wpdevelopment11@gmail.com