### PR TITLE
Update "Obfuscating WireGuard using Wstunnel"

### DIFF
--- a/tutorials/obfuscating-wireguard-using-wstunnel/01.en.md
+++ b/tutorials/obfuscating-wireguard-using-wstunnel/01.en.md
@@ -45,7 +45,7 @@ Open the latest [Wstunnel release on GitHub](https://github.com/erebe/wstunnel/r
 Run the command below and replace the link with the one that you copied from GitHub:
 
 ```bash
-cd ~ && curl -Lo wstunnel.tar.gz https://github.com/erebe/wstunnel/releases/download/v10.1.1/wstunnel_10.1.1_linux_amd64.tar.gz
+cd ~ && curl -fLo wstunnel.tar.gz https://github.com/erebe/wstunnel/releases/download/v10.1.6/wstunnel_10.1.6_linux_amd64.tar.gz
 ```
 
 You need to extract `wstunnel` from the tar file:
@@ -72,6 +72,12 @@ Run the following command to check that `wstunnel` is installed properly:
 wstunnel --version
 ```
 
+Run the command below to be able to bind the `443` (https) port without root privileges.
+
+```bash
+sudo setcap cap_net_bind_service=+ep /usr/local/bin/wstunnel
+```
+
 If you need to update `wstunnel`, repeat [step 1](#step-1---installing-wstunnel-on-server) again.
 
 ## Step 2 - Server configuration
@@ -89,10 +95,8 @@ The command to start `wstunnel` on your server looks like this:
   You can check the listen port with the following command: `sudo wg show all listen-port`.
 
 ```bash
-sudo wstunnel server --restrict-http-upgrade-path-prefix "<secret>" --restrict-to localhost:51820 wss://0.0.0.0:443
+wstunnel server --restrict-http-upgrade-path-prefix "<secret>" --restrict-to localhost:51820 wss://0.0.0.0:443
 ```
-
-> **Note:** `sudo` is needed to bind the `443` port.
 
 This command will run `wstunnel` server in foreground and print logs to your terminal. You can terminate it as usual by pressing `Ctrl + C`.
 
@@ -102,7 +106,13 @@ This server will listen on port `443` on all IPv4 addresses. If you have a web s
 
 Running the `wstunnel` server in foreground in your terminal is impractical. If you close the terminal, it will die. We will create a systemd service to run it in the background.
 
-Create a file for the service:
+First, create a separate unprivileged user for the `wstunnel` service:
+
+```bash
+sudo useradd --system --shell /usr/sbin/nologin wstunnel
+```
+
+Now, create a file for the service:
 
 ```bash
 sudo nano /etc/systemd/system/wstunnel.service
@@ -121,6 +131,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
+User=wstunnel
 Type=exec
 ExecStart=/usr/local/bin/wstunnel server --restrict-http-upgrade-path-prefix "<secret>" --restrict-to localhost:51820 wss://0.0.0.0:443
 Restart=on-failure
@@ -158,7 +169,34 @@ Continue with the steps for your client:
 
 > **Note:** This method doesn't require root on your device.
 
-This step will show you how to configure WireGuard with Wstunnel on an Android device.
+This step will show you how to configure WireGuard with Wstunnel on an Android device. You need a terminal emulator on your Android device to run Wstunnel.
+
+You can choose between the two terminals below:
+
+<details>
+
+<summary>Set up Wstunnel using Termux terminal</summary>
+
+Download and install [the latest Termux apk](https://github.com/termux/termux-app/releases) on your Android device.
+
+Open Termux and execute the commands below to download and extract Wstunnel:
+
+* You need to download the `wstunnel` binary for Android, i.e. `android_arm64.tar.gz`.
+* Replace the link with the [latest version of Wstunnel](https://github.com/erebe/wstunnel/releases/latest).
+
+```bash
+cd ~ \
+&& curl -fLo wstunnel.tar.gz https://github.com/erebe/wstunnel/releases/download/v10.1.6/wstunnel_10.1.6_android_arm64.tar.gz \
+&& tar -xzf wstunnel.tar.gz wstunnel
+```
+
+---
+
+</details>
+
+<details>
+
+<summary>Set up Wstunnel using TermOne Plus terminal</summary>
 
 Install the terminal [TermOne Plus](https://play.google.com/store/apps/details?id=com.termoneplus) on your Android device.
 It's needed to execute the `wstunnel` command.
@@ -206,13 +244,14 @@ Now scroll to the `chmod` command below, and run it to give execute permissions 
 
 If both commands are available, you can proceed further.
 
-You need to download the [`wstunnel` binary](https://github.com/erebe/wstunnel/releases/latest) for Linux and ARM64 architecture, i.e. `linux_arm64.tar.gz` to your Android device. I tried binary specifically for Android, i.e. `android_arm64.tar.gz`, but it doesn't work very well on my phone.
+You need to download the [`wstunnel` binary](https://github.com/erebe/wstunnel/releases/latest) for Linux and ARM64 architecture, i.e. `linux_arm64.tar.gz` to your Android device.
 
 To do this, open TermOne and execute the `curl` and `tar` commands below. You may need to replace the link in the `curl` command with one for the newer version of `wstunnel`.
 
 ```bash
-cd ~ && curl -Lo wstunnel.tar.gz https://github.com/erebe/wstunnel/releases/download/v10.1.0/wstunnel_10.1.0_linux_arm64.tar.gz &&
-tar -xzf wstunnel.tar.gz wstunnel
+cd ~ \
+&& curl -Lo wstunnel.tar.gz https://github.com/erebe/wstunnel/releases/download/v10.1.6/wstunnel_10.1.6_linux_arm64.tar.gz \
+&& tar -xzf wstunnel.tar.gz wstunnel
 ```
 
 If you get an error: "tar: chown 1001:127 'wstunnel': Operation not permitted", ignore it.
@@ -234,7 +273,13 @@ If you get an error: "tar: chown 1001:127 'wstunnel': Operation not permitted", 
 
 </details>
 
-Let's look what we have now:
+---
+
+</details>
+
+<br>
+
+You downloaded Wstunnel and extracted it using your terminal of choice. Let's look what we have now:
 
 ```bash
 ls -lh
@@ -280,11 +325,11 @@ You should get output similar to this:
 2024-08-29 INFO wstunnel::protocols::udp::server: Starting UDP server listening cnx on 127.0.0.1:51820 with cnx timeout of 0s
 ```
 
-Screenshot:
+<details>
 
-![](images/wstunnel-android-log-1.png)
+<summary>If you're using TermOne, you can run the <code>tunnel</code> script automatically.</summary>
 
-For additional convenience you can execute the `tunnel` script right after you open the new terminal window.
+For additional convenience you can run the `tunnel` script automatically right after you open the new terminal window.
 
 1. Open the TermOne menu:
 
@@ -301,6 +346,12 @@ For additional convenience you can execute the `tunnel` script right after you o
    ![](images/wstunnel-android-termone-cmd.png)
 
 Now if you try to open the TermOne app, `wstunnel` should be started automatically.
+
+Screenshot:
+
+![](images/wstunnel-android-log-1.png)
+
+</details>
 
 Now that `wstunnel` is fully working, it's time to change the settings in the WireGuard app on your device. You need to configure it to use the `wstunnel` client on your device as a WireGuard server instead of a remote WireGuard server directly.
 
@@ -328,7 +379,7 @@ Now that `wstunnel` is fully working, it's time to change the settings in the Wi
 
    ![](images/wstunnel-android-wireguard-4.png)
 
-Enable your WireGuard VPN profile to test it. Go back to TermOne. The output should be similar to this:
+Enable your WireGuard VPN profile to test it. Go back to your terminal. The output should be similar to this:
 
 * where `203.0.113.1` is the IP address of your server.
 
@@ -351,7 +402,7 @@ Execute the following commands in PowerShell to download it into the `~\wstunnel
 ```powershell
 mkdir ~\wstunnel
 cd ~\wstunnel
-curl.exe -Lo wstunnel.tar.gz https://github.com/erebe/wstunnel/releases/download/v10.1.0/wstunnel_10.1.0_windows_amd64.tar.gz
+curl.exe -fLo wstunnel.tar.gz https://github.com/erebe/wstunnel/releases/download/v10.1.6/wstunnel_10.1.6_windows_amd64.tar.gz
 tar -xzf wstunnel.tar.gz wstunnel.exe
 ```
 


### PR DESCRIPTION
* Add a note about Termux, as an alternative to TermOne Plus.
* Use a separate unprivileged user for the `wstunnel` systemd service.

I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: wpdevelopment11 wpdevelopment11@gmail.com