### PR TITLE
Fixed typo in "Securing the SSH service"

### DIFF
--- a/tutorials/securing-ssh/01.de.md
+++ b/tutorials/securing-ssh/01.de.md
@@ -29,7 +29,7 @@ Dabei werden die folgenden Punkte genauer erläutert:
 
 Dieses Tutorial erklärt, wie man die Datei `/etc/ssh/sshd_config` bearbeitet, die vom traditionellen SSH verwendet wird.
 
-Wenn Ihr System Socket-basiertes SSH verwendet (Ubuntu 22.10 und höher) und Sie trotzdem diesem Tutorial folgen möchten, müssen Sie `ssh.socket` deaktivieren und `ssh.service` manuel aktivieren.
+Wenn Ihr System Socket-basiertes SSH verwendet (Ubuntu 22.10 und höher) und Sie trotzdem diesem Tutorial folgen möchten, müssen Sie `ssh.socket` deaktivieren und `ssh.service` manuell aktivieren.
 
 <blockquote>
 <details>

--- a/tutorials/securing-ssh/01.de.md
+++ b/tutorials/securing-ssh/01.de.md
@@ -114,7 +114,7 @@ ClientAliveInterval 300
 ClientAliveCountMax 1
 ```
 
-`ClientActiveInterval` definiert die maximale Zeit, in der die Sitzung inaktiv sein darf, bevor sie geschlossen wird. In diesem Fall sind 300 Sekunden 5 Minuten. `ClientAliveCountMax` definiert die Anzahl der Prüfungen, die vor einer Trennung durchzuführen sind.
+`ClientAliveInterval` definiert die maximale Zeit, in der die Sitzung inaktiv sein darf, bevor sie geschlossen wird. In diesem Fall sind 300 Sekunden 5 Minuten. `ClientAliveCountMax` definiert die Anzahl der Prüfungen, die vor einer Trennung durchzuführen sind.
 
 ### Schritt 1.3 - Benutzer für SSH freischalten
 

--- a/tutorials/securing-ssh/01.en.md
+++ b/tutorials/securing-ssh/01.en.md
@@ -113,7 +113,7 @@ ClientAliveInterval 300
 ClientAliveCountMax 1
 ```
 
-`ClientActiveInterval` defines the maximum time the session can be inactive before it terminates. In this case, 300 seconds is 5 minutes. `ClientAliveCountMax` defines the number of checks to be performed before a disconnect.
+`ClientAliveInterval` defines the maximum time the session can be inactive before it terminates. In this case, 300 seconds is 5 minutes. `ClientAliveCountMax` defines the number of checks to be performed before a disconnect.
 
 ### Step 1.3 - Enable user for SSH
 


### PR DESCRIPTION
I noticed a typo when I was working my way through the article "Securing the SSH service". The keyword `ClientActiveInterval` does not exist and appearantly got confused with the keyword [`ClientAliveInterval`](https://manpages.ubuntu.com/manpages/noble/en/man5/sshd_config.5.html#:~:text=disables%20connection%20termination.-,ClientAliveInterval,-Sets%20a%20timeout). I have therefore replaced it accordingly