### PR TITLE
Update kubernetes guide to work with the new pkgs.k8s.io repository

### DIFF
--- a/tutorials/install-kubernetes-cluster/01.en.md
+++ b/tutorials/install-kubernetes-cluster/01.en.md
@@ -321,11 +321,11 @@ Then, install the required packages by executing the following commands on all s
 - **Install Kubernetes**
   
   ```bash
-  all$ curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | gpg --dearmor -o /usr/share/keyrings kubernetes-archive-keyring.gpg
+  all$ curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
   ```
   ```bash
   all$ cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
-          deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /
+          deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /
   EOF
   ```
   ```bash

--- a/tutorials/install-kubernetes-cluster/01.en.md
+++ b/tutorials/install-kubernetes-cluster/01.en.md
@@ -321,11 +321,11 @@ Then, install the required packages by executing the following commands on all s
 - **Install Kubernetes**
   
   ```bash
-  all$ curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+  all$ curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | gpg --dearmor -o /usr/share/keyrings kubernetes-archive-keyring.gpg
   ```
   ```bash
   all$ cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
-          deb http://packages.cloud.google.com/apt/ kubernetes-xenial main
+          deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /
   EOF
   ```
   ```bash


### PR DESCRIPTION
Guide: https://community.hetzner.com/tutorials/install-kubernetes-cluster

Since the old k8s repository http://packages.cloud.google.com/apt/ has been deprecated on sep 13, 2023.
This means the guide no longer work and leaves the user with the following when trying to install the kubernetes packages:
```
Unable to locate package kubeadm
Unable to locate package kubectl
Unable to locate package kubelet
```

You can see the official kubernetes announcement regarding the deprecation, i have updated the guide to use the new repository pkgs.k8s.io
https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/