### PR TITLE
Fix links

### DIFF
--- a/tutorials/how-to-use-ffmpeg-for-video-editing/01.en.md
+++ b/tutorials/how-to-use-ffmpeg-for-video-editing/01.en.md
@@ -71,9 +71,9 @@ Replace those filenames appropriately.
 
 FFmpeg is available on all major platforms. Use the instructions below to install it on your operating system.
 
-* [Installing FFmpeg on Linux](#installing-on-linux)
-* [Installing FFmpeg on macOS](#installing-on-macos)
-* [Installing FFmpeg on Windows](#installing-on-windows)
+* [Installing FFmpeg on Linux](#step-11---installing-on-linux)
+* [Installing FFmpeg on macOS](#step-12---installing-on-macos)
+* [Installing FFmpeg on Windows](#step-13---installing-on-windows)
 
 ### Step 1.1 - Installing on Linux
 


### PR DESCRIPTION
By the way, found a funny bug on https://community.hetzner.com.

[`` `-map 0:a:0` `` is rendered as `-map 0🅰️0`](https://community.hetzner.com/tutorials/how-to-use-ffmpeg-for-video-editing#step-33---extracting-streams)

This doesn't happen on https://community.hetzner.com/markdown-test-suite/

I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: wpdevelopment11 wpdevelopment11@gmail.com