### PR TITLE
Update "How to route cloud server over private network using pfSense and Hetzner Cloud Networks"

### DIFF
--- a/tutorials/how-to-route-cloudserver-over-private-network-using-pfsense-and-hcnetworks/01.en.md
+++ b/tutorials/how-to-route-cloudserver-over-private-network-using-pfsense-and-hcnetworks/01.en.md
@@ -360,6 +360,10 @@ Edit the file `/etc/network/interfaces`:
                   - 185.12.64.1
   ```
   
+  **Please note:** By default, the `hc-utils` package provides automatic network configuration on our servers.
+  When using a different configuration mechanism, like the `netplan` setup above, please make sure to uninstall the `hc-utils` package or deactivate it for the corresponding network interface ([see the documentation](https://docs.hetzner.com/cloud/networks/server-configuration#uninstalling-or-deactivating-the-auto-configuration-package)).
+  Otherwise there's a risk, that two DHCP clients will compete over the configuration, which will cause side effects or outages.
+
 - **Add the DNS servers**
 
   The configuration above already includes nameservers.  


### PR DESCRIPTION
Add note to deactivate hc-utils, when using netplan.