### PR TITLE
New Hetzner Cloud DNS Tutorial for Kubernetes / cert-manager

### DIFF
--- a/tutorials/cert-manager-hetzner-cloud-dns-webhook/01.de.md
+++ b/tutorials/cert-manager-hetzner-cloud-dns-webhook/01.de.md
@@ -3,7 +3,7 @@ SPDX-License-Identifier: MIT
 path: "/tutorials/cert-manager-hetzner-cloud-dns-webhook/de"
 slug: "cert-manager-hetzner-cloud-dns-webhook"
 date: "2026-02-09"
-title: "Automatische SSL-Zertifikate mit cert-manager und Hetzner Cloud DNS"
+title: "Automatische SSL-Zertifikate mit cert-manager und Hetzner Console DNS"
 short_description: "Richte die automatische Ausstellung von Let's Encrypt-Zertifikaten über DNS-01-Challenge mit dem offiziellen Hetzner Cloud-Webhook für cert-manager ein."
 tags: ["Kubernetes", "SSL", "DNS", "Let's Encrypt", "cert-manager"]
 author: "Björn Ternes"

--- a/tutorials/cert-manager-hetzner-cloud-dns-webhook/01.en.md
+++ b/tutorials/cert-manager-hetzner-cloud-dns-webhook/01.en.md
@@ -3,7 +3,7 @@ SPDX-License-Identifier: MIT
 path: "/tutorials/cert-manager-hetzner-cloud-dns-webhook"
 slug: "cert-manager-hetzner-cloud-dns-webhook"
 date: "2026-02-09"
-title: "Automatic SSL Certificates with cert-manager and Hetzner Cloud DNS"
+title: "Automatic SSL Certificates with cert-manager and Hetzner Console DNS"
 short_description: "Set up automatic Let's Encrypt certificate issuance via DNS-01 challenge using the official Hetzner Cloud webhook for cert-manager."
 tags: ["Kubernetes", "SSL", "DNS", "Let's Encrypt", "cert-manager"]
 author: "Björn Ternes"


### PR DESCRIPTION
I started migrating from the "old" Hetzner DNS API to the "new" Hetzner Cloud DNS API. I saw that there is not much information available regarding cert-manager and kubernetes.

So I started to look into it and decided to write it down. Maybe it is now worth getting merged.

Edit: I have proofread and tested the tutorial several times myself. 

I have read and understood the Contributor's Certificate of Origin available at the end of 
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Björn Ternes <mail@bternes.com>