### PR TITLE
Normalize author URLs

### DIFF
--- a/tutorials/a-basic-guide-to-php-symfony/01.en.md
+++ b/tutorials/a-basic-guide-to-php-symfony/01.en.md
@@ -7,7 +7,7 @@ title: "A basic guide to PHP Symfony - Setup"
 short_description: "Symfony is a powerful PHP framework. In this tutorial series we will take a look at many parts of it. In this part we are going to setup a new symfony project."
 tags: ["Development", "Lang:PHP", "Lang:HTML", "Lang:Twig"]
 author: "Moritz Fromm"
-author_link: "https://github.com/frommMoritz/"
+author_link: "https://github.com/frommMoritz"
 author_img: "https://avatars.githubusercontent.com/u/34239260"
 author_description: ""
 language: "en"

--- a/tutorials/a-basic-guide-to-php-symfony/02.en.md
+++ b/tutorials/a-basic-guide-to-php-symfony/02.en.md
@@ -7,7 +7,7 @@ title: "A basic guide to PHP Symfony - Routes, templates and controllers"
 short_description: "Symfony is a powerful PHP Framework. In this tutorial series we will take a look at many parts of it. In this part we are going to learn more about routes, templates and controllers."
 tags: ["Development", "Lang:PHP", "Lang:HTML", "Lang:Twig"]
 author: "Moritz Fromm"
-author_link: "https://github.com/frommMoritz/"
+author_link: "https://github.com/frommMoritz"
 author_img: "https://avatars.githubusercontent.com/u/34239260"
 author_description: " "
 language: "en"

--- a/tutorials/docker-ipv6-securely/01.en.md
+++ b/tutorials/docker-ipv6-securely/01.en.md
@@ -7,7 +7,7 @@ title: "IPv6 on Docker securely"
 short_description: "This tutorial will help you setup Docker with IPv6 in a secure way."
 tags: ["docker", "ipv6", "proxmox"]
 author: "Rodrigo A. Diaz Leven"
-author_link: "https://github.com/bruj0/"
+author_link: "https://github.com/bruj0"
 author_img: "https://avatars1.githubusercontent.com/u/2046474"
 author_description: ""
 language: "en"

--- a/tutorials/how-to-export-and-import-mysql-db/01.en.md
+++ b/tutorials/how-to-export-and-import-mysql-db/01.en.md
@@ -7,7 +7,7 @@ title: "Importing and exporting a MySQL/MariaDB Database"
 short_description: "A guide on how to import and export a MySQL/MariaDB Database"
 tags: ["MySQL", "MariaDB", "Export", "Import", "Database"]
 author: "Jean F."
-author_link: "https://github.com/Techout592/"
+author_link: "https://github.com/Techout592"
 author_img: "https://avatars.githubusercontent.com/u/77097756?v=4"
 author_description: "Hi there, I'm Techout. A full-stack developer, system admin, and a designer."
 language: "en"

--- a/tutorials/install-mattermost-on-managed-server/01.en.md
+++ b/tutorials/install-mattermost-on-managed-server/01.en.md
@@ -7,7 +7,7 @@ title: "Install Mattermost on Managed Server"
 short_description: "This tutorial will show you how to install Mattermost on a Managed Server."
 tags: ["Managed Server", "Mattermost"]
 author: "Lukas Heinrich"
-author_link: "https://github.com/luki9100/"
+author_link: "https://github.com/luki9100"
 author_img: "https://avatars.githubusercontent.com/u/26790273?v=4"
 author_description: ""
 language: "en"

--- a/tutorials/installing-aapanel/01.en.md
+++ b/tutorials/installing-aapanel/01.en.md
@@ -7,7 +7,7 @@ title: "A simple installation guide for aaPanel"
 short_description: "aaPanel - Free and Open source Hosting Control Panel"
 tags: ["Development", "Lang:JS", "Lang:HTML", "Lang:CSS", "Nginx", "apache", "Web", "Hosting", "Panel"]
 author: "Jean F."
-author_link: "https://github.com/Techout592/"
+author_link: "https://github.com/Techout592"
 author_img: "https://avatars.githubusercontent.com/u/77097756?v=4"
 author_description: "Hi there, I'm Techout. A full-stack developer, system admin, and a designer."
 language: "en"

--- a/tutorials/installing-nginx-proxy-manager/01.en.md
+++ b/tutorials/installing-nginx-proxy-manager/01.en.md
@@ -7,7 +7,7 @@ title: "A simple installation guide for Nginx Proxy Manager"
 short_description: "Nginx Proxy Manager - Expose your services easily and securely."
 tags: ["Development", "Lang:JS", "Lang:HTML", "Lang:CSS", "Nginx", "Web", "Reverse Proxy", "Docker Tools"]
 author: "Jean F."
-author_link: "https://github.com/Techout592/"
+author_link: "https://github.com/Techout592"
 author_img: "https://avatars.githubusercontent.com/u/77097756?v=4"
 author_description: "Hi there, I'm Techout. A full-stack developer, system admin, and a designer."
 language: "en"

--- a/tutorials/migrate-proxmox-to-new-server/01.en.md
+++ b/tutorials/migrate-proxmox-to-new-server/01.en.md
@@ -7,7 +7,7 @@ title: "Migrate Proxmox to a new server with minimal downtime! :+1:"
 short_description: "Move all Proxmox guests to a new server with minimal downtime and transfer IP subnet"
 tags: ["Proxmox", "Debian", "Server upgrade", "Migration"]
 author: "Pierre Fagrell"
-author_link: "https://github.com/mrfrenzy/"
+author_link: "https://github.com/mrfrenzy"
 author_img: "https://avatars.githubusercontent.com/u/14068692?v=4"
 author_description: ""
 language: "en"


### PR DESCRIPTION
Trailing slash leads to an error here: https://github.com/hetzneronline/community-content/issues/862.

I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: wpdevelopment11 wpdevelopment11@gmail.com