### PR TITLE
Fix typo

### DIFF
--- a/tutorials/installing-wireguard-ui-using-docker-compose/01.de.md
+++ b/tutorials/installing-wireguard-ui-using-docker-compose/01.de.md
@@ -119,7 +119,7 @@ Das Ergebnis sollte so aussehen:
 Ich empfehle ab jetzt die Verwendung eines Reverse Proxys (siehe [NGINX Proxy Manager](https://community.hetzner.com/tutorials/installing-nginx-proxy-manager)).
 
 Wenn du erfolgreich warst, solltest du jetzt die Login Seite von WireGuard UI sehen. Die Standardanmeldedaten sind:
- 
+
 - U: admin
 - PW: admin
 
@@ -181,7 +181,7 @@ Und starte (oder stoppe) WireGuard:
 
 * Vorübergehend
   ```bash
-  wg-quick up wg0 &
+  wg-quick up wg0
   wg-quick down wg0
   ```
 

--- a/tutorials/installing-wireguard-ui-using-docker-compose/01.en.md
+++ b/tutorials/installing-wireguard-ui-using-docker-compose/01.en.md
@@ -42,7 +42,7 @@ sudo apt update && sudo apt upgrade
 
 ## Step 2 - Setting up the .YML
 
-The `.yml` file contains all information needed, 
+The `.yml` file contains all information needed,
 to create Docker containers for the WireGuard UI.
 
 ```bash
@@ -121,7 +121,7 @@ Using your browser enter `http://<203.0.113.1>:5000`
 I recommend using a reverse proxy from now on (see [NGINX Proxy Manager](https://community.hetzner.com/tutorials/installing-nginx-proxy-manager)).
 
 If you were successful you should see the WireGuard UI login page. The default credentials are:
- 
+
 - Username: admin
 - Password: admin
 
@@ -183,7 +183,7 @@ And start (or stop) WireGuard:
 
 * Temporarily
   ```bash
-  wg-quick up wg0 &
+  wg-quick up wg0
   wg-quick down wg0
   ```
 


### PR DESCRIPTION
Don't run `wg-quick` in background. This doesn't work. It will only work by accident if you recently used `sudo` and typed your password.

I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: wpdevelopment11 wpdevelopment11@gmail.com