### PR TITLE
Added firewall rule to allow ICMPv6

### DIFF
--- a/tutorials/game-server-ddos-protection/01.de.md
+++ b/tutorials/game-server-ddos-protection/01.de.md
@@ -90,6 +90,9 @@ Wenn die Firewall noch keine Regeln hat, können diese jetzt hinzugefügt werden
 Wenn du nicht den Standard-Port für SSH verwendest, ersetze `22` entsprechend in den folgenden Befehlen.
 
 ```bash
+# ICMPv6 erlauben (für IPv6 zwingend erforderlich)
+sudo ip6tables -A INPUT -p icmpv6 -j ACCEPT
+
 # SSH-Verbindungen erlauben
 sudo iptables -A INPUT -p tcp --dport 22 -j ACCEPT  # Für IPv4-Adressen
 sudo ip6tables -A INPUT -p tcp --dport 22 -j ACCEPT # Für IPv6-Adressen

--- a/tutorials/game-server-ddos-protection/01.en.md
+++ b/tutorials/game-server-ddos-protection/01.en.md
@@ -90,6 +90,9 @@ If the firewall doesn't have any rules yet, you can add them now. When you set t
 If you are not using the default SSH port, make sure to replace `22` accordingly in the commands below.
 
 ```bash
+# Allow ICMPv6 (required for IPv6)
+sudo ip6tables -A INPUT -p icmpv6 -j ACCEPT
+
 # Allow SSH connections
 sudo iptables -A INPUT -p tcp --dport 22 -j ACCEPT  # For IPv4 addresses
 sudo ip6tables -A INPUT -p tcp --dport 22 -j ACCEPT # For IPv6 addresses


### PR DESCRIPTION
ICMPv6 is required for IPv6, else the server might become unreachable.