### PR TITLE
Add tutorial: Installing a Hytale Dedicated Server on Ubuntu

### DIFF
--- a/tutorials/game-server-hytale/01.en.md
+++ b/tutorials/game-server-hytale/01.en.md
@@ -350,6 +350,6 @@ By making a contribution to this project, I certify that:
     indefinitely and may be redistributed consistent with this project
     or the license(s) involved.
 
-Signed-off-by: [submitter's name and email address here]
+Signed-off-by: Tarkan Akyüz <akyuez.tarkan@gmail.com>
 
 -->


### PR DESCRIPTION
Hi Hetzner Team, 
I added a new tutorial on how to set up a Hytale Dedicated Server on Ubuntu 24.04/22.04. 
It includes Java 25 installation, Systemd service setup, and automated backups.

I have read and understood the Contributor's Certificate of Origin available at the end of 
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Rez2h <akyuez.tarkan@gmail.com>