### PR TITLE
 proxmox-ve: Fix IPv6 configuration in routed setup

### DIFF
--- a/tutorials/install-and-configure-proxmox_ve/01.de.md
+++ b/tutorials/install-and-configure-proxmox_ve/01.de.md
@@ -176,8 +176,7 @@ In einer gerouteten Konfiguration dient die Bridge-IP-Adresse des Hostsystems st
   
   # IPv6 des Main-interface
   iface enp0s31f6 inet6 static
-      address 2001:db8::2             # IPv6 Adresse aus dem /64 Subnetz
-      netmask 64
+      address 2001:db8::2/128             # /128 auf dem Ethernet, /64 auf der Bridge (um alle anderen Adressen zur Bridge zu routen)
       gateway fe80::1
   
   # Bridge für einzelne IP's (fremdes und gleiches Subnetz)
@@ -192,9 +191,7 @@ In einer gerouteten Konfiguration dient die Bridge-IP-Adresse des Hostsystems st
   
   # IPv6 für die bridge
   iface vmbr0 inet6 static
-    address 2001:db8::3                # Sollte nicht die gleiche Adresse wie das Main-interface sein
-    netmask 64
-    up ip -6 route add 2001:db8::/64 dev vmbr0
+    address 2001:db8::3/64                # Sollte nicht die gleiche Adresse wie das Main-interface sein
   
   # Zusätzliches Subnetz 203.0.113.0/24
   auto vmbr1

--- a/tutorials/install-and-configure-proxmox_ve/01.en.md
+++ b/tutorials/install-and-configure-proxmox_ve/01.en.md
@@ -176,8 +176,7 @@ In a routed configuration, the host system's bridge IP address serves as the gat
   
   # IPv6 for the main interface
   iface enp0s31f6 inet6 static
-      address 2001:db8::2             # IPv6 address from the /64 subnet
-      netmask 64
+      address 2001:db8::2/128         # /128 on the ethernet interface, /64 on the bridge (to route all other addresses via the bridge)
       gateway fe80::1
   
   # Bridge for single IP's (foreign and same subnet)
@@ -192,9 +191,7 @@ In a routed configuration, the host system's bridge IP address serves as the gat
   
   # IPv6 for the bridge
   iface vmbr0 inet6 static
-    address 2001:db8::3                # Should not be the same address as the main Interface
-    netmask 64
-    up ip -6 route add 2001:db8::/64 dev vmbr0
+    address 2001:db8::3/64                # Should not be the same address as the main Interface
   
   # Additional Subnet 203.0.113.0/24
   auto vmbr1


### PR DESCRIPTION
This change updates the IPv6 network configuration for Proxmox VE hosts in a routed configuration.
Previously, the proposed configuration would create 3 /64 routes on the system.
- 1 route generated by the vmbr0 interface being a /64
- 1 route created manually with the `up ip -6 route add` for the same /64
- 1 route created by the eth0 interface being a /64 as well (wrongly so, because none of the /64 hosts will be reachable via NDP on the physical L2 to the router)

This change results in 2 routes: 
- a single /128 route to the hosts IPv6 address itself on eth0
- a single /64 route to the vmbr0 interface for the whole subnet

```
I have read and understood the Contributor's Certificate of Origin available at the end of 
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.

Signed-off-by: Sarah Maedel <git@tbspace.de>
```