### PR TITLE
Make instructions match between languages

### DIFF
--- a/tutorials/install-and-configure-ntp/01.en.md
+++ b/tutorials/install-and-configure-ntp/01.en.md
@@ -34,7 +34,7 @@ Gentoo:
 
 OpenSuSE:
 
-Please install via YaSt
+`zypper install ntp`
 
 ## Step 2 - Configuring the NTP daemon
 

--- a/tutorials/install-and-configure-ntp/01.ru.md
+++ b/tutorials/install-and-configure-ntp/01.ru.md
@@ -34,7 +34,7 @@ Gentoo:
 
 OpenSuSE:
 
-Устанавливается через YaSt
+`zypper install ntp`
 
 ## Шаг 2 - Настройка службы NTP
 


### PR DESCRIPTION
This PR makes the english and russian variant of this article use the same command as the german version to install `ntp` on OpenSuSE.

I have read and understood the Contributor's Certificate of Origin available at the end of 
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Peter Lehmann <xgwq@xnee.net>