### PR TITLE
New tutorial: Proxmox ZFS Rescue Mode

### DIFF
--- a/tutorials/proxmox-zfs-rescue-mode/01.de.md
+++ b/tutorials/proxmox-zfs-rescue-mode/01.de.md
@@ -1,0 +1,101 @@
+### Mounten von ZFS-Pools im Rescue-Modus
+
+Dieses Dokument beschreibt, wie man auf das ZFS-Dateisystem im Rescue-Modus zugreift, um die Netzwerkkonfiguration oder andere Systemprobleme auf einem Proxmox-Server zu beheben.
+
+#### Voraussetzungen
+
+- Zugriff auf den Rescue-Modus Ihres Servers
+- Server mit ZFS-basiertem Speicher (wie Proxmox mit ZFS RAID0)
+
+#### Schritt 1: Verfügbare ZFS-Pools identifizieren
+
+Prüfen Sie, welche ZFS-Pools auf Ihrem System erkannt werden können:
+
+```bash
+zpool import
+```
+
+#### Schritt 2: ZFS-Pool importieren
+
+Importieren Sie den Pool (ersetzen Sie "rpool" durch Ihren Pool-Namen, falls abweichend):
+
+```bash
+zpool import rpool
+```
+
+#### Schritt 3: Pool-Status überprüfen
+
+Überprüfen Sie den Status des importierten Pools, um sicherzustellen, dass alles korrekt funktioniert:
+
+```bash
+zpool status
+```
+
+#### Schritt 4: ZFS-Datasets auflisten
+
+Listen Sie alle verfügbaren Datasets auf, um das Root-Dateisystem zu identifizieren:
+
+```bash
+zfs list
+```
+
+Typischerweise für Proxmox wird Ihre Ausgabe etwa so aussehen:
+
+```
+NAME               USED  AVAIL  REFER  MOUNTPOINT
+rpool             1.81G   913G   104K  /rpool
+rpool/ROOT        1.81G   913G    96K  /rpool/ROOT
+rpool/ROOT/pve-1  1.81G   913G  1.81G  /
+rpool/data          96K   913G    96K  /rpool/data
+rpool/var-lib-vz    96K   913G    96K  /var/lib/vz
+```
+
+#### Schritt 5: Root-Dateisystem mounten
+
+Erstellen Sie einen temporären Mount-Punkt und mounten Sie das Root-Dateisystem:
+
+```bash
+mkdir -p /mnt/proxmox
+zfs set mountpoint=/mnt/proxmox rpool/ROOT/pve-1
+zfs mount rpool/ROOT/pve-1
+```
+
+#### Schritt 6: Dateien zugreifen und bearbeiten
+
+Jetzt können Sie auf Systemdateien zugreifen und diese bearbeiten, einschließlich der Netzwerkkonfiguration:
+
+```bash
+nano /mnt/proxmox/etc/network/interfaces
+```
+
+#### Schritt 7: Ursprünglichen Mount-Punkt wiederherstellen und aufräumen
+
+Nachdem Sie Ihre Änderungen vorgenommen haben, stellen Sie den ursprünglichen Mount-Punkt wieder her und räumen auf:
+
+```bash
+zfs umount rpool/ROOT/pve-1
+zfs set mountpoint=/ rpool/ROOT/pve-1
+zpool export rpool
+```
+
+#### Schritt 8: Neustart
+
+Verlassen Sie den Rescue-Modus und starten Sie Ihr System neu:
+
+```bash
+reboot
+```
+
+### Fehlerbehebung
+
+Wenn Sie Probleme beim Importieren des Pools haben, versuchen Sie, den Import zu erzwingen:
+
+```bash
+zpool import -f rpool
+```
+
+Wenn der Pool-Name nicht erkannt wird, versuchen Sie:
+
+```bash
+zpool import -d /dev/disk/by-id
+```

--- a/tutorials/proxmox-zfs-rescue-mode/01.en.md
+++ b/tutorials/proxmox-zfs-rescue-mode/01.en.md
@@ -1,0 +1,105 @@
+# ZFS Rescue Mode Documentation for Proxmox Server
+
+This tutorial describes how to mount ZFS filesystems in rescue mode to fix network configuration or other system issues on a Proxmox server with a ZFS RAID0 configuration.
+
+### Mounting ZFS Pools in Rescue Mode
+
+This document describes how to access the ZFS file system while in rescue mode to fix network configuration or other system issues on a Proxmox server.
+
+#### Prerequisites
+
+- Access to your server's rescue mode
+- Server with ZFS-based storage (like Proxmox with ZFS RAID0)
+
+#### Step 1: Identify Available ZFS Pools
+
+Check which ZFS pools can be detected on your system:
+
+```bash
+zpool import
+```
+
+#### Step 2: Import the ZFS Pool
+
+Import the pool (replace "rpool" with your pool name if different):
+
+```bash
+zpool import rpool
+```
+
+#### Step 3: Verify Pool Status
+
+Check the status of the imported pool to ensure everything is working correctly:
+
+```bash
+zpool status
+```
+
+#### Step 4: List ZFS Datasets
+
+List all available datasets to identify the root filesystem:
+
+```bash
+zfs list
+```
+
+Typically for Proxmox, your output will show something like:
+
+```
+NAME               USED  AVAIL  REFER  MOUNTPOINT
+rpool             1.81G   913G   104K  /rpool
+rpool/ROOT        1.81G   913G    96K  /rpool/ROOT
+rpool/ROOT/pve-1  1.81G   913G  1.81G  /
+rpool/data          96K   913G    96K  /rpool/data
+rpool/var-lib-vz    96K   913G    96K  /var/lib/vz
+```
+
+#### Step 5: Mount the Root Filesystem
+
+Create a temporary mount point and mount the root filesystem:
+
+```bash
+mkdir -p /mnt/proxmox
+zfs set mountpoint=/mnt/proxmox rpool/ROOT/pve-1
+zfs mount rpool/ROOT/pve-1
+```
+
+#### Step 6: Access and Edit Files
+
+Now you can access and edit system files, including network configuration:
+
+```bash
+nano /mnt/proxmox/etc/network/interfaces
+```
+
+#### Step 7: Restore Original Mount Point and Clean Up
+
+After making your changes, restore the original mount point and clean up:
+
+```bash
+zfs umount rpool/ROOT/pve-1
+zfs set mountpoint=/ rpool/ROOT/pve-1
+zpool export rpool
+```
+
+#### Step 8: Reboot
+
+Exit rescue mode and reboot your system:
+
+```bash
+reboot
+```
+
+### Troubleshooting
+
+If you encounter issues importing the pool, try forcing the import:
+
+```bash
+zpool import -f rpool
+```
+
+If the pool name isn't recognized, try:
+
+```bash
+zpool import -d /dev/disk/by-id
+```


### PR DESCRIPTION
I have created a tutorial that shows how to access and repair a Proxmox server with ZFS storage from rescue mode. This guide is particularly useful when network configurations need to be fixed or when the server cannot boot normally.
The tutorial provides step-by-step instructions on:

Importing ZFS pools in rescue mode
Identifying and mounting the correct ZFS datasets
Accessing and editing configuration files
Properly unmounting and exporting the ZFS pool before reboot

It's available in both English and German versions, and follows all Hetzner Community guidelines.
I have read and understood the Contributor's Certificate of Origin available at the end of https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Malte Werkhausen [malte@werkhausen.org](mailto:malte@werkhausen.org)