### PR TITLE
Internal Hetzner rework - Install and configure Proxmox VE

### DIFF
--- a/tutorials/install-and-configure-proxmox_ve/01.de.md
+++ b/tutorials/install-and-configure-proxmox_ve/01.de.md
@@ -1,7 +1,7 @@
 ---
 path: "/tutorials/install-and-configure-proxmox_ve/de"
 slug: "install-and-configure-proxmox_ve"
-date: "2021-09-12"
+date: "2025-09-08"
 title: "Proxmox VE Installieren und Konfigurieren"
 short_description: "Proxmox VE ist eine Open-Source Virtualisierungsplattform mit Unterstützung für KVM und (ab Version 4.0) Linux Containers (LXC)."
 tags: ["Hetzner Official", "Proxmox"]
@@ -14,140 +14,146 @@ available_languages: ["en", "de"]
 header_img: "header-4"
 cta: "dedicated"
 ---
-
 ## Einführung
 
 Proxmox Virtual Environment (Proxmox VE) ist eine Open-Source-Virtualisierungsplattform mit Unterstützung für Kernel-based Virtual Machine (KVM) und Linux Containers (LXC). Proxmox bietet eine webbasierte Verwaltungsschnittstelle, CLI-Tools und eine REST-API für Verwaltungszwecke sowie [eine großartige Dokumentation](https://pve.proxmox.com/pve-docs/index.html) mit einem ausführlichen Proxmox VE Guide, Handbuchseiten und API-Viewer.
 
-Dieses Tutorial zeigt, wie man Proxmox VE 8 auf Debian 12 installiert und IP-Adressen auf virtuellen Maschinen konfiguriert.
+Dieses Tutorial zeigt, wie man Proxmox VE 9 auf Debian 13 installiert und IP-Adressen auf virtuellen Maschinen konfiguriert.
 
-***Vor der Installation***
+## 1 Installation
 
-Zunächst einige Tipps und Tricks, bevor Sie mit der Einrichtung der neuen Umgebung beginnen:
+Es gibt mehrere Möglichkeiten, Proxmox VE auf einem dedizierten Hetzner Root-Server zu installieren. Man kann entweder Debian 13 installieren und anschließend auf Proxmox upgraden oder das offizielle Image verwenden und Proxmox über `qemu` installieren.
 
-- Sollen nur Linux-Maschinen verwendet werden? Dann würde unter Umständen LXC ausreichen.
-- Soll LXC oder KVM verwendet werden? Beide haben ihre Vor- und Nachteile.
-
-Eine wohlüberlegte Entscheidung und gute Recherche kann in Zukunft für weniger Arbeit/Probleme sorgen.
-
-- KVM ist zwar nicht so leistungsfähig wie LXC, bietet aber eine vollständige Hardwarevirtualisierung und ermöglicht den Betrieb aller gängigen Betriebssysteme (einschließlich Windows).
-
-Eine Konvertierung der virtuellen Festplatten in Formate wie VMDK ist möglich.
-
-## Schritt 1 - Installation
-
-### Schritt 1.1 - Die Grundinstallation auf einem Hetzner-Server
+### 1.1 Installation von Proxmox VE auf Debian
 
 * Booten Sie den Server in das [Rescue System](https://docs.hetzner.com/de/robot/dedicated-server/troubleshooting/hetzner-rescue-system/).
-* Führen Sie [installimage](https://docs.hetzner.com/de/robot/dedicated-server/operating-systems/installimage/) aus, wählen Sie das erforderliche Debian 12 (Bookworm) aus und installieren Sie es.
+* Führen Sie [installimage](https://docs.hetzner.com/de/robot/dedicated-server/operating-systems/installimage/) aus, wählen Sie das erforderliche Debian 13 (trixie) aus und installieren Sie es.
 * Konfigurieren Sie den RAID-Level, den Hostnamen und die Partitionierung.
 * Speichern Sie die Konfiguration und führen Sie nach Abschluss der Installation einen Neustart durch.
+* Sobald der Server wieder erreichbar ist, folge der offiziellen Anleitung zum Upgrade von Debian 13 auf [Proxmox](https://pve.proxmox.com/wiki/Install_Proxmox_VE_on_Debian_13_Trixie).
 
-## Schritt 1.2 - Anpassen der APT-Quellen
+### 1.2 Installation mit ZFS
 
-* GPG-Key hinzuzufügen und APT-Quellen anpassen:
-  ```Go
-  curl -o /etc/apt/trusted.gpg.d/proxmox-release-bookworm.gpg http://download.proxmox.com/debian/proxmox-release-bookworm.gpg
-  echo "deb http://download.proxmox.com/debian/pve bookworm pve-no-subscription" > /etc/apt/sources.list.d/pve-install-repo.list
-  ```
-* Wenn Sie kein Proxmox VE Enterprise Abonnement haben und unberechtigte Zugriffsfehler vermeiden wollen, können Sie das Proxmox VE Enterprise Repository mit dem folgenden Befehl auskommentieren:
-  ```Go
-  echo '# deb https://enterprise.proxmox.com/debian/pve bookworm InRelease' > /etc/apt/sources.list.d/pve-enterprise.list
-  ```
-* Pakete aktualisieren:
-  ```Go
-  apt update           # Paketlisten aktualisieren
-  apt full-upgrade     # System aktualisieren
-  ```
+Proxmox kann auch über `qemu` mit dem offiziellen [ISO](https://www.proxmox.com/en/downloads) installiert werden. Dabei wird der Installer in einer virtuellen Maschine aus dem Hetzner Rescue System gestartet. Das Netzwerk muss jedoch vor dem Neustart konfiguriert werden, da das interface in dieser Methode virtualisiert ist.
 
-## Schritt 1.3 - Proxmox VE installieren
+#### Vorbereitung
 
-* Proxmox VE installieren
-  ```Go
-  apt install proxmox-ve
-  ```
-* Neustart ausführen
-* Nach einem Neustart sollte der Proxmox-Kernel geladen sein. Führen Sie den folgenden Befehl aus, um Informationen über die Kernelversion zu erhalten:
-  ```Go
-  uname -r
-  ```
-  Die Ausgabe sollte z.B. `pve` enthalten: `6.5.13-1-pve`
+Bevor Sie mit der Installation beginnen, leiten Sie einen lokalen Port weiter und verbinden Sie sich mit Ihrem Server über den folgenden Befehl:
+```bash
+ssh -L 5900:localhost:5900 root@your_server_ip
+```
+Kopiere die Download-URL des ISO-Images und lade es im Rescue System mit `wget` herunter:
+```bash
+wget https://enterprise.proxmox.com/iso/proxmox-ve_9.0-1.iso
+```
+Nun kann eine virtuelle Maschine im Rescue System gestartet, die Laufwerke durchgereicht und vom ISO gebootet werden:
+```bash
+qemu-system-x86_64 \
+  -enable-kvm \
+  -cpu host \
+  -m 16G \
+  -boot d \
+  -cdrom ./proxmox-ve_9.0-1.iso \
+  -drive file=/dev/nvme0n1,format=raw,if=virtio \
+  -drive file=/dev/nvme1n1,format=raw,if=virtio \
+  -bios /usr/share/OVMF/OVMF_CODE.fd \
+  -vnc 127.0.0.1:0
+```
+(Die Zeile `-bios /usr/share/OVMF/OVMF_CODE.fd \` ist nur für EFI-Server erforderlich. Entfernen Sie diese, wenn Ihr Server auf **Legacy** eingestellt ist. Prüfen können Sie dies mit `[ -d "/sys/firmware/efi" ] && echo "UEFI" || echo "BIOS"`.)
+```bash
+root@rescue ~ # [ -d "/sys/firmware/efi" ] && echo "UEFI" || echo "BIOS"
+UEFI
+```
+Falls Sie SATA-Laufwerke haben, passen Sie den Befehl entsprechend an (z. B. `/dev/sda` statt `/dev/nvme0n1`).
 
-Das Webinterface sollte unter `https://<server_ip>:8006` erreichbar sein.
+**Verbinden Sie sich mit einem VNC-Client zu 127.0.0.1**
 
-## Schritt 2 - Netzwerkkonfiguration
+**Bitte beachten Sie, dass der VNC-Client nach dem Klick auf ‚Install‘ einen Timeout bekommen kann. Verbinden Sie sich in diesem Fall einfach erneut.**
 
-Zunächst ist es wichtig zu entscheiden, welche Virtualisierungslösung (LXC und/oder KVM) und welche Variante (bridged/routed) verwendet werden soll.
+<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/db49cccb-697d-4570-bc3b-29d7dfbfa4ad" />
 
-Wenn Sie mit den genannten Technologien nicht vertraut sind, finden Sie nachfolgend einige Vor- und Nachteile.
+#### Konfiguration der Netzwerkschnittstelle
 
-* Virtualisierungslösung
-  
-  **LXC-Option**
-  
-  | Vorteile | Nachteile |
-  | -------- | --------- |
-  | <ul><li>Leichtgewichtig, schnell, geringer RAM-Bedarf</li><li>Sowohl schnelle Start- und Shutdown-Zeiten, was die Verwaltbarkeit und Skalierbarkeit von containerisierten Anwendungen verbessert</li><li>Ermöglicht die gleichzeitige Ausführung von mehr Containern auf derselben Hardware im Vergleich zu virtuellen Maschinen</li></ul> | <ul><li>Der Kernel des Hostsystems wird verwendet</li><li>Es können nur Linux-Distributionen verwendet werden</li></ul> |
+Nach Abschluss der Installation beenden Sie QEMU mit `strg + C` im Terminal. Vor dem Neustart muss das interface in `/etc/network/interfaces` angepasst werden.
 
-  **KVM-Option**
-  
-  | Vorteile | Nachteile |
-  | -------- | --------- |
-  | <ul><li>Jede VM arbeitet mit ihrem eigenen Kernel, was die Sicherheit und Stabilität erhöht</li><li>Es können fast alle Betriebssysteme installiert werden</li><li>Kann die Vorteile der Hardware-Virtualisierungsfunktionen (z. B. Intel VT-x und AMD-V) nutzen, um die Leistung zu verbessern</li></ul> | <ul><li>VMs benötigen ihre eigenen Ressourcen, einschließlich einer vollständigen Kopie des Betriebssystems, was zu einem erhöhten Verbrauch von CPU, RAM und Speicher führt</li></ul> |
+Sie können den richtigen Interface Namen herausfinden, indem Sie den Befehl `predict-check` im Rescue-System verwenden:
+```bash
+root@rescue ~ # predict-check 
+eth0 -> enp0s31f6
+```
+In diesem Fall lautet der Interface Name `enp0s31f6`. Das im Rescue System aktive Interface können Sie mit `netdata` einsehen:
+```bash
+root@rescue ~ # netdata
+Network data:
+   eth0  LINK: yes
+         MAC:  aa:bb:cc:dd:cc:ff
+         IP:   192.168.1.100/24
+         IPv6: (none)
+         Intel(R) PRO/1000 Network Driver
+```
+Starten Sie Proxmox anschließend erneut mit QEMU, diesmal ohne Installationsmedium:
+```bash
+qemu-system-x86_64 \
+  -enable-kvm \
+  -cpu host \
+  -m 16G \
+  -boot d \
+  -drive file=/dev/nvme0n1,format=raw,if=virtio \
+  -drive file=/dev/nvme1n1,format=raw,if=virtio \
+  -bios /usr/share/OVMF/OVMF_CODE.fd \
+  -vnc 127.0.0.1:0
+```
+Melden Sie sich an und passen Sie das Interface in `/etc/network/interfaces` an:
+```bash
+nano /etc/network/interfaces
+```
+Standard Konfiguration:
+```bash
+auto lo
+iface lo inet loopback
 
---------
+auto enp0s31f6
+iface enp0s31f6 inet static
+        address server_ip/32
+        gateway server_gateway
+```
+## 2 Netzwerkkonfiguration
 
-* Netzwerkkonfiguration
-  
-  **Routed Setup**
-  
-  | Vorteile | Nachteile |
-  | -------- | --------- |
-  | <ul><li>Mehrere einzelne IP-Adressen und Subnetze können auf einer VM verwendet werden</li></ul> | <ul><li>Es sind zusätzliche Routen auf dem Host erforderlich</li><li>Eine Punkt-zu-Punkt-Verbindung ist erforderlich</li></ul> |
+Hetzner hat eine strenge IP/MAC-Bindung, um die Sicherheit zu gewährleisten und Spoofing zu verhindern. In einigen Szenarien ist nur eine geroutete Konfiguration möglich. Beispielsweise sind zusätzliche Subnetze, einzelne Failover-IPs und Failover-Subnetze immer MAC-gebunden und statisch auf die Haupt IP-Adresse des Servers geroutet und können nur in einer **gerouteten** Konfiguration eingerichtet werden.
 
-  **Bridged Network Option**
-  
-  | Vorteile | Nachteile |
-  | -------- | --------- |
-  | <ul><li>Der Host ist transparent und nimmt nicht am Routing teil.</li><li>VMs können direkt mit dem Gateway der zugewiesenen IP kommunizieren.</li><li>VMs können ihre einzelne IPv4-Adresse vom DHCP-Server von Hetzner beziehen.</li></ul> | <ul><li>VMs können nur über die MAC-Adresse kommunizieren, die der jeweiligen IP-Adresse zugeordnet ist.</li><li>Diese MAC-Adresse muss in Hetzner Robot angefordert werden.</li><li>IP-Adressen aus weiteren Subnetzen können nur auf dem Host-System oder auf einer einzelnen VM mit einer einzigen IP verwendet werden (wenn das Subnetz darauf geroutet ist) (gilt sowohl für IPv4- als auch für IPv6-Subnetze).</li></ul> |
-
-### IP-Weiterleitung auf dem Host aktivieren
+#### IP-Weiterleitung auf dem Host aktivieren
     
-Bei einem gerouteten Setup sind die Bridges (z.B. `vmbr0`) nicht mit der physikalischen Schnittstelle verbunden. Die IP-Weiterleitung muss auf dem Host-System aktiviert werden. Bitte beachten Sie, dass die Paketweiterleitung zwischen Netzwerkschnittstellen bei der Standardinstallation von Hetzner deaktiviert ist. Um die IP-Weiterleitung über Neustarts hinweg zu aktivieren, verwenden Sie die folgenden Befehle:
+Bei einem gerouteten Setup sind die Bridges (z.B. `vmbr0`) nicht mit der physikalischen Schnittstelle verbunden. Die IP-Weiterleitung muss auf dem Host-System aktiviert werden. Bitte beachten Sie, dass die Paketweiterleitung zwischen Netzwerkschnittstellen bei der Standardinstallation von Hetzner deaktiviert ist.
 
-* Für IPv4 und IPv6:
-  ```bash
-  sed -i 's/#net.ipv4.ip_forward=1/net.ipv4.ip_forward=1/' /etc/sysctl.conf
-  sed -i 's/#net.ipv6.conf.all.forwarding=1/net.ipv6.conf.all.forwarding=1/' /etc/sysctl.conf
+Für IPv4 und IPv6:
+```bash
+echo 1 > /proc/sys/net/ipv4/ip_forward
+echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
   ```
-* Änderungen anwenden:
-  ```bash
-  sysctl -p
-  ```
-* Prüfen, ob die Weiterleitung aktiv ist:
-  ```bash
-  sysctl net.ipv4.ip_forward
-  sysctl net.ipv6.conf.all.forwarding
-  ```
+Änderungen anwenden:
+```bash
+systemctl restart systemd-sysctl
+```
+Prüfen, ob das forwarding aktiv ist:
+```bash
+sysctl net.ipv4.ip_forward
+sysctl net.ipv6.conf.all.forwarding
+```
 
-### Netzwerkkonfiguration hinzufügen
+#### Netzwerkkonfiguration hinzufügen
 
 Wählen Sie eine passende Variante:
 
-* [Routed Setup](#routed-setup)
-* [Bridged Setup](#bridged-setup)
-
-
-* [vSwitch mit öffentlichem Subnetz](#vswitch-mit-offentlichem-subnetz)<br>
+* [Routed Setup](#21-routed-setup)
+* [Bridged Setup](#22-bridged-setup)
+* [vSwitch mit öffentlichem Subnetz](#23-vswitch-mit-öffentlichem-subnetz)<br>
   <small>» Zuweisung von IP-Adressen an VMs/Container von vSwitch mit öffentlichem Subnetz.</small>
+* [Hetzner Cloud Netzwerk](#24-hetzner-cloud-netzwerk)<br>
+  <small>» Stellt eine Verbindung zwischen den virtuellen Maschinen/LXC und der Hetzner Cloud her.</small><br>
+* [Masquerading (NAT)](#25-masquerading-nat)<br> 
+  <small>» Ermöglicht VMs mit privaten IP-Adressen den Zugriff auf das Internet, indem die öffentliche IP-Adresse des Hosts genutzt wird..</small><br>
 
-
-* [Hetzner Cloud Netzwerk](#hetzner-cloud-netzwerk)<br>
-  <small>» Eine Verbindung zwischen den virtuellen Maschinen/LXC in Proxmox herstellen.</small><br>
-* [Masquerading (NAT)](#masquerading-nat)<br> 
-  <small>» VMs mit pvt IPs den Internetzugang über die öfftl. IP des Hosts ermöglichen.</small><br>
-
-##### Routed Setup
+### 2.1 Routed Setup
 
 In einer gerouteten Konfiguration dient die Bridge-IP-Adresse des Hostsystems standardmäßig als Gateway. Das manuelle Hinzufügen einer Route zu einer virtuellen Maschine ist erforderlich, wenn die zusätzliche IP nicht zum selben Subnetz gehört. Aus diesem Grund setzen wir die Subnetzmaske auf `/32`, da Geräte wie vmbr0 grundsätzlich den Datenverkehr nur für IP-Adressen weiterleiten, die zum selben Subnetz gehören. Durch die Verwendung einer `/32`-Subnetzmaske wird jede zusätzliche IP-Adresse als eigene Netzwerkeinheit behandelt, wodurch sichergestellt wird, dass der Datenverkehr sein richtiges Ziel erreicht, auch wenn die zusätzliche IP-Adresse nicht aus demselben Subnetz stammt.
 
@@ -160,8 +166,14 @@ In einer gerouteten Konfiguration dient die Bridge-IP-Adresse des Hostsystems st
   - Zusätzliches Subnetz: `203.0.113.0/24`
   - Zusätzliche Einzel-IP (fremdes Subnetz): `192.0.2.20/24`
   - Zusätzliche Einzel-IP (gleiches Subnetz): `198.51.100.30/24`
+  - Failover Einzel-IP: `172.17.234.100/32`
+  - Failover Subnetz: `172.17.234.0/24`
   - IPv6: `2001:DB8::/64`
-  
+
+**Bitte beachten Sie, dass Sie das Netzwerk nach dem Anwenden der Netzwerkkonfiguration neu starten müssen, damit der Proxmox-Host die statischen Routen hinzufügt. Wenn während des Neustarts des Netzwerks virtuelle Maschinen oder Container aktiv sind, müssen Sie diese anhalten (nicht nur neu starten) und anschließend wieder starten. Dadurch werden die Punkt-zu-Punkt-Verbindungen zwischen den virtuellen Maschinen und dem Host korrekt neu erstellt.**
+```bash
+systemctl restart networking
+```
   ```Go
   # /etc/network/interfaces
   
@@ -172,13 +184,16 @@ In einer gerouteten Konfiguration dient die Bridge-IP-Adresse des Hostsystems st
   
   auto enp0s31f6
   iface enp0s31f6 inet static
-          address 198.51.100.10/32    #Haupt-IP
-          gateway 198.51.100.1        #Gateway
+          address 198.51.100.10/32    # Haupt-IP
+          gateway 198.51.100.1        # Gateway
+
+          post-up echo 1 > /proc/sys/net/ipv4/ip_forward
+          post-up echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
   
   # IPv6 des Main-interface
   iface enp0s31f6 inet6 static
-      address 2001:db8::2/128             # /128 auf dem Ethernet, /64 auf der Bridge (um alle anderen Adressen zur Bridge zu routen)
-      gateway fe80::1
+          address 2001:db8::2/128             # /128 auf dem Ethernet, /64 auf der Bridge
+          gateway fe80::1
   
   # Bridge für einzelne IP's (fremdes und gleiches Subnetz)
   auto vmbr0
@@ -187,17 +202,26 @@ In einer gerouteten Konfiguration dient die Bridge-IP-Adresse des Hostsystems st
           bridge-ports none
           bridge-stp off
           bridge-fd 0
-          up ip route add 192.0.2.20/32 dev vmbr0    # Zusätzliche IP aus einem fremden Subnetz
-          up ip route add 198.51.100.30/32 dev vmbr0 # Zusätzliche IP aus dem gleichen Subnetz
+          post-up ip route add 192.0.2.20/32 dev vmbr0     # Zusätzliche IP aus einem fremden Subnetz
+          post-up ip route add 198.51.100.30/32 dev vmbr0  # Zusätzliche IP aus dem gleichen Subnetz
+          post-up ip route add 172.17.234.100/32 dev vmbr0 # Failover IP
   
   # IPv6 für die bridge
   iface vmbr0 inet6 static
-    address 2001:db8::3/64                # Sollte nicht die gleiche Adresse wie das Main-interface sein
+          address 2001:db8::3/64                # Sollte nicht die gleiche Adresse wie das Main-interface sein
   
   # Zusätzliches Subnetz 203.0.113.0/24
   auto vmbr1
   iface vmbr1 inet static
           address 203.0.113.1/24 #  Setzen Sie eine nutzbare IP aus dem Subnetzbereich
+          bridge-ports none
+          bridge-stp off
+          bridge-fd 0
+  
+  # Failover Subnetz 172.17.234.0/24
+  auto vmbr2
+  iface vmbr2 inet static
+          address 172.17.234.1/24 # Setzen Sie eine nutzbare IP aus dem Subnetzbereich
           bridge-ports none
           bridge-stp off
           bridge-fd 0
@@ -209,7 +233,7 @@ In einer gerouteten Konfiguration dient die Bridge-IP-Adresse des Hostsystems st
   
   Als Gateway wird immer die IP der Bridge im Hostsystem verwendet, d.h. die Haupt-IP für einzelne IPs und die IP aus dem im Hostsystem konfigurierten Subnetz für Subnetze.
   
-  Gastkonfiguration:
+  **Gastkonfiguration:**
   
   * Mit einer zusätzlichen IP aus dem gleichen Subnetz:
     ```Go
@@ -218,17 +242,15 @@ In einer gerouteten Konfiguration dient die Bridge-IP-Adresse des Hostsystems st
     auto lo
     iface lo inet loopback
     
-    
     auto ens18
     iface ens18 inet static
-      Adresse 198.51.100.30/32   # Zusätzliche IP
-      gateway 198.51.100.10      # Haupt-IP
+            adresse 198.51.100.30/32   # Zusätzliche IP
+            gateway 198.51.100.10      # Haupt-IP
     
     # IPv6
     iface ens18 inet6 static
-      address 2001:DB8::4      # IPv6-Adresse des Subnetzes
-      netmask 64               # /64
-      gateway 2001:DB8::3      # Bridge Adresse
+            address 2001:DB8::4/64      # IPv6-Adresse des Subnetzes
+            gateway 2001:DB8::3         # Bridge Adresse
     ```
 
   * Mit einer fremden Additional IP:
@@ -238,11 +260,10 @@ In einer gerouteten Konfiguration dient die Bridge-IP-Adresse des Hostsystems st
     auto lo
     iface lo inet loopback
     
-    
     auto ens18
     iface ens18 inet static
-      address 192.0.2.20/32 # Zusätzliche IP aus einem fremden Subnetz
-      gateway 198.51.100.10 # Haupt-IP
+            address 192.0.2.20/32 # Zusätzliche IP aus einem fremden Subnetz
+            gateway 198.51.100.10 # Haupt-IP
     ```
   
   * Mit einer IP aus dem zusätzlichen Subnetz:
@@ -252,18 +273,41 @@ In einer gerouteten Konfiguration dient die Bridge-IP-Adresse des Hostsystems st
     auto lo
     iface lo inet loopback
     
+    auto ens18
+    iface ens18 inet static
+            address 203.0.113.10/24 # Subnetz-IP
+            gateway 203.0.113.1     # Gateway ist die IP der bridge (vmbr1)
+    ```
+  * Mit einer IP aus dem failover Subnetz:
+    ```Go
+    # /etc/network/interfaces
+    
+    auto lo
+    iface lo inet loopback
     
     auto ens18
     iface ens18 inet static
-      address 203.0.113.10/24 # Subnetz-IP
-      gateway 203.0.113.1     # Gateway ist die IP der bridge (vmbr1)
+            address 172.17.234.10/24      # Failover Subnetz-IP
+            gateway 172.17.234.1          # Gateway ist die IP der bridge (vmbr2) 
+    ```
+  * Einzelne failover IP:
+    ```Go
+    # /etc/network/interfaces
+    
+    auto lo
+    iface lo inet loopback
+    
+    auto ens18
+    iface ens18 inet static
+            address 172.17.234.100/32      # Failvoer IP
+            gateway 198.51.100.10          # Haupt-IP
     ```
 
 ---------
 
 <br>
 
-##### Bridged Setup
+### 2.2 Bridged Setup
 
 Wenn Sie Proxmox im Bridged-Modus einrichten, müssen Sie unbedingt virtuelle MAC-Adressen für jede IP-Adresse über das Robot Panel anfordern. In diesem Modus fungiert der Host als transparente Brücke und ist nicht Teil des Routing-Pfads. Das bedeutet, dass Pakete, die am Router ankommen, die MAC-Quelladresse der virtuellen Maschinen enthalten. Wenn die MAC-Quelladresse vom Router nicht erkannt wird, wird der Datenverkehr als "Abuse" eingestuft und kann dazu führen, dass der Server blockiert wird. Daher ist es wichtig, virtuelle MAC-Adressen im Robot Panel anzufordern.
 
@@ -295,14 +339,14 @@ Wenn Sie Proxmox im Bridged-Modus einrichten, müssen Sie unbedingt virtuelle MA
   
   Hier verwenden wir das Gateway der zusätzlichen IP, oder wenn die zusätzliche IP im gleichen Subnetz wie die Haupt-IP liegt, verwenden wir das Gateway der Haupt-IP.
   
-  Statische Konfiguration:
+  **Statische Konfiguration:**
   ```Go
   # /etc/network/interfaces
   
   auto ens18
   iface ens18 inet static
-    address 192.0.2.20/32   # Zusätzliche IP 
-    gateway 192.0.2.1       # Gateway der zusätzlichen IP
+          address 192.0.2.20/32   # Zusätzliche IP 
+          gateway 192.0.2.1       # Gateway der zusätzlichen IP
   ```
   
   Im Bridged Modus kann DHCP auch zur automatischen Konfiguration der Netzwerkeinstellungen verwendet werden. Es ist jedoch wichtig, die virtuelle Maschine so zu konfigurieren, dass sie die vom Robot Panel erhaltene virtuelle MAC-Adresse für die spezifische IP-Konfiguration verwendet.
@@ -317,7 +361,6 @@ Wenn Sie Proxmox im Bridged-Modus einrichten, müssen Sie unbedingt virtuelle MA
   auto lo
   iface lo inet loopback
   
-  
   auto ens18
   iface ens18 inet dhcp
           hwaddress ether aa:bb:cc:dd:ee:ff # Die MAC-Adresse ist nur ein Beispiel
@@ -331,11 +374,11 @@ Wenn Sie Proxmox im Bridged-Modus einrichten, müssen Sie unbedingt virtuelle MA
 
 <br>
 
-##### vSwitch mit öffentlichem Subnetz
+### 2.3 vSwitch mit öffentlichem Subnetz
 
 Proxmox kann auch so eingerichtet werden, dass es sich direkt mit einem Hetzner vSwitch verbindet, der das Routing für ein öffentliches Subnetz verwaltet, so dass IP-Adressen aus diesem Subnetz direkt an VMs und Container zugewiesen werden können. Das Setup muss ein Bridged-Setup sein und es muss ein virtuelles Interface erstellt werden, damit die Pakete den vSwitch erreichen können. Die Bridge muss nicht VLAN-fähig sein und es muss keine VLAN-Konfiguration innerhalb der VM oder des LXC-Containers vorgenommen werden, das VLAN tagging erfolgt hier über das Subinterface, in unserem Beispiel das `enp0s31f6.4009`. Jedes Paket, das durch das Interface geht, wird mit der entsprechenden VLAN ID getaggt. (Bitte beachten Sie, dass diese Konfiguration für die LXC/VM's gedacht ist. Wenn Sie möchten, dass der Host selbst mit dem vSwitch kommunizieren kann, müssen Sie eine zusätzliche [Routing-Tabelle](https://docs.hetzner.com/robot/dedicated-server/network/vswitch#server-configuration-linux) erstellen). In diesem Fall werden wir `203.0.113.0/24` als Beispielsubnetz verwenden.
 
-* Hostsystem Konfiguration:
+* **Hostsystem Konfiguration:**
   ```Bash
   # /etc/network/interfaces
   
@@ -353,25 +396,24 @@ Proxmox kann auch so eingerichtet werden, dass es sich direkt mit einem Hetzner 
 
 <br>
 
-* Gastsystem Konfiguration:
+* **Gastsystem Konfiguration:**
   ```Go
   # /etc/network/interfaces
   
   auto lo
   iface lo inet loopback
   
-  
   auto ens18
   iface ens18 inet static
-    address 203.0.113.2/24 # Subnetz-IP vom vSwitch
-    gateway 203.0.113.1    # vSwitch-Gateway
+          address 203.0.113.2/24 # Subnetz-IP vom vSwitch
+          gateway 203.0.113.1    # vSwitch-Gateway
   ```
 
 ---------
 
 <br>
 
-##### Hetzner Cloud Netzwerk
+### 2.4 Hetzner Cloud Netzwerk
 
 Es ist auch möglich, eine Verbindung zwischen den virtuellen Maschinen/LXC in Proxmox mit dem Hetzner Cloud Netzwerk herzustellen. Für dieses Beispiel nehmen wir an, dass Sie Ihr Cloud Netzwerk bereits eingerichtet haben und den vSwitch mit der folgenden Konfiguration hinzugefügt haben:
 
@@ -385,7 +427,7 @@ Die Konfiguration sollte in etwa wie folgt aussehen:
 
 Ähnlich wie im Beispiel zuvor erstellen wir zunächst eine virtuelle Schnittstelle und definieren die VLAN ID, in unserem Fall wäre das `enp0s31f6.4000`. Wir müssen die Route zum Cloud Netzwerk `192.168.0.0/16` über den vSwitch hinzufügen. Bitte beachten Sie, dass das Hinzufügen einer Route zum Hetzner-Cloud-Netzwerk und das Zuweisen einer IP-Adresse aus dem privaten Subnetzbereich des vSwitch an die Bridge nur notwendig ist, wenn der Proxmox-Host selbst mit dem Hetzner-Cloud-Netzwerk kommunizieren soll.
 
-* Hostsystem Konfiguration:
+* **Hostsystem Konfiguration:**
   ```Go
   # /etc/network/interfaces
   
@@ -399,30 +441,29 @@ Die Konfiguration sollte in etwa wie folgt aussehen:
           bridge-stp off
           bridge-fd 0
           mtu 1400
-          up ip route add 192.168.0.0/16 via 192.168.1.1 dev vmbr4000
+          post-up ip route add 192.168.0.0/16 via 192.168.1.1 dev vmbr4000
           
   #vSwitch-to-cloud Privates Subnetz 192.168.1.0/24
   ```
 
 <br>
 
-* Gastsystem Konfiguration
+* **Gastsystem Konfiguration:**
   ```Go
   # /etc/network/interfaces
   
   auto lo
   iface lo inet loopback
   
-  
   auto ens18
   iface ens18 inet static
-    address 192.168.1.2/24
-    gateway 192.168.1.1
+          address 192.168.1.2/24
+          gateway 192.168.1.1
   ```
 
 <br>
 
-##### Masquerading (NAT)
+### 2.5 Masquerading (NAT)
   
   Die Freigabe der virtuellen Maschinen/LXC-Container gegenüber dem Internet ist auch möglich, ohne weitere öffentliche zusätzliche IP-Adressen zu konfigurieren/zu nutzen. Hetzner hat eine strenge IP/MAC-Bindung, d.h. wenn der Datenverkehr nicht richtig geroutet wird, kommt es zu Abuse und kann zu Server-Sperrungen führen. Um dieses Problem zu vermeiden, können wir den Datenverkehr von den LXC/VMs über das Main-Interface des Hosts leiten. Dadurch wird sichergestellt, dass alle Netzwerkpakete die gleiche MAC-Adresse verwenden. Masquerading ermöglicht virtuellen Maschinen mit privaten IP-Adressen den Internetzugang über die öffentliche IP-Adresse des Hosts für ausgehende Kommunikation. Iptables ändert jedes ausgehende Datenpaket so, dass es so aussieht, als käme es vom Host, und eingehende Antworten werden so angepasst, dass sie an den ursprünglichen Absender zurückgeleitet werden können.
   
@@ -437,10 +478,11 @@ Die Konfiguration sollte in etwa wie folgt aussehen:
   auto enp0s31f6
   iface enp0s31f6 inet static
           address 198.51.100.10/24
-          gateway 198.51.100.1/24
+          gateway 198.51.100.1
+          post-up echo 1 > /proc/sys/net/ipv4/ip_forward
+
           #post-up iptables -t nat -A PREROUTING -i enp0s31f6 -p tcp -m multiport ! --dports 22,8006 -j DNAT --to 172.16.16.2
           #post-down iptables -t nat -D PREROUTING -i enp0s31f6 -p tcp -m multiport ! --dports 22,8006 -j DNAT --to 172.16.16.2
-  
   
   auto vmbr4
   iface vmbr4 inet static
@@ -460,7 +502,7 @@ Die Konfiguration sollte in etwa wie folgt aussehen:
   post-down iptables -t nat -D PREROUTING -i enp0s31f6 -p tcp -m multiport ! --dports 22,8006 -j DNAT --an 172.16.16.2
   ```
 
-## Schritt 3 - Sicherheit
+## 3 Sicherheit
 
 Das Webinterface ist durch zwei verschiedene Authentifizierungsmethoden geschützt:
 

--- a/tutorials/install-and-configure-proxmox_ve/01.en.md
+++ b/tutorials/install-and-configure-proxmox_ve/01.en.md
@@ -1,7 +1,7 @@
 ---
 path: "/tutorials/install-and-configure-proxmox_ve"
 slug: "install-and-configure-proxmox_ve"
-date: "2021-09-12"
+date: "2025-09-08"
 title: "Install and Configure Proxmox VE"
 short_description: "This tutorial describes the basics of installing Proxmox VE, an open-source virtualization platform."
 tags: ["Hetzner Official", "Proxmox"]
@@ -19,135 +19,142 @@ cta: "dedicated"
 
 Proxmox Virtual Environment (Proxmox VE) is an open-source virtualization platform with support for Kernel-based Virtual Machine (KVM) and Linux Containers (LXC). Proxmox provides a web-based management interface, CLI tools, and REST API for management purposes as well as [a great documentation](https://pve.proxmox.com/pve-docs/index.html) including detailed Proxmox VE Administration Guide, manual pages and API viewer.
 
-This tutorial shows how to install Proxmox VE 8 on Debian 12 and configure IP addresses on virtual machines.
+**The tutorial focuses on the network configuration and installation of Proxmox VE on Hetzner servers, since there are some specific guidelines that must be followed.**
 
-***Before the Installation***
+## 1 Installation
 
-First, some suggestions and advice before starting to set up the new environment:
+There are several ways to install Proxmox VE on a dedicated Hetzner root server. You can either install Debian 13 and upgrade to Proxmox later on or use the official image and install it via `qemu`.
 
-- Will you only use Linux machines? Then, under certain circumstances, LXC would be sufficient.
-- Should you use LXC or KVM? Both have their advantages as well as disadvantages.
-
-A thoughtful decision and good research can provide less work/trouble in the future.
-
-- Although KVM is not as performant as LXC, it provides a complete hardware virtualization and enables the operation of all the most common operating systems (including Windows).
-
-A conversion of the virtual disks in formats such as VMDK is simple.
-
-## Step 1 - Installation
-
-### Step 1.1 - The Basic Installation on a Hetzner Server
+### 1.1 Installing Proxmox VE on Debian
 
 * Boot the server into the [Rescue System](https://docs.hetzner.com/robot/dedicated-server/troubleshooting/hetzner-rescue-system/).
-* Run [installimage](https://docs.hetzner.com/robot/dedicated-server/operating-systems/installimage/), select and install the required Debian 12 (Bookworm).
+* Run [installimage](https://docs.hetzner.com/robot/dedicated-server/operating-systems/installimage/), select and install the required Debian 13 (trixie).
 * Configure the RAID level, hostname, and partitioning.
-* Save the configuration and after completion of the installation perform a restart.
+* Save the configuration. After the installation completes, reboot the server.
+* Once the server becomes reachable again, follow the official guide on how to upgrade from Debian 13 to [Proxmox](https://pve.proxmox.com/wiki/Install_Proxmox_VE_on_Debian_13_Trixie).
 
-## Step 1.2 - Adjust the APT Sources
+### 1.2 Installation with ZFS
 
-* Add the GPG key and adjust the APT sources:
-  ```Go
-  curl -o /etc/apt/trusted.gpg.d/proxmox-release-bookworm.gpg http://download.proxmox.com/debian/proxmox-release-bookworm.gpg
-  echo "deb http://download.proxmox.com/debian/pve bookworm pve-no-subscription" > /etc/apt/sources.list.d/pve-install-repo.list
-  ```
-* If you do not have a Proxmox VE Enterprise subscription and wish to avoid unauthorized access errors, you can comment out the Proxmox VE Enterprise repository with the following command:
-  ```Go
-  echo '# deb https://enterprise.proxmox.com/debian/pve bookworm InRelease' > /etc/apt/sources.list.d/pve-enterprise.list
-  ```
-* Update the packages:
-  ```Go
-  apt update        # Update package lists
-  apt full-upgrade  # Update system
-  ```
+Proxmox can also be installed via `qemu` using the official [ISO](https://www.proxmox.com/en/downloads). In this method, you start the installer in a virtual machine from the Hetzner Rescue system. The network, however needs to be configured before the server is rebooted since the network interface is virtualized. The drives inside the VM will be shown as `/dev/vdX` which is normal because they are attached using the **virtio** interface.
 
-## Step 1.3 - Install Proxmox VE
+#### Preparing the Environment 
 
-* Install Proxmox VE
-  ```Go
-  apt install proxmox-ve
-  ```
-* Restart the server
-* After a restart, the Proxmox kernel should be loaded. Run the following command in order to see kernel release information:
-  ```Go
-  uname -r
-  ```
-  The output should contain `pve`, for example: `6.5.13-1-pve`
+Before starting with the installation process forward a local port and connect to your server with the following command:
+```bash
+ssh -L 5900:localhost:5900 root@your_server_ip
+```
+Copy the link address of your image and download it in the Rescue system using `wget`:
+```bash
+wget https://enterprise.proxmox.com/iso/proxmox-ve_9.0-1.iso
+```
+Now you can start a virtual machine in the Rescue system, pass the drives, and boot from the ISO. Copy the following command:
+```bash
+qemu-system-x86_64 \
+  -enable-kvm \
+  -cpu host \
+  -m 16G \
+  -boot d \
+  -cdrom ./proxmox-ve_9.0-1.iso \
+  -drive file=/dev/nvme0n1,format=raw,if=virtio \
+  -drive file=/dev/nvme1n1,format=raw,if=virtio \
+  -bios /usr/share/OVMF/OVMF_CODE.fd \
+  -vnc 127.0.0.1:0
+```
+(The ` -bios /usr/share/OVMF/OVMF_CODE.fd \` line is for **EFI** servers only. Remove the line if the BIOS is set to **legacy**. If you are unsure you can use `[ -d "/sys/firmware/efi" ] && echo "UEFI" || echo "BIOS"` to check if the server is on EFI.)
+```bash
+root@rescue ~ # [ -d "/sys/firmware/efi" ] && echo "UEFI" || echo "BIOS"
+UEFI
+```
 
-You can access the web interface by navigating to `https://<main address>:8006`.
+(If you have SATA drives rename the devices to `/dev/sda` for example instead of `/dev/nvme0n1`)
 
-## Step 2 - Network Configuration
+**Use a `VNC client` and connect to `127.0.0.1`, the installation should appear.**
 
-First of all, it is important to decide which virtualization solution (LXC and/or KVM) and which variant (bridged/routed) to use.
+**Please note that the VNC client may timeout once you press `install`, simply reconnect to `127.0.0.1`.**
+<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/db49cccb-697d-4570-bc3b-29d7dfbfa4ad" />
 
-If you are not familiar with mentioned technologies, please find a simple comparison in the "Pros and Cons of xxx option" sections below.
 
-* Virtualization solution
-  
-  **LXC Option**
-  
-  | Advantages | Disadvantages |
-  | ---------- | ------------- |
-  | <ul><li>Lightweight, fast, lower RAM requirement.</li><li>Mixed fast startup and shutdown times, enhancing the manageability and scalability of containerized applications.</li><li>Allows for more containers to run simultaneously on the same hardware compared to virtual machines.</li></ul> | <ul><li>Uses the kernel of the host system.</li><li>You can only use Linux distributions.</li></ul> |
+#### Configure the main interface
 
-  **KVM Option**
-  
-  | Advantages | Disadvantages |
-  | ---------- | ------------- |
-  | <ul><li>Each VM operates with its own kernel, enhancing security and stability.</li><li>You can install almost any operating system.</li><li>Can take advantage of hardware virtualization features (e.g., Intel VT-x and AMD-V) to improve performance.</li></ul> | <ul><li>VMs require their own set of resources, including a full copy of the operating system, leading to increased consumption of CPU, RAM, and storage.</li></ul> |
+Once the installation process has finished, stop QEMU (`ctrl + c` in the terminal window). Before rebooting the server, the network interface name must be adjusted in `/etc/network/interfaces`. In order to figure out the true interface name, you can use the `predict-check` command:
+```bash
+root@rescue ~ # predict-check 
+eth0 -> enp0s31f6
+```
+So in this example `enp0s31f6` would be the true interface name. The interface that is configured in the Rescue system can be viewed with `netdata`:
+```bash
+root@rescue ~ # netdata
+Network data:
+   eth0  LINK: yes
+         MAC:  aa:bb:cc:dd:cc:ff
+         IP:   192.168.1.100/24
+         IPv6: (none)
+         Intel(R) PRO/1000 Network Driver
+```
+Now boot up Proxmox using the same mehtod as earlier but without the installation medium and connect to `127.0.0.1`. Copy the following command:
+```bash
+qemu-system-x86_64 \
+  -enable-kvm \
+  -cpu host \
+  -m 16G \
+  -boot d \
+  -drive file=/dev/nvme0n1,format=raw,if=virtio \
+  -drive file=/dev/nvme1n1,format=raw,if=virtio \
+  -bios /usr/share/OVMF/OVMF_CODE.fd \
+  -vnc 127.0.0.1:0
+```
+Login and edit the network configuration in `/etc/network/interfaces`:
+```bash
+nano /etc/network/interfaces
+```
+Adjust the interface name, save and reboot the server. For example this would be a basic configuration:
+```bash
+root@pve:~# cat /etc/network/interfaces
+auto lo
+iface lo inet loopback
 
---------
+auto enp0s31f6
+iface enp0s31f6 inet static
+        address your_server_ip/32
+        gateway your_server_gateway
+```
+## 2 Network Configuration
 
-* Network configuration
-  
-  **Routed Network Option**
-  
-  | Advantages | Disadvantages |
-  | ---------- | ------------- |
-  | <ul><li>You can use multiple single IP addresses and subnets on one VM.</li></ul> | <ul><li>Requires extra routes on the host.</li><li>Requires a point-to-point setup.</li></ul> |
-  
-  **Bridged Network Option**
-  
-  | Advantages | Disadvantages |
-  | ---------- | ------------- |
-  | <ul><li>The host is transparent and not part of the routing.</li><li>VMs can directly communicate with the gateway of the assigned IP.</li><li>VMs can get their single IPv4 address from Hetzner's DHCP server.</li></ul> | <ul><li>VMs may only communicate via the MAC address assigned to the respective IP address.</li><li>You have to request that MAC address in Hetzner Robot.</li><li>You can use IP addresses from additional subnets only on the host system or on a single VM with a single IP (if the subnet is routed to it) (applies to both IPv4 and IPv6 subnets).</li></ul> |
+Hetzner has a strict IP/MAC binding to ensure security and prevent spoofing. In some scenarios, only a routed setup is possible. For example, additional subnets, single failover IPs and failover subnets are always MAC-bound and statically routed on the main IP address of the server, and can only be configured in a **routed** setup.
 
-### Enable IP Forwarding on the Host
+#### Enable IP Forwarding on the Host
 
-With a routed setup, the bridges (`vmbr0`, for example) are not connected with the physical interface. You need to activate IP forwarding on the host system. Please note that packet forwarding between network interfaces is disabled for the default Hetzner installation. In order to make IP forwarding persistent across reboots, use the following commands bellow:
+With a routed setup, the bridges (`vmbr0`, for example) are not connected with the physical interface. You need to activate IP forwarding on the host system. Please note that packet forwarding between network interfaces is disabled for the default Hetzner installation.
 
-* For IPv4 and IPv6:
-  ```bash
-  sed -i 's/#net.ipv4.ip_forward=1/net.ipv4.ip_forward=1/' /etc/sysctl.conf
-  sed -i 's/#net.ipv6.conf.all.forwarding=1/net.ipv6.conf.all.forwarding=1/' /etc/sysctl.conf
-  ```
-* Apply the changes:
-  ```bash
-  sysctl -p
-  ```
-* Check if the forwarding is active:
-  ```bash
-  sysctl net.ipv4.ip_forward
-  sysctl net.ipv6.conf.all.forwarding
-  ```
+For IPv4 and IPv6:
+```bash
+echo 1 > /proc/sys/net/ipv4/ip_forward
+echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
+```
+Apply the changes:
+```bash
+systemctl restart systemd-sysctl
+```
+Check if the forwarding is active:
+```bash
+sysctl net.ipv4.ip_forward
+sysctl net.ipv6.conf.all.forwarding
+```
 
-### Add the network configuration
+#### Add the network configuration
 
 Choose one of the variants:
 
-* [Routed Setup](#routed-setup)
-* [Bridged Setup](#bridged-setup)
-
-
-* [vSwitch with a public subnet](#vswitch-with-a-public-subnet)<br>
+* [Routed Setup](#21-routed-setup)
+* [Bridged Setup](#22-bridged-setup)
+* [vSwitch with a public subnet](#23-vswitch-with-a-public-subnet)<br>
   <small>» Assign IP addresses to VM's/Containers from a vSwitch with a public subnet.</small>
+* [Hetzner Cloud Network](#24-hetzner-cloud-network)<br>
+  <small>» Establish a connection between the virtual machines/LXC in Proxmox and the Hetzner cloud network.</small><br>
+* [Masquerading (NAT)](#25-masquerading-nat)<br> 
+  <small>» Enable VMs with private IPs to have internet access through the host's public IP.</small><br>
 
-
-* [Hetzner Cloud Network](#hetzner-cloud-network)<br>
-  <small>» Establish a connection between the virtual machines/LXC in Proxmox.</small><br>
-* [Masquerading (NAT)](#masquerading-nat)<br> 
-  <small>» Enable VMs with pvt IPs to have internet access through the host's public IP.</small><br>
-
-##### Routed Setup
+### 2.1 Routed Setup
 
 In a routed configuration, the host system's bridge IP address serves as the gateway by default, and manual route addition to a virtual machine is required when the extra IP does not belong to the same subnet. That's why we will set the mask to `/32`, because devices such as vmbr0 inherently route traffic only for IP addresses that fall within the same subnet.  By using a `/32` mask, each additional IP is treated as its own unique network entity which will ensure that the traffic reaches its correct destination even if the additional IP is not from the same subnet.
 
@@ -160,8 +167,14 @@ In a routed configuration, the host system's bridge IP address serves as the gat
   - Additional Subnet: `203.0.113.0/24`
   - Additional single IP (foreign subnet): `192.0.2.20/24`
   - Additional single IP (same subnet): `198.51.100.30/24`
+  - Failover single IP: `172.17.234.100/32`
+  - Failover subnet: `172.17.234.0/24`
   - IPv6: `2001:DB8::/64`
-  
+
+**Please note that you will have to restart the network after applying the network configuration for the Proxmox host to add the static routes. If virtual machines or containers are running during the network restart, you will need to stop (not just restart) and then start them again. This ensures that their point-to-point connections to the host are recreated properly.**
+```bash
+systemctl restart networking
+```
   ```Go
   # /etc/network/interfaces
   
@@ -172,13 +185,16 @@ In a routed configuration, the host system's bridge IP address serves as the gat
   
   auto enp0s31f6
   iface enp0s31f6 inet static
-          address 198.51.100.10/32    #Main IP
-          gateway 198.51.100.1        #Gateway
+          address 198.51.100.10/32    # Main IP
+          gateway 198.51.100.1        # Gateway
+
+          post-up echo 1 > /proc/sys/net/ipv4/ip_forward
+          post-up echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
   
   # IPv6 for the main interface
   iface enp0s31f6 inet6 static
-      address 2001:db8::2/128         # /128 on the ethernet interface, /64 on the bridge (to route all other addresses via the bridge)
-      gateway fe80::1
+          address 2001:db8::2/128         # /128 on the main interface, /64 on the bridge
+          gateway fe80::1
   
   # Bridge for single IP's (foreign and same subnet)
   auto vmbr0
@@ -187,17 +203,26 @@ In a routed configuration, the host system's bridge IP address serves as the gat
           bridge-ports none
           bridge-stp off
           bridge-fd 0
-          up ip route add 192.0.2.20/32 dev vmbr0    # Additional IP from a foreign subnet
-          up ip route add 198.51.100.30/32 dev vmbr0 # Additional IP from the same subnet
+          post-up ip route add 192.0.2.20/32 dev vmbr0     # Additional IP from a foreign subnet
+          post-up ip route add 198.51.100.30/32 dev vmbr0  # Additional IP from the same subnet
+          post-up ip route add 172.17.234.100/32 dev vmbr0 # Failover IP
   
   # IPv6 for the bridge
   iface vmbr0 inet6 static
-    address 2001:db8::3/64                # Should not be the same address as the main Interface
+         address 2001:db8::3/64                # Should not be the same address as the main Interface
   
   # Additional Subnet 203.0.113.0/24
   auto vmbr1
   iface vmbr1 inet static
           address 203.0.113.1/24 # Set one usable IP from the subnet range
+          bridge-ports none
+          bridge-stp off
+          bridge-fd 0
+
+  # Failover Subnet 172.17.234.0/24
+  auto vmbr2
+  iface vmbr2 inet static
+          address 172.17.234.1/24 # Set one usable IP from the subnet range
           bridge-ports none
           bridge-stp off
           bridge-fd 0
@@ -218,17 +243,15 @@ In a routed configuration, the host system's bridge IP address serves as the gat
     auto lo
     iface lo inet loopback
     
-    
     auto ens18
     iface ens18 inet static
-      address 198.51.100.30/32     # Additional IP
-      gateway 198.51.100.10        # Main IP
+            address 198.51.100.30/32     # Additional IP
+            gateway 198.51.100.10        # Main IP
       
     # IPv6
     iface ens18 inet6 static
-      address 2001:DB8::4      # IPv6 address of the subnet
-      netmask 64               # /64
-      gateway 2001:DB8::3      # Bridge Address
+            address 2001:DB8::4/64   # IPv6 address of the subnet
+            gateway 2001:DB8::3      # Bridge Address
     ```
   
   * With a foreign Additional IP:
@@ -238,11 +261,10 @@ In a routed configuration, the host system's bridge IP address serves as the gat
     auto lo
     iface lo inet loopback
     
-    
     auto ens18
     iface ens18 inet static
-      address 192.0.2.20/32        # Additional IP from a foreign subnet
-      gateway 198.51.100.10        # Main IP   
+            address 192.0.2.20/32        # Additional IP from a foreign subnet
+            gateway 198.51.100.10        # Main IP   
     ```
   
   * With an IP assigned from the additional subnet
@@ -252,18 +274,41 @@ In a routed configuration, the host system's bridge IP address serves as the gat
     auto lo
     iface lo inet loopback
     
+    auto ens18
+    iface ens18 inet static
+            address 203.0.113.10/24      # Subnet IP
+            gateway 203.0.113.1          # Gateway is the IP of the bridge (vmbr1) 
+    ```
+  * With an IP assigned from the failover subnet
+    ```Go
+    # /etc/network/interfaces
+    
+    auto lo
+    iface lo inet loopback
     
     auto ens18
     iface ens18 inet static
-      address 203.0.113.10/24      # Subnet IP
-      gateway 203.0.113.1          # Gateway is the IP of the bridge (vmbr1) 
+            address 172.17.234.10/24      # Subnet IP
+            gateway 172.17.234.1          # Gateway is the IP of the bridge (vmbr2) 
+    ```
+  * Single failover IP
+    ```Go
+    # /etc/network/interfaces
+    
+    auto lo
+    iface lo inet loopback
+    
+    auto ens18
+    iface ens18 inet static
+            address 172.17.234.100/32      # Failvoer IP
+            gateway 198.51.100.10          # The gateway IP is the main IP
     ```
 
 -----------
 
 <br>
 
-##### Bridged Setup
+### 2.2 Bridged Setup
 
 When setting up Proxmox in bridged mode, it is absolutely crucial to request virtual MAC addresses for each IP address through the Robot Panel. In this mode, the host acts as a transparent bridge and is not part of the routing path. This means that packets arriving at the router will have the source MAC address of the virtual machines. If the source MAC address is not recognized by the router, the traffic will be flagged as "Abuse" and might lead to the server being blocked. Therefore, it is essential to request virtual MAC addresses in the Robot Panel.
 
@@ -301,8 +346,8 @@ When setting up Proxmox in bridged mode, it is absolutely crucial to request vir
   
   auto ens18
   iface ens18 inet static
-    address 192.0.2.20/32         # Additional IP 
-    gateway 192.0.2.1             # Additional Gateway IP
+          address 192.0.2.20/32         # Additional IP 
+          gateway 192.0.2.1             # Additional Gateway IP
   ```
   
   In bridged mode, DHCP can also be used to automatically configure the network settings. However, it is essential to configure the virtual machine to use the virtual MAC address obtained from the Robot Panel for the specific IP configuration.
@@ -317,7 +362,6 @@ When setting up Proxmox in bridged mode, it is absolutely crucial to request vir
   auto lo
   iface lo inet loopback
   
-  
   auto ens18
   iface ens18 inet dhcp
           hwaddress ether aa:bb:cc:dd:ee:ff # The MAC address is just an example
@@ -331,11 +375,11 @@ When setting up Proxmox in bridged mode, it is absolutely crucial to request vir
 
 <br>
 
-##### vSwitch with a public subnet
+### 2.3 vSwitch with a public subnet
 
 Proxmox can also be set up to link directly with a Hetzner vSwitch that manages routing for a public subnet, allowing IP addresses from that subnet to be assigned directly to VM's and containers. The setup has to be a bridged setup and a virtual interface has to be created in order for the packets to be able to reach the vSwitch. The bridge does not require to be VLAN-aware and no VLAN configuration has to be made within the VM or LXC containers, the tagging is here done by the subinterface, in our example the `enp0s31f6.4009`. Every packet that goes through the interface will be tagged with the appropriate VLAN ID. (Please note that this configuration is meant for the LXC/VM's, If you would like the host itself to be able to communicate with the vSwitch you will have to create an additional [Routing table](https://docs.hetzner.com/robot/dedicated-server/network/vswitch#server-configuration-linux).) In this case we will use `203.0.113.0/24` as an example subnet.
 
-* Host system configuration:
+* **Host system configuration:**
   ```Bash
   # /etc/network/interfaces
   
@@ -353,25 +397,24 @@ Proxmox can also be set up to link directly with a Hetzner vSwitch that manages 
 
 <br>
 
-* Guest system configuration:
+* **Guest system configuration:**
   ```Go
   # /etc/network/interfaces
   
   auto lo
   iface lo inet loopback
   
-  
   auto ens18
   iface ens18 inet static
-    address 203.0.113.2/24      # Subnet IP from the vSwitch
-    gateway 203.0.113.1         # vSwitch Gateway
+          address 203.0.113.2/24      # Subnet IP from the vSwitch
+          gateway 203.0.113.1         # vSwitch Gateway
   ```
 
 ---------
 
 <br>
 
-##### Hetzner Cloud Network
+### 2.4 Hetzner Cloud Network
 
 It is also possible to establish a connection between the virtual machines/LXC in Proxmox with the Hetzner Cloud Network. For the sake of this example, let's assume that you have already setup your Cloud Network and have added the vSwitch with the following configuration:
 
@@ -385,7 +428,7 @@ The configuration should look something like this:
 
 Similarly as in the example before, we will first create a virtual interface and define the VLAN ID, so in our case that would be the `enp0s31f6.4000`. We will have to add the route to the Cloud Network `192.168.0.0/16` via the vSwitch. Please note that adding a route to the Hetzner Cloud network and assigning an IP address from the private subnet range of the vSwitch to the bridge is only necessary if the Proxmox host itself is to communicate with the Hetzner Cloud network.
 
-* Host system configuration:
+* **Host system configuration:**
   ```Go
   # /etc/network/interfaces
   
@@ -399,30 +442,29 @@ Similarly as in the example before, we will first create a virtual interface and
           bridge-stp off
           bridge-fd 0
           mtu 1400
-          up ip route add 192.168.0.0/16 via 192.168.1.1 dev vmbr4000
+          post-up ip route add 192.168.0.0/16 via 192.168.1.1 dev vmbr4000
           
   #vSwitch-to-cloud Private Subnet 192.168.1.0/24
   ```
 
 <br>
 
-* Guest system configuration
+* **Guest system configuration**
   ```Go
   # /etc/network/interfaces
   
   auto lo
   iface lo inet loopback
   
-  
   auto ens18
   iface ens18 inet static
-    address 192.168.1.2/24
-    gateway 192.168.1.1
+          address 192.168.1.2/24
+          gateway 192.168.1.1
   ```
 
 <br>
 
-##### Masquerading (NAT)
+### 2.5 Masquerading (NAT)
   
   Exposing the virtual machines/LXC containers to the internet is also possible without configuring/having any further public additional IP addresses. Hetzner has a strict IP/MAC binding which means that if the traffic is not routed properly, it will cause abuse and can lead to server blockings. In order to avoid this problem, we can route the traffic from the LXC/VM's through the main interface of the host. This ensures that the MAC address is the same across all network packets. Masquerading enables virtual machines with private IP addresses to have internet access through the host's public IP address for outbound communications. Iptables modifies each outgoing data packet to seem as if it is coming from the host and incoming replies are adjusted so they can be directed back to the initial sender.
   
@@ -437,10 +479,11 @@ Similarly as in the example before, we will first create a virtual interface and
   auto enp0s31f6
   iface enp0s31f6 inet static
           address 198.51.100.10/24
-          gateway 198.51.100.1/24
+          gateway 198.51.100.1
+          post-up echo 1 > /proc/sys/net/ipv4/ip_forward
+
           #post-up iptables -t nat -A PREROUTING -i enp0s31f6 -p tcp -m multiport ! --dports 22,8006 -j DNAT --to 172.16.16.2
           #post-down iptables -t nat -D PREROUTING -i enp0s31f6 -p tcp -m multiport ! --dports 22,8006 -j DNAT --to 172.16.16.2
-  
   
   auto vmbr4
   iface vmbr4 inet static
@@ -462,7 +505,7 @@ Similarly as in the example before, we will first create a virtual interface and
   post-down iptables -t nat -D PREROUTING -i enp0s31f6 -p tcp -m multiport ! --dports 22,8006 -j DNAT --to 172.16.16.2
   ```
 
-## Step 3 - Security
+## Security
 
 The web interface is protected by two different authentication methods:
 


### PR DESCRIPTION
This is a Hetzner-internal rework of the official tutorial made by Martin Kitanov. I am the author of this article and have adjusted a few things:

- restructured the installation guide
- added ZFS installation via Rescue
- adjusted IP forwarding
- added failover IP configuration
- unnecessary information has been removed to reduce reading time