### PR TITLE
Fix typo

### DIFF
--- a/tutorials/install-and-configure-ntp/01.de.md
+++ b/tutorials/install-and-configure-ntp/01.de.md
@@ -32,7 +32,7 @@ Gentoo:
 
 `emerge ntp`
 
-OpenSuSS:
+OpenSuSE:
 
 `zypper install ntp`
 


### PR DESCRIPTION
Fix typo introduced in https://github.com/hetzneronline/community-content/commit/7c052a6d3faf5f4a9e43ac28701252e6ca534661

I have read and understood the Contributor's Certificate of Origin available at the end of 
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Peter Lehmann <xgwq@xnee.net>