### PR TITLE
Update article for Debian 12

### DIFF
--- a/tutorials/install-lemp-stack-on-debian-12/01.en.md
+++ b/tutorials/install-lemp-stack-on-debian-12/01.en.md
@@ -1,10 +1,10 @@
 ---
 SPDX-License-Identifier: MIT
-path: "/tutorials/install-lemp-stack-on-debian-10"
-slug: "install-lemp-stack-on-debian-10"
+path: "/tutorials/install-lemp-stack-on-debian-12"
+slug: "install-lemp-stack-on-debian-12"
 date: "2019-07-31"
-title: "Install LEMP Stack on Debian 10"
-short_description: "This tutorial explains how to install LEMP (Linux, Nginx, MySQL, PHP) on Debian 10"
+title: "Install LEMP Stack on Debian 12"
+short_description: "This tutorial explains how to install LEMP (Linux, Nginx, MySQL, PHP) on Debian 12"
 tags: ["Linux", "Nginx", "MySQL", "PHP", "LEMP", "Debian"]
 author: "MohammadHossein Fakhraei"
 author_link: ""
@@ -18,11 +18,12 @@ cta: "cloud"
 
 ## Introduction
 
-The LEMP stack (Linux, NGINX, MySQL, and PHP) is a popular alternative to the LAMP stack that uses NGINX instead of Apache. This tutorial will guide you through basic installation, setup and configuration of a LEMP stack on Debian 10.
+The LEMP stack (Linux, NGINX, MySQL, and PHP) is a popular alternative to the LAMP stack that uses NGINX instead of Apache. This tutorial will guide you through basic installation, setup and configuration of a LEMP stack on Debian 12.
 
 **Prerequisites**
 
-To install LEMP stack on your server, make sure you are logged into your server with a `sudo` user.
+- Debian 12 installed with root access
+- Domain or subdomain that you can point to your server's IP address (A and/or AAAA Record)
 
 ## Step 1 - Install Nginx
 
@@ -37,7 +38,7 @@ apt update
 apt install nginx
 ```
 
-On Debian 10, Nginx is configured to start running upon installation.
+On Debian 12, Nginx is configured to start running upon installation.
 
 You can check this with:
 
@@ -58,19 +59,13 @@ If you don't know what your server's public IP address is, there are many ways t
 From the command line, you can use the `iproute2` tools to get your address by typing this:
 
 ```bash
-ip a s | sed -ne '/127.0.0.1/!{s/^[ \t]*inet[ \t]*\([0-9.]\+\)\/.*$/\1/p}'
+ip address show | sed -ne '/127.0.0.1/!{s/^[ \t]*inet[ \t]*\([0-9.]\+\)\/.*$/\1/p}'
 ```
 
-Another method is to use an outside party to tell you how it sees your server:
+Another method is to use [ip.hetzner.com](https://ip.hetzner.com):
 
 ```bash
-curl https://ipecho.net/plain; echo
-```
-
-or
-
-```bash
-curl https://icanhazip.com
+curl -4 https://ip.hetzner.com
 ```
 
 ## Step 2 - Install MySQL (MariaDB)
@@ -83,7 +78,7 @@ Install MariaDB with:
 apt install mariadb-server
 ```
 
-On Debian 10, MariaDB is configured to start running upon installation.
+On Debian 12, MariaDB is configured to start running upon installation.
 
 You can check this with:
 
@@ -110,19 +105,25 @@ NOTE: RUNNING ALL PARTS OF THIS SCRIPT IS RECOMMENDED FOR ALL MariaDB
       SERVERS IN PRODUCTION USE!  PLEASE READ EACH STEP CAREFULLY!
 
 In order to log into MariaDB to secure it, we'll need the current
-password for the root user.  If you've just installed MariaDB, and
-you haven't set the root password yet, the password will be blank,
-so you should just press enter here.
+password for the root user. If you've just installed MariaDB, and
+haven't set the root password yet, you should just press enter here.
 
-Enter current password for root (enter for none):
+Enter current password for root (enter for none): 
 OK, successfully used password, moving on...
 
-Setting the root password ensures that nobody can log into the MariaDB
-root user without the proper authorisation.
+Setting the root password or using the unix_socket ensures that nobody
+can log into the MariaDB root user without the proper authorisation.
 
-Set root password? [Y/n] Y
-New password:
-Re-enter new password:
+You already have your root account protected, so you can safely answer 'n'.
+
+Switch to unix_socket authentication [Y/n] n
+ ... skipping.
+
+You already have your root account protected, so you can safely answer 'n'.
+
+Change the root password? [Y/n] Y
+New password: 
+Re-enter new password: 
 Password updated successfully!
 Reloading privilege tables..
  ... Success!
@@ -183,9 +184,9 @@ You now have your PHP components installed. Next, you'll configure Nginx to use 
 
 When using the Nginx web server, server blocks can be used to encapsulate configuration details and host more than one domain on a single server.
 
-In this guide, we'll use **example.com** as example domain name.
+In this guide, we'll use **example.com** as example domain name. You will have to replace occurrences of **example.com** with your domain or subdomain.
 
-On **Debian 10**, Nginx has one server block enabled by default and is configured to serve documents out of a directory at `/var/www/html`.
+On **Debian 12**, Nginx has one server block enabled by default and is configured to serve documents out of a directory at `/var/www/html`.
 
 Create the root web directory for example.com as follows:
 
@@ -193,16 +194,10 @@ Create the root web directory for example.com as follows:
 mkdir /var/www/example.com
 ```
 
-Next, assign ownership of the directory with the `$USER` environment variable, which should reference your current system user:
-
-```bash
-chown -R $USER:$USER /var/www/example.com
-```
-
 Then, open a new configuration file in Nginx's `sites-available` directory using your preferred command-line editor.
 
 ```bash
-vi /etc/nginx/sites-available/example.com
+nano /etc/nginx/sites-available/example.com
 ```
 
 This will create a new blank file. Paste in the following bare-bones configuration:
@@ -223,7 +218,7 @@ server {
 
     location ~ \.php$ {
         include snippets/fastcgi-php.conf;
-        fastcgi_pass unix:/var/run/php/php7.3-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php8.2-fpm.sock;
     }
 }
 ```
@@ -259,7 +254,7 @@ You are now able to upload your sites files to the `/var/www/example.com` direct
 You can do this by creating a test PHP file in your document root. Open a new file called `info.php` within your document root in your text editor:
 
 ```bash
-vi /var/www/example.com/info.php
+nano /var/www/example.com/info.php
 ```
 
 Type or paste the following lines into the new file. This is valid PHP code that will return information about your server:


### PR DESCRIPTION
Update Article for Debian 12 to keep it relevant.
Replaced the IP echoing services with https://ip.hetzner.com to make more use of Hetzner services.

Tracking issue #862 
