### PR TITLE
Fix typo in "How to install Ubuntu 24.04 with full disk encryption"

### DIFF
--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
@@ -78,7 +78,7 @@ IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.gz
 SSHKEYS_URL /tmp/authorized_keys
 ```
 
-> **Hinweis:** Wenn `PART /boot/efi esp 256M` entfernt wird, sollte auch Debian 12 (`Debian-1208-bookworm-amd64-base.tar.gz`) funktionieren — allerdings ohne Garantie.
+> **Hinweis:** Wenn `PART /boot/efi esp 256M` entfernt wird, sollte auch Debian 12 (`Debian-1211-bookworm-amd64-base.tar.gz`) funktionieren — allerdings ohne Garantie.
 
 Diese Konfiguration installiert Ubuntu auf einem einzelnen verschlüsselten Laufwerk (`/dev/sda`) mit einer separaten unverschlüsselten `/boot` Partition, das für die Entschlüsselung benötigt wird.
 
@@ -361,7 +361,7 @@ Warte, bis die Installation abgeschlossen ist, und prüfe die `debug.txt`-Datei 
 
 ## Schritt 5 - Installiertes System booten
 
-Nachdem die Installation abgeschlossen ist und alle Fehler behoben wurden, kann `reboot` ausgeführt werden, um den Server neu zu starten und das neu installierte System zu booten. Man kann den Boot-Vorgang beobachten, wenn eine KVM angeschlossen ist oder über die [VNC-Konsole in Cloud Console](https://docs.hetzner.com/de/cloud/servers/getting-started/vnc-console).
+Nachdem die Installation abgeschlossen ist und alle Fehler behoben wurden, kann `reboot` ausgeführt werden, um den Server neu zu starten und das neu installierte System zu booten. Man kann den Boot-Vorgang beobachten, wenn eine KVM angeschlossen ist oder über die [VNC-Konsole in Hetzner Console](https://docs.hetzner.com/de/cloud/servers/getting-started/vnc-console).
 
 Nach einiger Zeit sollte der Server auf einen Ping reagieren. Über den Default-SSH-Port 22 sollte ein Login nicht möglich sein, da die root-Partition noch verschlüsselt ist. Verbinde dich stattdessen über Port 2222 mit dropbear und führe `cryptroot-unlock` aus, um die verschlüsselte(n) Partition(en) zu entsperren. Wenn du dich mit Dropbear verbindest, nutze den privaten Key, der zum öffentlichen Key gehört, den du in `/tmp/authorized_keys` angegeben hast.
 

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
@@ -77,7 +77,7 @@ IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.gz
 SSHKEYS_URL /tmp/authorized_keys
 ```
 
-> **Note:** It should also work with Debain 12 (`Debian-1208-bookworm-amd64-base.tar.gz`) when you remove `PART /boot/efi esp 256M` — but without guarantee.
+> **Note:** It should also work with Debain 12 (`Debian-1211-bookworm-amd64-base.tar.gz`) when you remove `PART /boot/efi esp 256M` — but without guarantee.
 
 This configuration will install Ubuntu on a single encrypted drive (`/dev/sda`) with a separate unencrypted `/boot` required for remote unlocking.
 
@@ -359,7 +359,7 @@ Wait until the installation completes and check the `debug.txt` for any errors.
 
 ## Step 5 - Boot installed system
 
-After the installation has finished and any errors are resolved, you can run `reboot` to restart the server and boot the newly installed system. You can watch the boot process if you have a KVM attached or via the [VNC console in Cloud Console](https://docs.hetzner.com/cloud/servers/getting-started/vnc-console).
+After the installation has finished and any errors are resolved, you can run `reboot` to restart the server and boot the newly installed system. You can watch the boot process if you have a KVM attached or via the [VNC console in Hetzner Console](https://docs.hetzner.com/cloud/servers/getting-started/vnc-console).
 
 After some time, the server should respond to ping. Login to the default SSH port 22 should fail because the disk is still encrypted. Login to the dropbear SSH port 2222 and run `cryptroot-unlock` to unlock the encrypted partition(s). When you connect to dropbear, make sure you use the private SSH key corresponding to the public key stored in `/tmp/authorized_keys`.
 


### PR DESCRIPTION
> I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: svenja11