### PR TITLE
Tutorial: Setting up pfSense on Proxmox at Hetzner

### DIFF
--- a/tutorials/setup-proxmox-pfsense-2-ips/01.de.md
+++ b/tutorials/setup-proxmox-pfsense-2-ips/01.de.md
@@ -1,0 +1,187 @@
+---
+SPDX-License-Identifier: MIT
+path: "/tutorials/pfsense-auf-proxmox-hetzner/de"
+slug: "pfsense-auf-proxmox-hetzner"
+date: "2024-12-06"
+title: "pfSense auf Proxmox bei Hetzner: Eine vollständige Anleitung"
+short_description: "Erfahre, wie du pfSense auf Proxmox bei Hetzner einrichtest, inklusive Proxmox-Netzwerkkonfiguration, pfSense-Installation und WAN-, LAN- sowie DMZ-Einrichtung."
+tags: ["Netzwerk", "Firewall", "Proxmox", "Hetzner"]
+author: "Dennis Floer"
+author_link: "https://github.com/encore99"
+author_img: "https://avatars3.githubusercontent.com/u/....."
+author_description: "Proxmox- und pfSense-Enthusiast mit langjähriger Erfahrung in Netzwerken und Virtualisierung."
+language: "de"
+available_languages: ["de", "en"]
+header_img: "header-networking"
+cta: "product"
+---
+
+### Einführung
+
+Diese Anleitung zeigt dir, wie du pfSense auf Proxmox bei Hetzner einrichtest. Am Ende dieser Anleitung hast du eine vollständig funktionsfähige pfSense-Firewall, die WAN-, LAN- und DMZ-Netzwerke in deiner virtualisierten Umgebung verwaltet. Voraussetzungen sind ein dedizierter Hetzner-Server mit Proxmox VE sowie grundlegende Kenntnisse in Virtualisierung und Netzwerken sowie einer zusatzip von Hetzner.
+
+---
+
+### Voraussetzungen
+
+Für diese Anleitung benötigst du:
+
+- Einen dedizierten oder Cloud-Server bei Hetzner.
+- Eine Hetzner-Konfiguration mit einer **zusätzlichen IP und separater MAC-Adresse**.  
+- Auf dem Server installiertes Proxmox VE via "installimage."
+- Zugang zu Hetzners Robot- und Proxmox-Webinterface.
+
+**Beispiel-Konfiguration für diese Anleitung**:
+- **Haupt-IP**: `<10.0.0.1>`
+- **Zusätzliche IP**: `<10.0.0.2>`
+- **Gateway**: `<192.0.2.254>`
+- **Netzmaske**: `255.255.255.224`
+- **Separate MAC-Adresse**: `<00:50:56:00:76:3E>`
+
+---
+
+### Schritt 1 - Proxmox-Netzwerk konfigurieren
+
+#### 1.1 Netzwerkkonfigurationsdatei bearbeiten
+Öffne die Datei `/etc/network/interfaces` auf deinem Proxmox-Host:
+
+```bash
+nano /etc/network/interfaces
+```
+
+Füge folgende Konfiguration hinzu:
+
+```plaintext
+# Loopback-Schnittstelle
+auto lo
+iface lo inet loopback
+
+# Physisches Interface ohne IP
+auto enp41s0
+iface enp41s0 inet manual
+
+# WAN-Bridge
+auto vmbr0
+iface vmbr0 inet static
+    address <10.0.0.1>
+    netmask 255.255.255.224
+    gateway <192.0.2.254>
+    bridge_ports enp41s0
+    bridge_stp off
+    bridge_fd 0
+
+# LAN-Bridge
+auto vmbr1
+iface vmbr1 inet static
+    address 192.168.1.1
+    netmask 255.255.255.0
+    bridge_ports none
+    bridge_stp off
+    bridge_fd 0
+
+# DMZ-Bridge
+auto vmbr2
+iface vmbr2 inet static
+    address 192.168.2.1
+    netmask 255.255.255.0
+    bridge_ports none
+    bridge_stp off
+    bridge_fd 0
+```
+
+#### 1.2 Netzwerkschnittstellen neu starten
+Wende die Änderungen an, indem du den Netzwerkdienst neu startest:
+```bash
+systemctl restart networking
+```
+
+---
+
+### Schritt 2 - pfSense-VM in Proxmox einrichten
+
+#### 2.1 Neue VM erstellen
+1. Öffne das Proxmox-Webinterface.
+2. Erstelle eine neue virtuelle Maschine:
+   - **ISO**: Verwende das pfSense-ISO.
+   - **Netzwerkschnittstellen**:
+     - WAN: Verbinde mit `vmbr0`.
+     - LAN: Verbinde mit `vmbr1`.
+
+#### 2.2 pfSense installieren
+1. Starte die VM vom ISO und folge den Installationsanweisungen.
+2. Weise die Schnittstellen zu:
+   - WAN: `em0` (verbunden mit `vmbr0`).
+   - LAN: `em1` (verbunden mit `vmbr1`).
+
+#### 2.3 Zugriff auf das Webinterface
+Verbinde einen Rechner mit dem LAN-Netzwerk (`192.168.1.0/24`) und öffne das pfSense GUI:
+```
+http://192.168.1.1
+```
+Standard-Zugangsdaten:
+- Benutzername: `admin`
+- Passwort: `pfsense`
+
+---
+
+### Schritt 3 - Netzwerk in pfSense konfigurieren
+
+#### 3.1 WAN-Schnittstelle konfigurieren
+1. Gehe zu **Interfaces > WAN**.
+2. Setze folgende Einstellungen:
+   - **IP-Adresse**: `<10.0.0.2>`
+   - **Netzmaske**: `255.255.255.224`
+   - **Gateway**: `<192.0.2.254>`
+   - **MAC-Adresse**: `<00:50:56:00:76:3E>`
+
+#### 3.2 DHCP für LAN aktivieren
+1. Gehe zu **Services > DHCP Server**.
+2. Aktiviere den DHCP-Server für die LAN-Schnittstelle.
+3. Lege einen IP-Bereich fest:
+   - Start: `192.168.1.100`
+   - Ende: `192.168.1.200`
+
+---
+
+### Schritt 4 - Firewall-Regeln anpassen
+
+#### 4.1 LAN-Traffic erlauben
+1. Gehe zu **Firewall > Rules > LAN**.
+2. Erstelle eine Regel:
+   - Aktion: Pass
+   - Quelle: LAN subnet
+   - Ziel: Any
+   - Protokoll: Any
+
+#### 4.2 WAN-Regeln anpassen
+Beschränke den eingehenden WAN-Zugriff auf notwendige Ports (z. B. für SSH oder einen Webserver).
+
+---
+
+### Schritt 5 - Test und Fehlerbehebung
+
+#### 5.1 Verbindung testen
+Führe folgende Befehle aus:
+```bash
+ping <192.0.2.254>   # Test des Gateways
+ping 8.8.8.8         # Test der externen Verbindung
+```
+
+#### 5.2 Häufige Probleme
+- **Keine IP-Adresse für LAN-Clients**: Stelle sicher, dass der DHCP-Server für LAN aktiviert ist.
+- **WAN funktioniert nicht**: Überprüfe, ob die MAC-Adresse korrekt im Hetzner Robot eingetragen ist.
+
+---
+
+### Ergebnis
+
+Durch diese Anleitung hast du:
+1. Die Netzwerke von Proxmox für pfSense konfiguriert.
+2. pfSense erfolgreich als Firewall für WAN-, LAN- und DMZ-Netzwerke eingerichtet.
+3. DHCP und Firewall-Regeln so angepasst, dass deine VMs Zugriff auf das Internet haben.
+
+Du bist jetzt bereit, dein pfSense-Setup in einer produktiven Umgebung zu nutzen.
+
+---
+
+License: MIT

--- a/tutorials/setup-proxmox-pfsense-2-ips/01.de.md
+++ b/tutorials/setup-proxmox-pfsense-2-ips/01.de.md
@@ -3,46 +3,42 @@ SPDX-License-Identifier: MIT
 path: "/tutorials/pfsense-auf-proxmox-hetzner/de"
 slug: "pfsense-auf-proxmox-hetzner"
 date: "2024-12-06"
-title: "pfSense auf Proxmox bei Hetzner: Eine vollständige Anleitung"
+title: "pfSense auf Proxmox bei Hetzner"
 short_description: "Erfahre, wie du pfSense auf Proxmox bei Hetzner einrichtest, inklusive Proxmox-Netzwerkkonfiguration, pfSense-Installation und WAN-, LAN- sowie DMZ-Einrichtung."
 tags: ["Netzwerk", "Firewall", "Proxmox", "Hetzner"]
 author: "Dennis Floer"
 author_link: "https://github.com/encore99"
-author_img: "https://avatars3.githubusercontent.com/u/....."
+author_img: "https://avatars3.githubusercontent.com/u/3808935"
 author_description: "Proxmox- und pfSense-Enthusiast mit langjähriger Erfahrung in Netzwerken und Virtualisierung."
 language: "de"
 available_languages: ["de", "en"]
-header_img: "header-networking"
-cta: "product"
+header_img: "header-8"
+cta: "dedicated"
 ---
 
-### Einführung
+## Einführung 
 
-Diese Anleitung zeigt dir, wie du pfSense auf Proxmox bei Hetzner einrichtest. Am Ende dieser Anleitung hast du eine vollständig funktionsfähige pfSense-Firewall, die WAN-, LAN- und DMZ-Netzwerke in deiner virtualisierten Umgebung verwaltet. Voraussetzungen sind ein dedizierter Hetzner-Server mit Proxmox VE sowie grundlegende Kenntnisse in Virtualisierung und Netzwerken sowie einer zusatzip von Hetzner.
+Diese Anleitung zeigt dir, wie du pfSense auf Proxmox bei Hetzner einrichtest. Am Ende dieser Anleitung hast du eine vollständig funktionsfähige pfSense-Firewall, die WAN-, LAN- und DMZ-Netzwerke in deiner virtualisierten Umgebung verwaltet. Voraussetzungen sind ein dedizierter Hetzner-Server mit Proxmox VE sowie grundlegende Kenntnisse in Virtualisierung und Netzwerken sowie einer zusätzlichen IP von Hetzner.
 
----
-
-### Voraussetzungen
+**Voraussetzungen**
 
 Für diese Anleitung benötigst du:
 
 - Einen dedizierten oder Cloud-Server bei Hetzner.
-- Eine Hetzner-Konfiguration mit einer **zusätzlichen IP und separater MAC-Adresse**.  
-- Auf dem Server installiertes Proxmox VE via "installimage."
+  - Auf dem Server installiertes Proxmox VE via "installimage" (folge dafür Schritt 1 in dem Tutorial "[Proxmox VE Installieren und Konfigurieren](https://community.hetzner.com/tutorials/install-and-configure-proxmox_ve/de)")
+  - Eine Hetzner-Konfiguration mit einer **zusätzlichen IP und separater MAC-Adresse**.
 - Zugang zu Hetzners Robot- und Proxmox-Webinterface.
 
-**Beispiel-Konfiguration für diese Anleitung**:
-- **Haupt-IP**: `<10.0.0.1>`
-- **Zusätzliche IP**: `<10.0.0.2>`
-- **Gateway**: `<192.0.2.254>`
-- **Netzmaske**: `255.255.255.224`
-- **Separate MAC-Adresse**: `<00:50:56:00:76:3E>`
+**Beispiel-Benennungen**
 
----
+- Haupt-IP: `<10.0.0.1>`
+- Zusätzliche IP: `<10.0.0.2>`
+- Gateway: `<192.0.2.254>`
+- Netzmaske: `255.255.255.224`
+- Separate MAC-Adresse: `<00:50:56:00:76:3E>`
 
-### Schritt 1 - Proxmox-Netzwerk konfigurieren
+## Schritt 1 - Proxmox-Netzwerk konfigurieren
 
-#### 1.1 Netzwerkkonfigurationsdatei bearbeiten
 Öffne die Datei `/etc/network/interfaces` auf deinem Proxmox-Host:
 
 ```bash
@@ -89,17 +85,15 @@ iface vmbr2 inet static
     bridge_fd 0
 ```
 
-#### 1.2 Netzwerkschnittstellen neu starten
 Wende die Änderungen an, indem du den Netzwerkdienst neu startest:
+
 ```bash
 systemctl restart networking
 ```
 
----
+## Schritt 2 - pfSense-VM in Proxmox einrichten
 
-### Schritt 2 - pfSense-VM in Proxmox einrichten
-
-#### 2.1 Neue VM erstellen
+### Schritt 2.1 - Neue VM erstellen
 1. Öffne das Proxmox-Webinterface.
 2. Erstelle eine neue virtuelle Maschine:
    - **ISO**: Verwende das pfSense-ISO.
@@ -107,75 +101,85 @@ systemctl restart networking
      - WAN: Verbinde mit `vmbr0`.
      - LAN: Verbinde mit `vmbr1`.
 
-#### 2.2 pfSense installieren
+### Schritt 2.2 - pfSense installieren
 1. Starte die VM vom ISO und folge den Installationsanweisungen.
 2. Weise die Schnittstellen zu:
    - WAN: `em0` (verbunden mit `vmbr0`).
    - LAN: `em1` (verbunden mit `vmbr1`).
 
-#### 2.3 Zugriff auf das Webinterface
+### Schritt 2.3 - Zugriff auf das Webinterface
 Verbinde einen Rechner mit dem LAN-Netzwerk (`192.168.1.0/24`) und öffne das pfSense GUI:
+
 ```
 http://192.168.1.1
 ```
+
 Standard-Zugangsdaten:
 - Benutzername: `admin`
 - Passwort: `pfsense`
 
----
+## Schritt 3 - Netzwerk in pfSense konfigurieren
 
-### Schritt 3 - Netzwerk in pfSense konfigurieren
+* WAN-Schnittstelle konfigurieren
+  
+  Gehe zu `Interfaces` > `WAN`.
+  
+  Setze folgende Einstellungen:
+  - IP-Adresse: `<10.0.0.2>`
+  - Netzmaske: `255.255.255.224`
+  - Gateway: `<192.0.2.254>`
+  - MAC-Adresse: `<00:50:56:00:76:3E>`
 
-#### 3.1 WAN-Schnittstelle konfigurieren
-1. Gehe zu **Interfaces > WAN**.
-2. Setze folgende Einstellungen:
-   - **IP-Adresse**: `<10.0.0.2>`
-   - **Netzmaske**: `255.255.255.224`
-   - **Gateway**: `<192.0.2.254>`
-   - **MAC-Adresse**: `<00:50:56:00:76:3E>`
+<br>
 
-#### 3.2 DHCP für LAN aktivieren
-1. Gehe zu **Services > DHCP Server**.
-2. Aktiviere den DHCP-Server für die LAN-Schnittstelle.
-3. Lege einen IP-Bereich fest:
+* DHCP für LAN aktivieren
+  
+  Gehe zu `Services` > `DHCP Server`.
+  
+  Aktiviere den DHCP-Server für die LAN-Schnittstelle.
+  
+  Lege einen IP-Bereich fest:
    - Start: `192.168.1.100`
    - Ende: `192.168.1.200`
 
----
+## Schritt 4 - Firewall-Regeln anpassen
 
-### Schritt 4 - Firewall-Regeln anpassen
-
-#### 4.1 LAN-Traffic erlauben
-1. Gehe zu **Firewall > Rules > LAN**.
-2. Erstelle eine Regel:
+* LAN-Traffic erlauben
+  
+  Gehe zu `Firewall` > `Rules` > `LAN`.
+  
+  Erstelle eine Regel:
    - Aktion: Pass
    - Quelle: LAN subnet
    - Ziel: Any
    - Protokoll: Any
 
-#### 4.2 WAN-Regeln anpassen
-Beschränke den eingehenden WAN-Zugriff auf notwendige Ports (z. B. für SSH oder einen Webserver).
+<br>
 
----
+* WAN-Regeln anpassen
+  
+  Beschränke den eingehenden WAN-Zugriff auf notwendige Ports (z. B. für SSH oder einen Webserver).
 
-### Schritt 5 - Test und Fehlerbehebung
+## Schritt 5 - Test und Fehlerbehebung
 
-#### 5.1 Verbindung testen
-Führe folgende Befehle aus:
-```bash
-ping <192.0.2.254>   # Test des Gateways
-ping 8.8.8.8         # Test der externen Verbindung
-```
+* Verbindung testen
+  
+  Führe folgende Befehle aus:
+  ```bash
+  ping <192.0.2.254>   # Test des Gateways
+  ping 8.8.8.8         # Test der externen Verbindung
+  ```
 
-#### 5.2 Häufige Probleme
-- **Keine IP-Adresse für LAN-Clients**: Stelle sicher, dass der DHCP-Server für LAN aktiviert ist.
-- **WAN funktioniert nicht**: Überprüfe, ob die MAC-Adresse korrekt im Hetzner Robot eingetragen ist.
+<br>
 
----
+* Häufige Probleme
+  - **Keine IP-Adresse für LAN-Clients**: Stelle sicher, dass der DHCP-Server für LAN aktiviert ist.
+  - **WAN funktioniert nicht**: Überprüfe, ob die MAC-Adresse korrekt im Hetzner Robot eingetragen ist.
 
-### Ergebnis
+## Ergebnis
 
 Durch diese Anleitung hast du:
+
 1. Die Netzwerke von Proxmox für pfSense konfiguriert.
 2. pfSense erfolgreich als Firewall für WAN-, LAN- und DMZ-Netzwerke eingerichtet.
 3. DHCP und Firewall-Regeln so angepasst, dass deine VMs Zugriff auf das Internet haben.

--- a/tutorials/setup-proxmox-pfsense-2-ips/01.en.md
+++ b/tutorials/setup-proxmox-pfsense-2-ips/01.en.md
@@ -1,49 +1,44 @@
-
 ---
 SPDX-License-Identifier: MIT
-path: "/tutorials/pfsense-on-proxmox-hetzner/de"
+path: "/tutorials/pfsense-on-proxmox-hetzner"
 slug: "pfsense-on-proxmox-hetzner"
 date: "2024-12-06"
-title: "pfSense on Proxmox at Hetzner: A Complete Setup Guide"
+title: "pfSense on Proxmox at Hetzner"
 short_description: "Learn how to set up pfSense on Proxmox at Hetzner, including Proxmox network configuration, pfSense installation, and setting up WAN, LAN, and DMZ."
 tags: ["Networking", "Firewall", "Proxmox", "Hetzner"]
 author: "Dennis Floer"
 author_link: "https://github.com/encore99"
-author_img: "https://avatars3.githubusercontent.com/u/....."
+author_img: "https://avatars3.githubusercontent.com/u/3808935"
 author_description: "Proxmox and pfSense enthusiast with years of experience in networking and virtualization."
 language: "en"
 available_languages: ["en", "de"]
-header_img: "header-networking"
-cta: "product"
+header_img: "header-8"
+cta: "dedicated"
 ---
 
-### Introduction
+## Introduction
 
 This tutorial provides a detailed guide for setting up pfSense on Proxmox at Hetzner. By the end of this tutorial, you will have a fully functional pfSense firewall managing WAN, LAN, and DMZ networks in your virtualized environment. This guide assumes you have a dedicated Hetzner server with Proxmox VE installed and basic knowledge of virtualization and networking.
 
----
-
-### Prerequisites
+**Prerequisites**
 
 To follow this tutorial, you will need:
 
 - A Hetzner dedicated or cloud server.
-- A Hetzner configuration with an **additional IP and a separate MAC address**.  
-- Proxmox VE installed on the server via "installimage."
-- Access to Hetzner's Robot and Proxmox web interfaces.
+  - Proxmox VE installed on the server via "installimage" (follow step 1 in the tutorial "[Install and Configure Proxmox VE](https://community.hetzner.com/tutorials/install-and-configure-proxmox_ve)")
+  - A Hetzner configuration with an **additional IP and a separate MAC address**.
+- Access to the Proxmox web interfaces.
 
-**Example Configuration for This Guide**:
-- **Main IP**: `<10.0.0.1>`
-- **Additional IP**: `<10.0.0.2>`
-- **Gateway**: `<192.0.2.254>`
-- **Netmask**: `255.255.255.224`
-- **Separate MAC Address**: `<00:50:56:00:76:3E>`
+**Example terminology**
 
----
+- Main IP: `<10.0.0.1>`
+- Additional IP: `<10.0.0.2>`
+- Gateway: `<192.0.2.254>`
+- Netmask: `255.255.255.224`
+- Separate MAC Address: `<00:50:56:00:76:3E>`
 
-### Step 1 - Configure Proxmox Networking
+## Step 1 - Configure Proxmox Networking
 
-#### 1.1 Edit the Network Configuration File
 Open the `/etc/network/interfaces` file on your Proxmox host:
 
 ```bash
@@ -90,17 +85,15 @@ iface vmbr2 inet static
     bridge_fd 0
 ```
 
-#### 1.2 Restart Networking
 Apply the changes by restarting the network service:
+
 ```bash
 systemctl restart networking
 ```
 
----
+## Step 2 - Set Up the pfSense VM in Proxmox
 
-### Step 2 - Set Up the pfSense VM in Proxmox
-
-#### 2.1 Create a New VM
+### Step 2.1 - Create a New VM
 1. Open the Proxmox web interface.
 2. Create a new virtual machine:
    - **ISO**: Use the pfSense ISO.
@@ -108,81 +101,89 @@ systemctl restart networking
      - WAN: Connect to `vmbr0`.
      - LAN: Connect to `vmbr1`.
 
-#### 2.2 Install pfSense
+### Step 2.2 - Install pfSense
 1. Boot the VM from the ISO and follow the installation steps.
 2. Assign interfaces:
    - WAN: `em0` (linked to `vmbr0`).
    - LAN: `em1` (linked to `vmbr1`).
 
-#### 2.3 Access the Web Interface
+### Step 2.3 - Access the Web Interface
 Connect to the LAN (`192.168.1.0/24`) and access the pfSense GUI:
+
 ```
 http://192.168.1.1
 ```
+
 Default credentials:
 - Username: `admin`
 - Password: `pfsense`
 
----
+## Step 3 - Configure pfSense Networking
 
-### Step 3 - Configure pfSense Networking
+* Configure WAN Interface
+  
+  Go to `Interfaces` > `WAN`.
+  
+  Set the following:
+  - IP Address: `<10.0.0.2>`
+  - Netmask: `255.255.255.224`
+  - Gateway: `<192.0.2.254>`
+  - MAC Address: `<00:50:56:00:76:3E>`
 
-#### 3.1 Configure WAN Interface
-1. Go to **Interfaces > WAN**.
-2. Set the following:
-   - **IP Address**: `<10.0.0.2>`
-   - **Netmask**: `255.255.255.224`
-   - **Gateway**: `<192.0.2.254>`
-   - **MAC Address**: `<00:50:56:00:76:3E>`
+<br>
 
-#### 3.2 Enable DHCP for LAN
-1. Navigate to **Services > DHCP Server**.
-2. Enable DHCP for the LAN interface.
-3. Set an IP range:
-   - Start: `192.168.1.100`
-   - End: `192.168.1.200`
+* Enable DHCP for LAN
+  
+  Go to `Services` > `DHCP Server`.
+  
+  Enable DHCP for the LAN interface.
+  
+  Set an IP range:
+  - Start: `192.168.1.100`
+  - End: `192.168.1.200`
 
----
+## Step 4 - Adjust Firewall Rules
 
-### Step 4 - Adjust Firewall Rules
+* Allow LAN Traffic
+  
+  Go to `Firewall` > `Rules` > `LAN`.
+  
+  Add a rule:
+  - Action: Pass
+  - Source: LAN subnet
+  - Destination: Any
+  - Protocol: Any
 
-#### 4.1 Allow LAN Traffic
-1. Go to **Firewall > Rules > LAN**.
-2. Add a rule:
-   - Action: Pass
-   - Source: LAN subnet
-   - Destination: Any
-   - Protocol: Any
+<br>
 
-#### 4.2 Adjust WAN Rules
-Restrict WAN access to necessary ports only (e.g., for SSH or a web server).
+* Adjust WAN Rules
+  
+  Restrict WAN access to necessary ports only (e.g., for SSH or a web server).
 
----
+## Step 5 - Test and Troubleshoot
 
-### Step 5 - Test and Troubleshoot
+* Verify Connectivity
+  
+  Run the following commands:
+  ```bash
+  ping <192.0.2.254>   # Test gateway
+  ping 8.8.8.8         # Test external connectivity
+  ```
 
-#### 5.1 Verify Connectivity
-Run the following commands:
-```bash
-ping <192.0.2.254>   # Test gateway
-ping 8.8.8.8         # Test external connectivity
-```
+<br>
 
-#### 5.2 Common Issues
-- **No IP Address on LAN Clients**: Ensure the DHCP server is enabled for LAN.
-- **No Internet on WAN**: Verify that the MAC address is correctly set in Hetzner Robot.
+* Common Issues
+  - **No IP Address on LAN Clients**: Ensure the DHCP server is enabled for LAN.
+  - **No Internet on WAN**: Verify that the MAC address is correctly set in Hetzner Robot.
 
----
-
-### Results
+## Conclusion
 
 By completing this guide, you have:
+
 1. Configured Proxmox networking for pfSense.
 2. Installed and set up pfSense to manage WAN, LAN, and DMZ.
 3. Enabled DHCP and firewall rules for your virtualized environment.
 
 You are now ready to use your pfSense setup in a production environment.
-
----
 
 License: MIT

--- a/tutorials/setup-proxmox-pfsense-2-ips/01.en.md
+++ b/tutorials/setup-proxmox-pfsense-2-ips/01.en.md
@@ -1,0 +1,188 @@
+
+---
+SPDX-License-Identifier: MIT
+path: "/tutorials/pfsense-on-proxmox-hetzner/de"
+slug: "pfsense-on-proxmox-hetzner"
+date: "2024-12-06"
+title: "pfSense on Proxmox at Hetzner: A Complete Setup Guide"
+short_description: "Learn how to set up pfSense on Proxmox at Hetzner, including Proxmox network configuration, pfSense installation, and setting up WAN, LAN, and DMZ."
+tags: ["Networking", "Firewall", "Proxmox", "Hetzner"]
+author: "Dennis Floer"
+author_link: "https://github.com/encore99"
+author_img: "https://avatars3.githubusercontent.com/u/....."
+author_description: "Proxmox and pfSense enthusiast with years of experience in networking and virtualization."
+language: "en"
+available_languages: ["en", "de"]
+header_img: "header-networking"
+cta: "product"
+---
+
+### Introduction
+
+This tutorial provides a detailed guide for setting up pfSense on Proxmox at Hetzner. By the end of this tutorial, you will have a fully functional pfSense firewall managing WAN, LAN, and DMZ networks in your virtualized environment. This guide assumes you have a dedicated Hetzner server with Proxmox VE installed and basic knowledge of virtualization and networking.
+
+---
+
+### Prerequisites
+
+To follow this tutorial, you will need:
+
+- A Hetzner dedicated or cloud server.
+- A Hetzner configuration with an **additional IP and a separate MAC address**.  
+- Proxmox VE installed on the server via "installimage."
+- Access to Hetzner's Robot and Proxmox web interfaces.
+
+**Example Configuration for This Guide**:
+- **Main IP**: `<10.0.0.1>`
+- **Additional IP**: `<10.0.0.2>`
+- **Gateway**: `<192.0.2.254>`
+- **Netmask**: `255.255.255.224`
+- **Separate MAC Address**: `<00:50:56:00:76:3E>`
+
+---
+
+### Step 1 - Configure Proxmox Networking
+
+#### 1.1 Edit the Network Configuration File
+Open the `/etc/network/interfaces` file on your Proxmox host:
+
+```bash
+nano /etc/network/interfaces
+```
+
+Add the following configuration:
+
+```plaintext
+# Loopback interface
+auto lo
+iface lo inet loopback
+
+# Physical interface without IP
+auto enp41s0
+iface enp41s0 inet manual
+
+# WAN Bridge
+auto vmbr0
+iface vmbr0 inet static
+    address <10.0.0.1>
+    netmask 255.255.255.224
+    gateway <192.0.2.254>
+    bridge_ports enp41s0
+    bridge_stp off
+    bridge_fd 0
+
+# LAN Bridge
+auto vmbr1
+iface vmbr1 inet static
+    address 192.168.1.1
+    netmask 255.255.255.0
+    bridge_ports none
+    bridge_stp off
+    bridge_fd 0
+
+# DMZ Bridge
+auto vmbr2
+iface vmbr2 inet static
+    address 192.168.2.1
+    netmask 255.255.255.0
+    bridge_ports none
+    bridge_stp off
+    bridge_fd 0
+```
+
+#### 1.2 Restart Networking
+Apply the changes by restarting the network service:
+```bash
+systemctl restart networking
+```
+
+---
+
+### Step 2 - Set Up the pfSense VM in Proxmox
+
+#### 2.1 Create a New VM
+1. Open the Proxmox web interface.
+2. Create a new virtual machine:
+   - **ISO**: Use the pfSense ISO.
+   - **Network Interfaces**:
+     - WAN: Connect to `vmbr0`.
+     - LAN: Connect to `vmbr1`.
+
+#### 2.2 Install pfSense
+1. Boot the VM from the ISO and follow the installation steps.
+2. Assign interfaces:
+   - WAN: `em0` (linked to `vmbr0`).
+   - LAN: `em1` (linked to `vmbr1`).
+
+#### 2.3 Access the Web Interface
+Connect to the LAN (`192.168.1.0/24`) and access the pfSense GUI:
+```
+http://192.168.1.1
+```
+Default credentials:
+- Username: `admin`
+- Password: `pfsense`
+
+---
+
+### Step 3 - Configure pfSense Networking
+
+#### 3.1 Configure WAN Interface
+1. Go to **Interfaces > WAN**.
+2. Set the following:
+   - **IP Address**: `<10.0.0.2>`
+   - **Netmask**: `255.255.255.224`
+   - **Gateway**: `<192.0.2.254>`
+   - **MAC Address**: `<00:50:56:00:76:3E>`
+
+#### 3.2 Enable DHCP for LAN
+1. Navigate to **Services > DHCP Server**.
+2. Enable DHCP for the LAN interface.
+3. Set an IP range:
+   - Start: `192.168.1.100`
+   - End: `192.168.1.200`
+
+---
+
+### Step 4 - Adjust Firewall Rules
+
+#### 4.1 Allow LAN Traffic
+1. Go to **Firewall > Rules > LAN**.
+2. Add a rule:
+   - Action: Pass
+   - Source: LAN subnet
+   - Destination: Any
+   - Protocol: Any
+
+#### 4.2 Adjust WAN Rules
+Restrict WAN access to necessary ports only (e.g., for SSH or a web server).
+
+---
+
+### Step 5 - Test and Troubleshoot
+
+#### 5.1 Verify Connectivity
+Run the following commands:
+```bash
+ping <192.0.2.254>   # Test gateway
+ping 8.8.8.8         # Test external connectivity
+```
+
+#### 5.2 Common Issues
+- **No IP Address on LAN Clients**: Ensure the DHCP server is enabled for LAN.
+- **No Internet on WAN**: Verify that the MAC address is correctly set in Hetzner Robot.
+
+---
+
+### Results
+
+By completing this guide, you have:
+1. Configured Proxmox networking for pfSense.
+2. Installed and set up pfSense to manage WAN, LAN, and DMZ.
+3. Enabled DHCP and firewall rules for your virtualized environment.
+
+You are now ready to use your pfSense setup in a production environment.
+
+---
+
+License: MIT


### PR DESCRIPTION
This tutorial explains how to set up pfSense on Proxmox with a Hetzner server. It covers Proxmox network configuration, installation of pfSense, and configuring WAN, LAN, and DMZ networks. The guide also includes troubleshooting steps and tips for ensuring smooth operation.