### PR TITLE
Fix the genfstab command in "How to install Arch Linux on a Hetzner Cloud server"

### DIFF
--- a/tutorials/how-to-install-archlinux-on-a-hetzner-cloud-server/01.en.md
+++ b/tutorials/how-to-install-archlinux-on-a-hetzner-cloud-server/01.en.md
@@ -210,7 +210,7 @@ We then mount it to `/mnt` and generate our fstab from that:
 
 ```shell
 [root@bootstrap /]# mount /dev/sda2 /mnt
-[root@bootstrap /]# genfstab -U /mnt >> /etc/fstab
+[root@bootstrap /]# genfstab -U /mnt >> /mnt/etc/fstab
 ```
 
 Now we can install Arch Linux via pacstrap. We will use this opportunity to install OpenSSH, as we will need it to connect to our server later.


### PR DESCRIPTION
Fix #984, Fix #956

I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: wpdevelopment11 wpdevelopment11@gmail.com