### PR TITLE
[Update] Nextcloud tutorial: Improved encryption architecture with key separation

### DIFF
--- a/tutorials/encrypted-private-nextcloud-VPS-and-storagebox/01.en.md
+++ b/tutorials/encrypted-private-nextcloud-VPS-and-storagebox/01.en.md
@@ -249,6 +249,8 @@ nano /etc/systemd/system/mnt-myshare.mount
 
 Add the following content:
 
+> Replace `YOURSTORAGEBOXUSER-subX` with your actual account name.
+
 ```ini
 [Unit]
 Description=Mount SMB Share myshare
@@ -280,6 +282,8 @@ systemctl daemon-reload
 systemctl enable --now mnt-myshare.mount
 ```
 
+> If you get an error message like `Failed to mount mnt-myshare.mount - Mount SMB Share myshare`, double-check in Hetzner Console if the subaccount has "Allow SMB" enabled.
+
 Verify it mounted:
 
 ```bash
@@ -299,7 +303,7 @@ Once installed, make Docker wait for the SMB mount to be ready:
 systemctl edit docker.service
 ```
 
-Add above the line that says `### Lines below this comment will be discarded`:
+Add above the line that says `### Edits below this comment will be discarded`:
 
 ```ini
 [Unit]
@@ -344,7 +348,9 @@ Make the following adjustments:
 
 - Uncomment `NEXTCLOUD_MAX_TIME:` and increase the value (I use `7200`)
 
-- Uncomment `NEXTCLOUD_MEMORY_LIMIT:` and set it to `2048M`
+- Uncomment `NEXTCLOUD_MEMORY_LIMIT:` and set it to `2048`
+
+- Uncomment `environment:` above `NEXTCLOUD_MAX_TIME:` and `NEXTCLOUD_MEMORY_LIMIT:`
 
 - If you plan to use full-text search, uncomment `FULLTEXTSEARCH_JAVA_OPTIONS:` and set reasonable values:
   ```yaml
@@ -480,6 +486,7 @@ Verify they're active:
 
 ```bash
 mount | grep admin/files
+mount | grep admin/uploads
 ```
 
 You should see four bind mounts.
@@ -496,11 +503,23 @@ If a username contains spaces (like "Hans Werner"), escape spaces with `\040` in
 
 If the user already has files in Nextcloud before you set up the bind mount:
 
-1. Stop Nextcloud containers: `cd ~/containers/nextcloud && docker compose down`
-2. Move existing files to Storage Box: `mv /var/lib/docker/volumes/nextcloud_aio_nextcloud_data/_data/admin/files/* /mnt/myshare/_data/admin/files/`
+1. Stop Nextcloud containers:
+   ```bash
+   cd ~/containers/nextcloud && docker compose down
+   ```
+2. Move existing files to Storage Box:
+   ```bash
+   mv /var/lib/docker/volumes/nextcloud_aio_nextcloud_data/_data/admin/files/* /mnt/myshare/_data/admin/files/
+   ```
 3. Set up bind mounts as described above
-4. Start Nextcloud: `docker compose up -d`
-5. Optionally, run a file scan: `docker exec -it nextcloud-aio-nextcloud php occ files:scan admin`
+4. Start Nextcloud:
+   ```bash
+   docker compose up -d
+   ```
+5. Optionally, run a file scan:
+   ```bash
+   docker exec -it nextcloud-aio-nextcloud php occ files:scan admin
+   ```
 
 ### Important notes
 
@@ -655,6 +674,7 @@ The borg backup covers Nextcloud configuration and database, but for comprehensi
 - **Storage Box snapshots:** Enable automatic snapshots on your Storage Box. This protects your (encrypted) user files.
 
 Together with borg backup, this gives you:
+
 | Data | Protected by |
 |------|--------------|
 | Nextcloud config & database | Borg backup |
@@ -731,11 +751,11 @@ Anyone with access to your Storage Box has both the ciphertext AND the keys.
 
 ### Migration overview
 
-A. Stop Nextcloud
-B. Copy encryption keys and config to local disk
-C. Copy per-user local data
-D. Update `NEXTCLOUD_DATADIR` to use local Docker volume
-E. Set up per-user bind mounts for file storage
+A. Stop Nextcloud  
+B. Copy encryption keys and config to local disk  
+C. Copy per-user local data  
+D. Update `NEXTCLOUD_DATADIR` to use local Docker volume  
+E. Set up per-user bind mounts for file storage  
 F. Start Nextcloud
 
 ### Step-by-step migration


### PR DESCRIPTION
## Summary

This PR updates the Nextcloud tutorial with a significantly improved security architecture that separates encryption keys from encrypted data.

## Problem with the previous approach

The original guide stored the entire Nextcloud data directory on the Storage Box, including the `files_encryption` folder containing encryption keys. This meant anyone with access to the Storage Box had both the encrypted files AND the keys to decrypt them.

## New architecture

- **Encryption keys** stay on the local LUKS-encrypted VPS disk
- **Encrypted files** are stored on the Storage Box via per-user bind mounts
- If the Storage Box is compromised, attackers get only encrypted blobs with no way to decrypt them

## Changes in this PR

### Security improvements
- `NEXTCLOUD_DATADIR` now points to local Docker volume
- Per-user bind mounts for `files/`, `files_trashbin/`, `files_versions/`, `uploads/`
- Per-user `files_encryption/` and `cache/` folders remain local

### Bug fixes
- Fixed systemd mount unit: added `DefaultDependencies=no` to prevent ordering cycles
- Added mount verification service to prevent Docker starting with unmounted directories

### Updates
- Debian 12 Bookworm → Debian 13 Trixie
- Standardized on ext4 filesystem (simpler, VPS snapshots make btrfs redundant)

### New sections
- Architecture Overview explaining the security model
- Step 10: Setting up per-user storage offloading
- Step 11: Adding the mounts verification service
- Migration guide for users of the previous version

## Migration path

Existing users can follow the new "Migration from Previous Guide" section to move their encryption keys to the local disk while keeping their files on the Storage Box.

## Testing

This architecture has been running in production with 120,000+ files across multiple users, surviving multiple reboots. But it should be tested again whether new setup and whether migration fully works. I have migrated mine and am happily running it like this for now

I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Justin Scholz [git@justinscholz.de](git@justinscholz.de)
