### PR TITLE
Fix typo in "Installing and configuring a WireGuard VPN server on Debian"

### DIFF
--- a/tutorials/install-and-configure-wireguard-vpn-debian/01.en.md
+++ b/tutorials/install-and-configure-wireguard-vpn-debian/01.en.md
@@ -98,7 +98,7 @@ To explain each configuration parameter:
 
 Each peer (you can add multiple in the same file) has a public key which will be generated on the client, as well as:
 
-* `AllowedIPs`: Here we place the subnet for our clients, as well as the allowed IP address for the client. Restrict this as needed (for example, remove the `10.0.0.0/24` if you do not want each client to be able to talk to other clients on that subnet).
+* `AllowedIPs`: Here we place the subnet for our clients, as well as the allowed IP address for the client. Restrict this as needed (for example, remove the `10.0.0.1/24` if you do not want each client to be able to talk to other clients on that subnet).
 * `PersistentKeepalive`: Keeps the connection alive by sending a handshake every 25 seconds.
 
 ## Step 3 - Client configuration


### PR DESCRIPTION
> I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: svenja11

<br>

--------

<br>

Fix #1310
