### PR TITLE
SAP ABAP Cloud Developer Trial on Hetzner AX41-NVMe

### DIFF
--- a/tutorials/abap-cloud-hetzner/01.en.md
+++ b/tutorials/abap-cloud-hetzner/01.en.md
@@ -1,0 +1,114 @@
+# SAP ABAP Cloud Developer Trial on a Hetzner AX41-NVMe Server
+
+The ABAP Cloud Developer Trial is the official way to run a complete ABAP system locally or in a cloud environment.  
+This guide shows how to deploy the SAP Trial image on a **Hetzner AX41-NVMe server** running **Debian 12**.  
+
+The AX41-NVMe is ideal due to its **powerful Ryzen CPU**, **32 GB RAM**, and **fast NVMe SSDs**, which meet the high demands of the ABAP trial environment.
+
+---
+
+## Requirements
+
+To run the trial smoothly, you need:  
+
+- **Server**: Hetzner AX41-NVMe or similar  
+- **Memory**: minimum 32 GB RAM  
+- **Storage**: at least 200 GB free (image >50 GB decompressed + database growth)  
+- **Operating System**: Debian 12 (Ubuntu 22.04 LTS also works)  
+- **Docker**: latest version  
+- **Docker Hub account**: required to pull the SAP image  
+
+---
+
+## Prepare the System
+
+Update your Debian system and install Docker:
+
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y docker.io
+sudo systemctl enable --now docker
+```
+
+Login to Docker Hub (mandatory, as the image is private):
+
+```bash
+docker login
+```
+
+---
+
+## Download the SAP Image
+
+Find the available tags on Docker Hub:  
+👉 [SAP ABAP Cloud Developer Trial](https://hub.docker.com/r/sapse/abap-cloud-developer-trial/tags)  
+
+Example (2023 tag):  
+
+```bash
+docker pull sapse/abap-cloud-developer-trial:2023
+```
+
+---
+
+## Start the Container
+
+SAP requires the hostname `vhcala4hci`. Use the following command to start the container with all necessary ports exposed:
+
+```bash
+docker run --stop-timeout 3600 -i   --name a4h   -h vhcala4hci   -p 3200:3200   -p 3300:3300   -p 8443:8443   -p 30213:30213   -p 50000:50000   -p 50001:50001   sapse/abap-cloud-developer-trial:2023   -agree-to-sap-license   -skip-limits-check
+```
+
+### Ports Overview
+- `3200`: SAP GUI  
+- `3300`: RFC Instance  
+- `8443`: Cloud Connector  
+- `30213`: HANA MDC Database  
+- `50000/50001`: AS ABAP HTTP/HTTPS  
+
+---
+
+## Access the System
+
+### Web Access
+- HTTP: `http://<server-ip>:50000`  
+- HTTPS: `https://<server-ip>:50001`  
+- Cloud Connector: `https://<server-ip>:8443` (User: `Administrator`, PW: `manage`)  
+
+### SAP GUI
+- Application Server: `<server-ip>` or `vhcala4hci`  
+- System ID: `A4H`  
+- Instance Number: `00`  
+- Client: `001`  
+- User: `DEVELOPER`  
+- Password: version-dependent, e.g. `ABAPtr2023#00`  
+
+---
+
+## Manage the Container
+
+### Stop the container (gracefully)
+```bash
+docker stop -t 7200 a4h
+```
+
+### Restart the container
+```bash
+docker start -ai a4h
+```
+
+---
+
+## Notes & Best Practices
+
+- The initial startup takes **10–20 minutes**. Wait until CPU and memory usage stabilize before logging in.  
+- The hostname `vhcala4hci` must be resolvable. Add it to `/etc/hosts` if necessary.  
+- SAP licenses expire after ~90 days. Renew them via transaction `SLICENSE` or by copying a license file into the container.  
+- For production-like setups, use a static IP and secure access with a firewall.  
+
+---
+
+## Conclusion
+
+With a **Hetzner AX41-NVMe server**, the SAP ABAP Cloud Developer Trial can be run stably and efficiently.  
+Thanks to sufficient RAM, fast NVMe storage, and Docker’s flexibility, you get a complete ABAP development environment for testing, training, or proof-of-concepts — without compromising performance or reliability.  


### PR DESCRIPTION
Tutorial for running the SAP ABAP Cloud Developer Trial on a Hetzner AX41-NVMe server with Debian 12.
