### PR TITLE
fix: update packer tutorial post

### DIFF
--- a/tutorials/custom-os-images-with-packer/01.de.md
+++ b/tutorials/custom-os-images-with-packer/01.de.md
@@ -71,7 +71,7 @@ Um ein personalisiertes, benutzerdefiniertes Image zu erstellen, benötigt Packe
 source "hcloud" "base-amd64" {
   image         = "debian-12"
   location      = "nbg1"
-  server_type   = "cx11"
+  server_type   = "cx22"
   ssh_keys      = []
   user_data     = ""
   ssh_username  = "root"
@@ -150,7 +150,7 @@ variable "user_data_path" {
 source "hcloud" "base-amd64" {
   image         = var.base_image
   location      = "nbg1"
-  server_type   = "cx11"
+  server_type   = "cx22"
   ssh_keys      = []
   user_data     = file(var.user_data_path)
   ssh_username  = "root"

--- a/tutorials/custom-os-images-with-packer/01.en.md
+++ b/tutorials/custom-os-images-with-packer/01.en.md
@@ -71,7 +71,7 @@ To create a personalized custom image, Packer needs a base form where it starts 
 source "hcloud" "base-amd64" {
   image         = "debian-12"
   location      = "nbg1"
-  server_type   = "cx11"
+  server_type   = "cx22"
   ssh_keys      = []
   user_data     = ""
   ssh_username  = "root"
@@ -150,7 +150,7 @@ variable "user_data_path" {
 source "hcloud" "base-amd64" {
   image         = var.base_image
   location      = "nbg1"
-  server_type   = "cx11"
+  server_type   = "cx22"
   ssh_keys      = []
   user_data     = file(var.user_data_path)
   ssh_username  = "root"


### PR DESCRIPTION
As requested in #1009 this updates the poss as a minimal changes was necessary.

It updates the hacloud-packer post to use a hcloud server type that is still avaiable for customers


I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Henrik Gerdes hegerdes@outlook.de 