### PR TITLE
Fix broken links

### DIFF
--- a/tutorials/configuring-windows-remote-desktop-services/01.de.md
+++ b/tutorials/configuring-windows-remote-desktop-services/01.de.md
@@ -61,7 +61,7 @@ Die Lösung ist, den `REG_BINARY` Wert innerhalb der Registry in untenstehendem 
 
 (Zum Löschen ist im Vorfeld das Anpassen der zugehörigen Permissions erforderlich.)
 
-[Quelle](http://www.360ict.nl/blog/no-remote-desktop-licence-server-availible-on-rd-session-host-server-2012/)
+[Quelle](https://360ict.nl/en/blog/no-remote-desktop-licence-server-availible-on-rd-session-host-server-2012)
 
 ## Designvorgabe Microsoft
 

--- a/tutorials/configuring-windows-remote-desktop-services/01.en.md
+++ b/tutorials/configuring-windows-remote-desktop-services/01.en.md
@@ -61,7 +61,7 @@ The solution is to delete the `REG_BINARY` value within the registry at the belo
 
 (you must take ownership and give admin users full control to be able to delete this key)
 
-[Source](http://www.360ict.nl/blog/no-remote-desktop-licence-server-availible-on-rd-session-host-server-2012/)
+[Source](https://360ict.nl/en/blog/no-remote-desktop-licence-server-availible-on-rd-session-host-server-2012)
 
 ## Microsoft Design Specification
 

--- a/tutorials/configuring-windows-remote-desktop-services/01.ru.md
+++ b/tutorials/configuring-windows-remote-desktop-services/01.ru.md
@@ -60,7 +60,7 @@ The remote session was disconnected because there are no Remote Desktop Licence 
 
 (вы должны взять на себя ответственность и дать администраторам полный контроль, чтобы они имели возможность удалить этот ключ)
 
-[Источник](http://www.360ict.nl/blog/no-remote-desktop-licence-server-availible-on-rd-session-host-server-2012/)
+[Источник](https://360ict.nl/en/blog/no-remote-desktop-licence-server-availible-on-rd-session-host-server-2012)
 
 ## Особенности архитектуры Microsoft
 

--- a/tutorials/create-and-install-custom-centos-8-image/01.en.md
+++ b/tutorials/create-and-install-custom-centos-8-image/01.en.md
@@ -26,7 +26,7 @@ You will need a virtualisation tool to install CentOS 8. I used GNOME Boxes, a p
 
 ## Step 1 - Install CentOS 8 in a VM
 
-You can download the install image from any of the mirrors: [CentOS 8](http://isoredirect.centos.org/centos/8/isos/x86_64/) or [CentOS 8 Stream](http://isoredirect.centos.org/centos/8-stream/isos/x86_64/). I strongly recommend getting the much smaller "boot" version.
+You can download the install image from any of the mirrors: [CentOS 8](https://vault.centos.org/8.5.2111/isos/x86_64/) or [CentOS 8 Stream](https://vault.centos.org/8-stream/isos/x86_64/). I strongly recommend getting the much smaller "boot" version.
 
 Settings for the VM box don't matter. Just install it as you normally would.
 

--- a/tutorials/howto-hcloud-terraform-fedora-coreos/01.en.md
+++ b/tutorials/howto-hcloud-terraform-fedora-coreos/01.en.md
@@ -256,7 +256,7 @@ passwd:
 
 ### Step 3.2 - Adjust the configuration files
 
-In the section `Variables` of the `main.tf`, adjust the default values for `ssh_public_key`, `ssh_public_key_name`, `hcloud_server_type`, `hcloud_server_datacenter` and `hcloud_server_name` to your needs or add a [`terraform.tfvars` file](https://www.terraform.io/docs/configuration/variables.html#variable-definitions-tfvars-files) to set your desired settings.
+In the section `Variables` of the `main.tf`, adjust the default values for `ssh_public_key`, `ssh_public_key_name`, `hcloud_server_type`, `hcloud_server_datacenter` and `hcloud_server_name` to your needs or add a [`terraform.tfvars` file](https://developer.hashicorp.com/terraform/language/values/variables#variable-definitions-tfvars-files) to set your desired settings.
 
 Optionally, have a look at the `config.yaml`. This file will be used by the `coreos-installer` to configure the OS. For the first try, you should leave it as it is. But after successful provisioning, you want to add `systemd` service definitions to [run containers](https://docs.fedoraproject.org/en-US/fedora-coreos/running-containers/) on it.
 

--- a/tutorials/install-and-configure-vmware-vcenter/01.en.md
+++ b/tutorials/install-and-configure-vmware-vcenter/01.en.md
@@ -36,7 +36,7 @@ More information on licensing can be found [here](https://blogs.vmware.com/vsphe
 
 We have to download the vCenter Server Appliance ISO, mount it and install it.
 
-First, download the vCenter Server Appliance ISO. You can download it from [here](https://my.vmware.com/web/vmware/details?productId=742&rPId=22641&downloadGroup=VC67U2).
+First, download the vCenter Server Appliance ISO.
 
 Select the most up-to-date version on the top, and then click on the blue Download Now button next to "VMware vCenter Server Appliance". You will have to login with your VMware account and click on the blue link to activate your VMware vSphere 6.7 trial.
 

--- a/tutorials/install-and-secure-phpmyadmin-with-nginx-on-centos-7/01.en.md
+++ b/tutorials/install-and-secure-phpmyadmin-with-nginx-on-centos-7/01.en.md
@@ -24,7 +24,7 @@ phpMyAdmin is a free and open source administration tool for MySQL and MariaDB. 
 
 - Make sure you are logged into your server with a `sudo` user.
 
-- Install LEMP Stack on CentOS 7. Follow the tutorial on [Install LEMP Stack on CentOS 7](https://community.hetzner.com/tutorials/install-lemp-stack-on-centos-7).
+- Install LEMP Stack on CentOS 7. Follow the tutorial on [Install LEMP Stack on CentOS 7](https://community.hetzner.com/tutorials/install-matomo-analytics-on-centos-7#step-1---installing-lemp-stack).
 
 ## Step 1 - Install phpMyAdmin
 

--- a/tutorials/install-kubernetes-cluster/01.en.md
+++ b/tutorials/install-kubernetes-cluster/01.en.md
@@ -545,7 +545,7 @@ data:
 EOF
 ```
 
-This will configure MetalLB to use the IPv4 Floating IP as LoadBalancer IP. MetalLB can reuse IPs for multiple LoadBalancer services if some [conditions](https://metallb.universe.tf/usage/#ip-address-sharing) are met. This can be enabled by adding an annotation `metallb.universe.tf/allow-shared-ip` to the service.
+This will configure MetalLB to use the IPv4 Floating IP as LoadBalancer IP. MetalLB can reuse IPs for multiple LoadBalancer services if some [conditions](https://metallb.io/usage/#ip-address-sharing) are met. This can be enabled by adding an annotation `metallb.universe.tf/allow-shared-ip` to the service.
 
 ### Step 3.7 - Setup Floating IP failover (Optional)
 

--- a/tutorials/install-outline-vpn-server/01.en.md
+++ b/tutorials/install-outline-vpn-server/01.en.md
@@ -37,18 +37,9 @@ In this tutorial we will install [Outline](https://getoutline.org/), a VPN serve
 
 You will need to download two clients. The Outline Manager to administrate your server and the Outline Client to establish the VPN connection.
 
-Outline Manager download links:
-[Windows](https://raw.githubusercontent.com/Jigsaw-Code/outline-releases/master/manager/stable/Outline-Manager.exe)  
-[MacOS](https://raw.githubusercontent.com/Jigsaw-Code/outline-releases/master/manager/stable/Outline-Manager.dmg)  
-[Linux](https://raw.githubusercontent.com/Jigsaw-Code/outline-releases/master/manager/stable/Outline-Manager.AppImage)  
+* [Outline Manager download links](https://github.com/Jigsaw-Code/outline-releases?tab=readme-ov-file#outline-manager).
 
-Outline Client download links:
-[Android](https://play.google.com/store/apps/details?id=org.outline.android.client)  
-[Windows](https://raw.githubusercontent.com/Jigsaw-Code/outline-releases/master/client/stable/Outline-Client.exe)  
-[ChromeOS](https://play.google.com/store/apps/details?id=org.outline.android.client)  
-[iOS](https://itunes.apple.com/us/app/outline-app/id1356177741)  
-[MacOS](https://itunes.apple.com/us/app/outline-app/id1356178125)  
-[Linux](https://raw.githubusercontent.com/Jigsaw-Code/outline-releases/master/client/stable/Outline-Client.AppImage)  
+* [Outline Client download links](https://github.com/Jigsaw-Code/outline-releases?tab=readme-ov-file#outline-client). 
 
 ## Step 3 - Install updates on the server (Optional)
 

--- a/tutorials/lsi-raid-controller/01.ru.md
+++ b/tutorials/lsi-raid-controller/01.ru.md
@@ -16,4 +16,4 @@ header_img: "header-2"
 
 ## Information
 
-This article is located at [docs.hetzner.com](https://docs.hetzner.com/en/robot/dedicated-server/raid/lsi-raid-controller/)
+This article is located at [docs.hetzner.com](https://docs.hetzner.com/robot/dedicated-server/raid/lsi-raid-controller/)

--- a/tutorials/setup-https-on-nginx-on-freebsd-12/01.en.md
+++ b/tutorials/setup-https-on-nginx-on-freebsd-12/01.en.md
@@ -23,14 +23,14 @@ If you are already using a domain with your website, it's completely free!
 
 *Despite this tutorial being focused on websites, a Let's Encrypt TLS certificate can be used with other services like SMTP/IMAP (mail servers), FTP, or XMPP (IM servers)*
 
-This tutorial will guide you through the steps necessary to update an already existing FreeBSD 12 server with a FEMP stack to use a HTTPS certificate provided by [Let's Encrypt](https://letsencrypt.org/). If you do not have a FEMP stack setup yet, please follow [this tutorial first.](https://community.hetzner.com/tutorials/install-a-femp-stack-on-freebsd-12)
+This tutorial will guide you through the steps necessary to update an already existing FreeBSD 12 server with a FEMP stack to use a HTTPS certificate provided by [Let's Encrypt](https://letsencrypt.org/). If you do not have a FEMP stack setup yet, please follow [this tutorial first.](https://community.hetzner.com/tutorials/install-a-femp-stack-on-freebsd)
 
 * It is assumed that you are running as the `root` user during this guide. Use `su` to change to `root` if you are not running as `root` already.
 
 **Prerequisites**
 
 * A FreeBSD 12 server with root access.
-* A FEMP stack (FreeBSD, Engine X, MySQL, PHP) installed as setup in [this tutorial.](https://community.hetzner.com/tutorials/install-a-femp-stack-on-freebsd-12)
+* A FEMP stack (FreeBSD, Engine X, MySQL, PHP) installed as setup in [this tutorial.](https://community.hetzner.com/tutorials/install-a-femp-stack-on-freebsd)
 * A domain or subdomain which can work with Let's Encrypt (e.g. *.your-server.de won't work as it has a CAA record preventing certificates for Let's Encrypt)
 
 ## Step 1 - Configuring Domain DNS Records

--- a/tutorials/testing-ansible-with-molecule/01.de.md
+++ b/tutorials/testing-ansible-with-molecule/01.de.md
@@ -354,7 +354,7 @@ Herzlichen Glückwunsch! Du hast erfolgreich eine Ansible-Rolle mit Molecule ein
 Zusätzliche Ressourcen:
 
 * [Molecule Documentation](https://ansible.readthedocs.io/projects/molecule/)
-* [Ansible Galaxy](https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/community/userguide/)
+* [Ansible Galaxy](https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/)
 * [Hetzner Ansible Module](https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/server_module.html)
 
 ##### License: MIT

--- a/tutorials/testing-ansible-with-molecule/01.en.md
+++ b/tutorials/testing-ansible-with-molecule/01.en.md
@@ -354,7 +354,7 @@ Congratulations! You've successfully set up and tested an Ansible role using Mol
 Additional Resources:
 
 * [Molecule Documentation](https://ansible.readthedocs.io/projects/molecule/)
-* [Ansible Galaxy](https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/community/userguide/)
+* [Ansible Galaxy](https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/)
 * [Hetzner Ansible module](https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/server_module.html)
 
 ##### License: MIT


### PR DESCRIPTION
I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: wpdevelopment11 wpdevelopment11@gmail.com

I published my script that I used to find the broken links:
https://github.com/wpdevelopment11/brittle

I will publish another script that I used to extract links from Markdown files soon.