### PR TITLE
New tutorial - "Setup custom domain with S3-compatible object storage"

### DIFF
--- a/tutorials/hetzner-object-storage-custom-domain/01.en.md
+++ b/tutorials/hetzner-object-storage-custom-domain/01.en.md
@@ -1,0 +1,233 @@
+---
+SPDX-License-Identifier: MIT
+path: "/tutorials/hetzner-object-storage-custom-domain"
+slug: "hetzner-object-storage-custom-domain"
+date: "2025-01-05"
+title: "Setup custom domain with S3-compatible object storage"
+short_description: "This tutorial explains how to setup custom domain for S3-compatible object storage using reverse proxy."
+tags: ["Custom domain", "Reverse proxy", "Object Storage"]
+author: "Ivan Zaitsev"
+author_link: "https://github.com/ivan-zaitsev"
+author_img: "https://avatars.githubusercontent.com/u/15122759"
+author_description: ""
+language: "en"
+available_languages: ["en"]
+header_img: "header-7"
+cta: "cloud"
+---
+
+## Introduction
+
+This tutorial will guide you to setup custom domain for S3-compatible object storage using reverse proxy.
+The advantages of custom domain is to enable seamless integration with existing infrastructure or services under a unified domain.
+
+A custom domain can be configured in various ways, such as using a CNAME record or a reverse proxy.
+This tutorial focuses on configuring a custom domain using a reverse proxy.
+
+**Prerequisites**
+
+* A server (e.g. with [Hetzner Cloud](https://www.hetzner.com/cloud/))
+* A S3-compatible bucket (e.g. with [Hetzner](https://www.hetzner.com))
+* A domain you want to use (e.g. `storage.example.com`).
+
+## Step 1 - Create Object Storage Bucket
+
+Create a S3-compatible bucket.
+With Hetzner, see the getting started "[Creating a Bucket](https://docs.hetzner.com/storage/object-storage/getting-started/creating-a-bucket)".
+Make sure it is set to public access permissions. No much benefit of using custom domain for private buckets.
+
+Create S3 credentials to access your bucket.
+With Hetzner, see the getting started "[Generating S3 keys](https://docs.hetzner.com/storage/object-storage/getting-started/generating-s3-keys)".
+
+## Step 2 - Create Server
+
+Create a new server.
+With Hetzner, see the getting started "[Creating a Server](https://docs.hetzner.com/cloud/servers/getting-started/creating-a-server)").
+To install Docker and Docker Compose, follow the [official Docker documentation](https://docs.docker.com/engine/install/).
+
+## Step 3 - Deploy Caddy
+
+SSH to your server `ssh root@<server-ip>`.
+
+Create a directory for your Docker Compose files and folders for the persistent storage of the Caddy container:
+
+```bash
+mkdir -p /opt/caddy/data
+```
+
+### Step 3.1 - Create docker deployment and configuration files
+
+`vim /opt/caddy/compose.yaml`
+
+```yaml
+services:
+  caddy:
+    container_name: caddy
+    image: caddy:latest
+    restart: unless-stopped
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+       - ./data/Caddyfile:/etc/caddy/Caddyfile
+       - ./data/certs:/certs
+       - ./data/config:/config
+       - ./data/data:/data
+       - ./data/sites:/srv
+```
+
+`vim /opt/caddy/data/Caddyfile`
+
+```text
+storage.example.com {
+    tls {
+        issuer acme {
+            dir https://acme-v02.api.letsencrypt.org/directory
+        }
+    }
+}
+
+storage.example.com:443 {
+  reverse_proxy https://fsn1.your-objectstorage.com {
+    header_up Host {http.reverse_proxy.upstream.hostport}
+    header_up X-Forwarded-Host {host}
+  }
+}
+```
+
+### Step 3.2 - Start Caddy
+
+```bash
+cd /opt/caddy
+
+docker compose up -d
+```
+
+**Note:**
+
+The request url would be `https://storage.example.com/bucket-name/object.txt`.
+It is equivalent to `https://fsn1.your-objectstorage.com/bucket-name/object.txt`.
+
+### Step 3.3 - Create kubernetes deployment and configuration files (Optional)
+
+Assuming you already have configured kubernetes, gateway api.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: caddy-storage
+  namespace: caddy
+spec:
+  type: ClusterIP
+  selector:
+    service: caddy-storage
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: caddy-storage
+  namespace: caddy
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      service: caddy-storage
+  template:
+    metadata:
+      labels:
+        service: caddy-storage
+    spec:
+      containers:
+        - image: "caddy:latest"
+          name: caddy
+          ports:
+            - name: http
+              protocol: TCP
+              containerPort: 80
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/caddy
+      volumes:
+        - name: config-volume
+          configMap:
+            name: caddy-storage-config
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: caddy-storage-config
+  namespace: caddy
+data:
+  Caddyfile: |
+    storage.example.com:80 {
+      reverse_proxy https://fsn1.your-objectstorage.com {
+        header_up Host {http.reverse_proxy.upstream.hostport}
+        header_up X-Forwarded-Host {host}
+      }
+    }
+
+---
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: caddy-storage-route
+  namespace: caddy
+spec:
+  parentRefs:
+    - name: kubernetes-gateway
+      namespace: istio-gateway
+  hostnames:
+    - "storage.example.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: caddy-storage
+          port: 80
+          weight: 100
+```
+
+##### License: MIT
+
+<!--
+
+Contributor's Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it under the license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate license and I have the
+    right under that license to submit that work with modifications,
+    whether created in whole or in part by me, under the same license
+    (unless I am permitted to submit under a different license), as
+    indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are
+    public and that a record of the contribution (including all personal
+    information I submit with it, including my sign-off) is maintained
+    indefinitely and may be redistributed consistent with this project
+    or the license(s) involved.
+
+Signed-off-by: Ivan Zaitsev, https://github.com/ivan-zaitsev
+
+-->

--- a/tutorials/hetzner-object-storage-custom-domain/01.en.md
+++ b/tutorials/hetzner-object-storage-custom-domain/01.en.md
@@ -2,9 +2,9 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/hetzner-object-storage-custom-domain"
 slug: "hetzner-object-storage-custom-domain"
-date: "2025-01-05"
-title: "Setup custom domain with S3-compatible object storage"
-short_description: "This tutorial explains how to setup custom domain for S3-compatible object storage using reverse proxy."
+date: "2025-01-17"
+title: "Setup custom domain for S3-compatible object storage via reverse proxy"
+short_description: "This tutorial explains how to setup custom domains for S3-compatible object storage using reverse proxy."
 tags: ["Custom domain", "Reverse proxy", "Object Storage"]
 author: "Ivan Zaitsev"
 author_link: "https://github.com/ivan-zaitsev"
@@ -18,23 +18,23 @@ cta: "cloud"
 
 ## Introduction
 
-This tutorial will guide you to setup custom domain for S3-compatible object storage using reverse proxy.
-The advantages of custom domain is to enable seamless integration with existing infrastructure or services under a unified domain.
+This tutorial will guide you to setup a custom domain for S3-compatible object storage using reverse proxy.
+The advantages of a custom domain are to enable seamless integration with existing infrastructure or services under a unified domain.
 
-A custom domain can be configured in various ways, such as using a CNAME record or a reverse proxy.
+There are different ways to configure a custom domain, such as using a CNAME record or a reverse proxy.
 This tutorial focuses on configuring a custom domain using a reverse proxy.
 
 **Prerequisites**
 
 * A server (e.g. with [Hetzner Cloud](https://www.hetzner.com/cloud/))
-* A S3-compatible bucket (e.g. with [Hetzner](https://www.hetzner.com))
+* An S3-compatible bucket (e.g. with [Hetzner](https://www.hetzner.com/storage/object-storage/))
 * A domain you want to use (e.g. `storage.example.com`).
 
 ## Step 1 - Create Object Storage Bucket
 
-Create a S3-compatible bucket.
+Create an S3-compatible bucket.
 With Hetzner, see the getting started "[Creating a Bucket](https://docs.hetzner.com/storage/object-storage/getting-started/creating-a-bucket)".
-Make sure it is set to public access permissions. No much benefit of using custom domain for private buckets.
+Make sure it is set to public access permissions. Not much benefit to using a custom domain for private buckets.
 
 Create S3 credentials to access your bucket.
 With Hetzner, see the getting started "[Generating S3 keys](https://docs.hetzner.com/storage/object-storage/getting-started/generating-s3-keys)".
@@ -42,7 +42,7 @@ With Hetzner, see the getting started "[Generating S3 keys](https://docs.hetzner
 ## Step 2 - Create Server
 
 Create a new server.
-With Hetzner, see the getting started "[Creating a Server](https://docs.hetzner.com/cloud/servers/getting-started/creating-a-server)").
+With Hetzner, see the getting started "[Creating a Server](https://docs.hetzner.com/cloud/servers/getting-started/creating-a-server)".
 To install Docker and Docker Compose, follow the [official Docker documentation](https://docs.docker.com/engine/install/).
 
 ## Step 3 - Deploy Caddy
@@ -52,65 +52,84 @@ SSH to your server `ssh root@<server-ip>`.
 Create a directory for your Docker Compose files and folders for the persistent storage of the Caddy container:
 
 ```bash
-mkdir -p /opt/caddy/data
+sudo mkdir -p /opt/caddy/data
 ```
 
-### Step 3.1 - Create docker deployment and configuration files
+### Step 3.1 - Create Docker deployment and configuration files
 
-`vim /opt/caddy/compose.yaml`
+* Add a Docker compose file
+  
+  ```bash
+  sudo vim /opt/caddy/compose.yaml
+  ```
+  Add the following content:
+  ```yaml
+  services:
+    caddy:
+      container_name: caddy
+      image: caddy:latest
+      restart: unless-stopped
+      ports:
+        - 80:80
+        - 443:443
+      volumes:
+         - ./data/Caddyfile:/etc/caddy/Caddyfile
+         - ./data/certs:/certs
+         - ./data/config:/config
+         - ./data/data:/data
+         - ./data/sites:/srv
+  ```
 
-```yaml
-services:
-  caddy:
-    container_name: caddy
-    image: caddy:latest
-    restart: unless-stopped
-    ports:
-      - 80:80
-      - 443:443
-    volumes:
-       - ./data/Caddyfile:/etc/caddy/Caddyfile
-       - ./data/certs:/certs
-       - ./data/config:/config
-       - ./data/data:/data
-       - ./data/sites:/srv
-```
+<br>
 
-`vim /opt/caddy/data/Caddyfile`
+* Add a Caddyfile
 
-```text
-storage.example.com {
-    tls {
-        issuer acme {
-            dir https://acme-v02.api.letsencrypt.org/directory
-        }
-    }
-}
-
-storage.example.com:443 {
-  reverse_proxy https://fsn1.your-objectstorage.com {
-    header_up Host {http.reverse_proxy.upstream.hostport}
-    header_up X-Forwarded-Host {host}
+  ```bash
+  sudo vim /opt/caddy/data/Caddyfile
+  ```
+  Add the following content:
+  
+  > Replace `storage.example.com` with your own domain.  
+  > Replace `fsn1.your-objectstorage.com` with the endpoint of your object storage bucket. If the bucket name comes after the endpoint (e.g. `https://s3-endpoint.example.org/<bucket_name>`) add your endpoint without the bucket name.
+  
+  ```text
+  storage.example.com {
+  
+      tls {
+          issuer acme {
+              dir https://acme-v02.api.letsencrypt.org/directory
+          }
+      }
+  
+      reverse_proxy https://<bucket_name>.fsn1.your-objectstorage.com {
+      #reverse_proxy https://s3-endpoint.example.org {
+        header_up Host {http.reverse_proxy.upstream.hostport}
+        header_up X-Forwarded-Host {host}
+      }
   }
-}
-```
+  ```
 
 ### Step 3.2 - Start Caddy
 
 ```bash
 cd /opt/caddy
-
 docker compose up -d
+docker ps
 ```
 
-**Note:**
+After the Docker container started, you can access your files via `storage.example.com`.
 
-The request url would be `https://storage.example.com/bucket-name/object.txt`.
-It is equivalent to `https://fsn1.your-objectstorage.com/bucket-name/object.txt`.
+If your bucket name comes after the endpoint, note:
 
-### Step 3.3 - Create kubernetes deployment and configuration files (Optional)
+The request URL would be `https://storage.example.com/<bucket_name>/object.txt`.  
+It is equivalent to `https://s3-endpoint.example.org/<bucket_name>/object.txt`.
 
-Assuming you already have configured kubernetes, gateway api.
+### Step 3.3 - Create Kubernetes deployment and configuration files (Optional)
+
+Assuming you already have configured Kubernetes, [gateway API](https://gateway-api.sigs.k8s.io/guides/#installing-gateway-api).
+
+> Replace `storage.example.com` with your own domain.  
+> Replace `fsn1.your-objectstorage.com` with the endpoint of your object storage bucket. If the bucket name comes after the endpoint (e.g. `https://s3-endpoint.example.org/<bucket_name>`) add your endpoint without the bucket name.
 
 ```yaml
 apiVersion: v1
@@ -171,7 +190,8 @@ metadata:
 data:
   Caddyfile: |
     storage.example.com:80 {
-      reverse_proxy https://fsn1.your-objectstorage.com {
+      reverse_proxy https://<bucket_name>.fsn1.your-objectstorage.com {
+      #reverse_proxy https://s3-endpoint.example.org {
         header_up Host {http.reverse_proxy.upstream.hostport}
         header_up X-Forwarded-Host {host}
       }
@@ -200,6 +220,10 @@ spec:
           port: 80
           weight: 100
 ```
+
+## Conclusion
+
+You should now be able to access the contents of your S3-compatible object storage via a custom domain.
 
 ##### License: MIT
 


### PR DESCRIPTION
Tutorial shows how to setup custom domain with S3-compatible object storage using a reverse proxy.

At the time of writing this tutorial custom domain using CNAME is not available, and reverse proxy is the only way.

```
I have read and understood the Contributor's Certificate of Origin available at the end of 
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Ivan Zaitsev https://github.com/ivan-zaitsev
```