### PR TITLE
Update links in "Installing FreeBSD with OpenZFS via the Linux rescue system"

### DIFF
--- a/tutorials/freebsd-with-openzfs-via-linux-rescue/01.en.md
+++ b/tutorials/freebsd-with-openzfs-via-linux-rescue/01.en.md
@@ -53,8 +53,8 @@ zfs
 Download `base.txz` and `kernel.txz` from a FreeBSD mirror:
 
 ```bash
-curl -O http://ftp2.de.freebsd.org/pub/FreeBSD/releases/amd64/14.0-RELEASE/base.txz
-curl -O http://ftp2.de.freebsd.org/pub/FreeBSD/releases/amd64/14.0-RELEASE/kernel.txz
+curl -O http://ftp2.de.freebsd.org/pub/FreeBSD/releases/amd64/14.2-RELEASE/base.txz
+curl -O http://ftp2.de.freebsd.org/pub/FreeBSD/releases/amd64/14.2-RELEASE/kernel.txz
 ```
 
 > You can use `ls` to check if the files are now available.


### PR DESCRIPTION
Fix #1225