### PR TITLE
Update "Restrict access by an IP or password in nginx"

### DIFF
--- a/tutorials/restrict-access-by-ip-or-password-in-nginx/01.en.md
+++ b/tutorials/restrict-access-by-ip-or-password-in-nginx/01.en.md
@@ -133,7 +133,7 @@ curl -4 --head http://example.com
 ```
 
 > * Replace `example.com` with `server_name` of the `server` you want to configure, and `http` with `https` if necessary.
-> 
+>
 > * The combination of the domain (or an IP) and port must correspond to the nginx `server_name` and `listen` directive (in this example, port `80` is used because it is the default for HTTP).
 
 You should get the output similar to this, with the HTTP status `200`:
@@ -168,7 +168,7 @@ You need to add this line to the appropriate `location` context in your `server`
 deny 10.0.0.5;
 ```
 
-> Replace `10.0.0.5` with your own public IP. 
+> Replace `10.0.0.5` with your own public IP.
 
 The complete configuration may look like this:
 
@@ -297,9 +297,9 @@ sudo systemctl reload nginx
 <summary><b>Attention!</b></summary>
 
 1. If you have a configuration like this, requests to `example.com/admin/index.php` will **not** be protected:
-   
+
    > The request is handled with the `location ~ \.php$` context. This means that the allow and deny directives of `location /admin` are **not** used.
-   
+
    ```nginx
    server {
        listen 80;
@@ -318,23 +318,23 @@ sudo systemctl reload nginx
        }
    }
    ```
-   
+
    > * `location /` and `location /admin` are "prefix locations"
    > * `location ~ \.php$` is a "regular expression location"
-   
+
    In the example request `example.com/admin/index.php`:
-   
+
    * The path `/admin` matches with the "**prefix location**" `location /admin`.
    * The file `index.php` matches with the "**regular expression location**" `location ~ \.php$`.
-   
+
    Nginx remembers the longest **prefix location** that matches the request, in this example that's `location/admin`. However, it will only use the **prefix location** to process the request if no **regular expression location** matches the request. In this example, the regular expression location `location ~ \.php$` matches the request and is used.
-   
+
    **Regular expression locations** are marked with a tilde `~` or `~*`. Starting from the top of the `server` block, nginx first checks every **prefix location** inside out. The first matching regular expression location that nginx can find is automatically used.
- 
+
    Hence, the regular expression `location` must be defined separately for the protected prefix `location` as show below.
-  
+
 2. If you edit the configuration from above like this, requests to `example.com/admin/index.php` will be protected:
-   
+
    > The request is handled with the first **regular expression locations** that matches the request.  In this configuration, that's the `location ~ \.php$` context within the `location /admin` context. This means that the allow and deny directives of `location /admin` **are used**.
 
    ```nginx
@@ -360,17 +360,17 @@ sudo systemctl reload nginx
        }
    }
    ```
-  
+
 3. If you don't like duplication, you can put the common parts into a file and refer to this file via an `include` directive. In this example, the file `/etc/nginx/php.conf` can be created with these directives:
-   
+
    ```nginx
    try_files $fastcgi_script_name =404;
    fastcgi_pass unix:/run/php/php-fpm.sock;
    include fastcgi.conf;
    ```
-   
+
    Now, it can be included:
-   
+
    ```nginx
    server {
        listen 80;
@@ -455,75 +455,75 @@ and you can show the message to the blocked client. The message can contain vari
 First of all, you need to install the nginx dynamic module `geoip2` which adds support for the IP databases with geographical information. The database will be queried to determine the country of the user by their IP. This information in turn will be used to allow or block access.
 
 - Install the required package:
-  
+
   ```bash
   sudo apt update && sudo apt install libnginx-mod-http-geoip2
   ```
-  
+
 - Check the `/etc/nginx/nginx.conf` file:
-  
+
   By default, at the beginning of the file `/etc/nginx/nginx.conf` and outside of any curly brackets, you must have the uncommented line:
-  
+
   ```nginx
   include /etc/nginx/modules-enabled/*.conf;
   ```
-  
+
   If it's not the case, you need to add or uncomment it.
-  
+
   Alternatively, you can load only `geoip2` module like this:
-  
+
   ```nginx
   load_module modules/ngx_http_geoip2_module.so;
   ```
-  
+
 - Reload the nginx configuration:
-  
+
   ```bash
   sudo systemctl reload nginx
   ```
 
 Now you only have the `geoip2` module, this is not enough to start enabling restrictions.
 
-You need to download the `geoip2` compatible IP database that can be used to check the country of a user. 
+You need to download the `geoip2` compatible IP database that can be used to check the country of a user.
 
 - Install the required package:
-  
-  
+
+
   ```bash
   cd /etc/nginx && sudo curl --fail -LO https://github.com/P3TERX/GeoLite.mmdb/releases/latest/download/GeoLite2-Country.mmdb
   ```
-  
+
   Alternatively you can [create an account](https://www.maxmind.com/en/geolite2/signup?lang=en) on the MaxMind website and download the GeoLite2 Country database from there:
-  
+
   1. Open the [registration form](https://www.maxmind.com/en/geolite2/signup?lang=en) in your browser and fill it in.
   2. You will receive an email with the link to create your password.
   3. [Log in](https://www.maxmind.com/en/account/login) with your email and password.
   4. Go to `Account / Manage License Keys` and create a new license key. Copy your license key and save it somewhere.
   5. Now you can download the GeoLite2 Country database by running this command:
-  
+
     ```bash
     cd /etc/nginx && sudo curl --fail -o GeoLite2-Country.tar.gz "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=YOUR_LICENSE_KEY&suffix=tar.gz" && sudo tar --strip-components=1 -xzf GeoLite2-Country.tar.gz --wildcards "*.mmdb" && sudo rm GeoLite2-Country.tar.gz
     ```
     > Replace `YOUR_LICENSE_KEY` with your license key. The database is saved to the file `/etc/nginx/GeoLite2-Country.mmdb`.
-    
+
 - Edit the nginx configuration
-  
+
   Now you need to edit your nginx configuration to add the `geoip2` directive which loads the database into nginx. After the database is loaded, it can be used to block or allow access.
   The complete configuration may look like this:
-  
+
   > `0 = allow` and `1 = deny`
 
   ```nginx
   geoip2 /etc/nginx/GeoLite2-Country.mmdb {
       $user_country country iso_code;
   }
-  
+
   map $user_country $not_allowed {
       CA       1;
       US       1;
       default  0;
   }
-  
+
   server {
       listen 80;
       server_name example.com;
@@ -534,16 +534,16 @@ You need to download the `geoip2` compatible IP database that can be used to che
       }
   }
   ```
-  
+
   * `geoip2` directive is used to specify the path to an IP database and to define variables.
   In the example above, the variable `$user_country` is defined.
   When the request is processed by nginx, this variable is set to the user country's two-letter code.
-  
+
   * `map` directive is used to create the boolean variable `$not_allowed`. Its value is chosen according to the `$user_country` variable defined in the `geoip2` block.
   In this example configuration, the users from United States and Canada are blocked, users from other countries are allowed. The two-letter country codes which can be used inside the `map` are listed [on this Wikipedia page](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes).
-  
+
   * Finally, the `$not_allowed` variable is used inside the `if` statement to block or allow a request.
-  
+
 You can find more information about the `geoip2` module on its [GitHub page](https://github.com/leev/ngx_http_geoip2_module).
 
 ## Step 5 - Password-based authentication
@@ -552,13 +552,13 @@ You can restrict access by only allowing access to users with a password. This i
 
 > You can use [this tutorial](https://community.hetzner.com/tutorials/add-ssl-certificate-with-lets-encrypt-to-nginx-on-ubuntu-20-04) to setup HTTPS.
 > The configuration you will end up with will be similar to this:
-> 
+>
 > ```nginx
 > server {
 >     server_name example.com;
 >     location / {
 >     }
-> 
+>
 >     listen 443 ssl; # managed by Certbot
 >     ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem; # managed by Certbot
 >     ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem; # managed by Certbot
@@ -566,7 +566,7 @@ You can restrict access by only allowing access to users with a password. This i
 >     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 > }
 > ```
-> 
+>
 > After you have configured HTTPS, you can setup the password-based authentication.
 
 First of all, you need to create a special file where all usernames and corresponding passwords are stored.
@@ -576,22 +576,32 @@ You can create it like this:
 sudo touch /etc/nginx/users
 ```
 
-You can use this command to add users:
+You can use this command to add users: <a id="create_user"></a>
 
 * Follow the prompts. If you made a mistake, you can cancel the command by pressing `Ctrl + C`.
 
 * Note that this command uses `sudo` and may ask for your password, this is not the password for the new user.
 
 ```bash
-python3 -c 'from subprocess import *; import sys; print("Username: ", end="", file=sys.stderr); user = input();
-passwd = run(["openssl", "passwd", "-6"], encoding="utf-8", stdout=PIPE).stdout.strip();
-print("Username or password is empty. Try again!", file=sys.stderr) if user == "" or passwd == "" else print(user + ":" + passwd)' | sudo tee -a /etc/nginx/users
+while true; do
+  read -r -p "Username: " ngxuser
+  if [[ -z "$ngxuser" ]]; then
+    echo "Username is empty. Try again!"
+    continue
+  fi
+  ngxpass="$(openssl passwd -6)"
+  if (( $? != 0 )); then
+    echo "Try again!"
+  else
+    break
+  fi
+done; echo "$ngxuser:$ngxpass" | sudo tee -a /etc/nginx/users
 ```
 
 Above command will add the user to the `/etc/nginx/users` file, and additionally output the username and hash of the password to your terminal separated by a colon `:`.
 The password itself is not stored on the server.
 
-You can add more users to `/etc/nginx/users` by repeating the same `python3` command above.
+You can add more users to `/etc/nginx/users` by repeating the same command above.
 You can manually edit `/etc/nginx/users` to remove users. Each user is on a separate line.
 
 The special file with users is created and you can now modify your `server` block.
@@ -642,14 +652,14 @@ You can test the new configuration with `curl`:
 
 * With username and password:
 
-  Replace `user` with your username, `password` with your password created using the `python3` command above, and `example.com` with your domain.
+  Replace `user` with your username, `password` with your password created using the [command above](#create_user), and `example.com` with your domain.
 
   ```bash
   curl --verbose -u user:password https://example.com
   ```
 
   This time you should get HTTP status `200` and the requested content. Response headers will look like this:
-  
+
   ```
   < HTTP/1.1 200 OK
   < Server: nginx
@@ -667,7 +677,7 @@ You can test the new configuration with `curl`:
 **Restricting access to a single URL**
 
 - You can restrict access to a single URL by adding the `auth_basic` and `auth_basic_user_file` directives directly to a `location` context instead of its parent-context `server`. For example:
-  
+
   ```nginx
   server {
       server_name example.com;
@@ -677,7 +687,7 @@ You can test the new configuration with `curl`:
           auth_basic "Protected area!";
           auth_basic_user_file /etc/nginx/users;
       }
-  
+
       listen 443 ssl; # managed by Certbot
       ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem; # managed by Certbot
       ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem; # managed by Certbot
@@ -685,7 +695,7 @@ You can test the new configuration with `curl`:
       ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
   }
   ```
-  
+
   Here, `location /admin` is protected by password-based authentication.
 
 -------------
@@ -693,13 +703,13 @@ You can test the new configuration with `curl`:
 **Logging of wrong access details**
 
 - If someone used the wrong password, it will be logged to the `/var/log/nginx/error.log` file like this:
-  
+
   ```log
   2023/03/28 12:06:49 [error] 1865#1865: *14 user "holu": password mismatch, client: 10.0.0.5, server: example.com, request: "GET / HTTP/1.1", host: "example.com"
   ```
 
 - If someone used a username that doesn't exist in the `/etc/nginx/users` file, it will be logged to the `error.log` file like this:
-  
+
   ```log
   2023/03/28 12:08:21 [error] 1865#1865: *16 user "root" was not found in "/etc/nginx/users", client: 10.0.0.5, server: example.com, request: "GET / HTTP/1.1", host: "example.com"
   ```


### PR DESCRIPTION
Replace python snippet with bash, which is more appropriate here. Works the same.

I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: wpdevelopment11 wpdevelopment11@gmail.com