### PR TITLE
Add tutorial: Deploy Libre WebUI with Ollama on a Hetzner GPU Server

### DIFF
--- a/tutorials/ai-chatbot-with-ollama-and-libre-webui/01.en.md
+++ b/tutorials/ai-chatbot-with-ollama-and-libre-webui/01.en.md
@@ -2,29 +2,29 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/ai-chatbot-with-ollama-and-libre-webui"
 slug: "ai-chatbot-with-ollama-and-libre-webui"
-date: "2026-01-30"
+date: "2026-02-26"
 title: "Deploy a Private AI Chat Interface with Libre WebUI and Ollama on a GPU Server"
-short_description: "Set up Libre WebUI with Ollama in Docker on a Hetzner GPU server to run open-source LLMs privately with CUDA acceleration."
+short_description: "Set up Libre WebUI with Ollama in Docker on a GPU server to run open-source LLMs privately with CUDA acceleration."
 tags: ["Docker", "AI", "GPU", "Ollama", "Ubuntu"]
 author: "Robin Kroonen"
 author_link: "https://github.com/rob-x-ai"
-author_img: "https://avatars.githubusercontent.com/u/rob-x-ai"
+author_img: "https://avatars.githubusercontent.com/u/64106559"
 author_description: "Founder of KROONEN AI, Inc. and creator of Libre WebUI, making AI accessible to everyone, Free and Open Source advocate"
 language: "en"
 available_languages: ["en"]
-header_img: "header-gpu-ai"
+header_img: "header-1"
 cta: "gpu"
 ---
 
 ## Introduction
 
-Large language models (LLMs) like Llama, Mistral, and Gemma are incredibly powerful, but using them through commercial APIs means sending your data to third parties. By self-hosting, you keep full control over your data while getting fast, private AI chat.
+Large language models (LLMs) like Llama, Mistral, and Gemma are incredibly powerful, but using them through commercial APIs means sending your data to third parties. By self-hosting, you keep full control over your data while getting fast, private AI chats.
 
 [Libre WebUI](https://github.com/libre-webui/libre-webui) is an open-source AI chat interface licensed under **Apache 2.0** with zero telemetry, zero tracking, and no CLA. All stored data (chat history, documents, credentials) is encrypted at rest with AES-256-GCM. It works with Ollama for local models and 100+ cloud providers, and includes document chat (RAG), interactive artifacts, custom personas, and multi-user access control.
 
 > **Note:** Libre WebUI was started after Open WebUI adopted a BSD-3 license with a CLA and took on venture capital. Libre WebUI is a separate project rewritten around privacy and encryption, maintained under Apache 2.0.
 
-In this tutorial, you will deploy Libre WebUI alongside [Ollama](https://ollama.com) on a Hetzner GPU dedicated server. By the end, you'll have a fully functional, GPU-accelerated AI chat application accessible from your browser - with all data staying on EU infrastructure.
+In this tutorial, you will deploy Libre WebUI alongside [Ollama](https://ollama.com) on a GPU dedicated server. By the end, you'll have a fully functional, GPU-accelerated AI chat application accessible from your browser - with all data staying on EU infrastructure.
 
 **What you'll set up:**
 
@@ -35,9 +35,9 @@ In this tutorial, you will deploy Libre WebUI alongside [Ollama](https://ollama.
 
 **Choosing a Hetzner GPU server**
 
-Hetzner offers two GPU dedicated server lines, both located in their German data centers (Falkenstein / Nuremberg) and powered by 100% green electricity:
+At the time of writing (early 2026), Hetzner offers two GPU dedicated server lines, both located in their German data centers (Falkenstein / Nuremberg) and powered by 100% green electricity:
 
-| Server | GPU | VRAM | RAM | CPU | Use case |
+| Server | GPU | vRAM | RAM | CPU | Use case |
 |--------|-----|------|-----|-----|----------|
 | **GEX44** | NVIDIA RTX 4000 SFF Ada | 20 GB GDDR6 | 64 GB DDR4 | Intel i5-13500 | Running 7B-14B parameter models comfortably |
 | **GEX131** | NVIDIA RTX PRO 6000 Blackwell Max-Q | 96 GB GDDR7 | 256 GB DDR5 ECC | Intel Xeon Gold 5412U | Running 70B+ parameter models, fine-tuning |
@@ -46,8 +46,8 @@ This tutorial uses the **GEX44** as the baseline - it is the most affordable opt
 
 **Prerequisites**
 
-* A Hetzner GPU Dedicated Server ([GEX44](https://www.hetzner.com/dedicated-rootserver/matrix-gpu/) or GEX131)
-* Ubuntu 24.04 installed via the [Hetzner Robot panel](https://robot.hetzner.com)
+* A GPU Dedicated Server, e.g. [with Hetzner](https://www.hetzner.com/dedicated-rootserver/matrix-gpu/) (GEX44 or GEX131)
+* Ubuntu 24.04 installed, e.g. via the [Hetzner Robot panel](https://robot.hetzner.com)
 * An [SSH key](https://community.hetzner.com/tutorials/howto-ssh-key) added to your server
 * A domain name pointed at your server (optional, for HTTPS access)
 * Basic familiarity with the Linux command line
@@ -84,12 +84,8 @@ usermod -aG sudo holu
 Copy your SSH key to the new user's home directory so you can log in without a password. The `authorized_keys` file contains the public keys that are allowed to authenticate:
 
 ```bash
-mkdir -p /home/holu/.ssh
-cp ~/.ssh/authorized_keys /home/holu/.ssh/
-chown -R holu:holu /home/holu/.ssh
+rsync --archive --chown=holu:holu ~/.ssh /home/holu
 ```
-
-The `chown` command ensures that the `.ssh` directory and its contents are owned by `holu`, which is required for SSH key authentication to work.
 
 Log out and reconnect as `holu`:
 
@@ -109,13 +105,13 @@ Update the package index and upgrade any existing packages to ensure you are sta
 sudo apt update && sudo apt upgrade -y
 ```
 
-Install the NVIDIA driver. The `nvidia-driver-560` package includes the kernel module that communicates with the GPU, and `nvidia-utils-560` provides command-line utilities like `nvidia-smi` for monitoring GPU status:
+Install the NVIDIA driver. The `nvidia-driver-580` package includes the kernel module that communicates with the GPU, and `nvidia-utils-580` provides command-line utilities like `nvidia-smi` for monitoring GPU status:
 
 ```bash
-sudo apt install -y nvidia-driver-560 nvidia-utils-560
+sudo apt install -y nvidia-driver-580 nvidia-utils-580
 ```
 
-> **Note:** The driver version (560) is current as of January 2026 for Ubuntu 24.04. If your Hetzner server ships with a newer GPU or Ubuntu version, check the [NVIDIA driver downloads page](https://www.nvidia.com/Download/index.aspx) for the recommended version.
+> **Note:** The driver version (580) is current as of February 2026 for Ubuntu 24.04. If your server ships with a newer GPU or Ubuntu version, check the [NVIDIA driver downloads page](https://www.nvidia.com/Download/index.aspx) for the recommended version.
 
 Reboot the server to load the newly installed kernel module:
 
@@ -138,7 +134,7 @@ Docker will run both Libre WebUI and Ollama as isolated containers. The NVIDIA C
 
 ### Step 3.1 - Install Docker
 
-Install Docker Engine using the official convenience script. This script detects your distribution and configures the Docker apt repository automatically:
+Install Docker Engine as explained [in the official documentation](https://docs.docker.com/engine/install/ubuntu/) or by using the official convenience script. This script detects your distribution and configures the Docker apt repository automatically:
 
 ```bash
 curl -fsSL https://get.docker.com | sudo sh
@@ -307,7 +303,7 @@ docker compose logs ollama
 
 Ollama does not include any models by default - you need to download them. Models are stored in the `ollama_data` volume and persist across container restarts.
 
-Pull Gemma 3 12B, Google's latest open model with vision capabilities, making it an excellent starting point for the GEX44's 20 GB of VRAM:
+Pull [Gemma 3 12B](https://registry.ollama.ai/library/gemma3), Google's latest open model with vision capabilities, making it an excellent starting point for the GEX44's 20 GB of VRAM:
 
 ```bash
 docker exec ollama ollama pull gemma3:12b
@@ -439,7 +435,7 @@ docker compose logs ollama | grep -i cuda
 
 ## Conclusion
 
-You now have a private, GPU-accelerated AI chat interface running on your Hetzner server. Libre WebUI gives you a polished chat experience with AES-256-GCM encrypted storage, while Ollama handles running the models locally with full CUDA acceleration. Your conversations never leave your server.
+You now have a private, GPU-accelerated AI chat interface running on your server. Libre WebUI gives you a polished chat experience with AES-256-GCM encrypted storage, while Ollama handles running the models locally with full CUDA acceleration. Your conversations never leave your server.
 
 Because Hetzner's data centers are located in Germany and Finland, this setup is inherently GDPR-compliant - your AI infrastructure runs entirely within the EU, with no data sent to third-party cloud providers. This makes it suitable for organizations handling sensitive data across industries like healthcare, legal, and finance, regardless of where their users are located.
 
@@ -455,7 +451,7 @@ Because Hetzner's data centers are located in Germany and Finland, this setup is
 * Explore [Libre WebUI's features](https://github.com/libre-webui/libre-webui) - document chat (RAG), personas, artifacts, and more
 * Try larger models - upgrade to the GEX131 (96 GB VRAM) to run `llama3.3:70b` and beyond
 * Connect cloud providers (OpenAI, Anthropic, Mistral AI) alongside Ollama for a unified interface
-* For GDPR-compliant managed AI infrastructure on Hetzner, [Kroonen AI](https://kroonen.ai) partners with Hetzner to deliver turnkey deployments for organizations worldwide - including custom model fine-tuning, SLA-backed support, and air-gapped installations
+* For GDPR-compliant managed AI infrastructure, Kroonen AI deliverss turnkey deployments for organizations worldwide - including custom model fine-tuning, SLA-backed support, and air-gapped installations
 
 ##### License: MIT
 
@@ -480,7 +476,7 @@ By making a contribution to this project, I certify that:
 
 (d) I understand and agree that this project and the contribution are
     public and that a record of the contribution (including all personal
-    information I submit with me, including my sign-off) is maintained
+    information I submit with it, including my sign-off) is maintained
     indefinitely and may be redistributed consistent with this project
     or the license(s) involved.
 


### PR DESCRIPTION
I have read and understood the Contributor's Certificate of Origin available at the end of https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Robin Kroonen <robin@kroonen.ai>

## New Tutorial

**Title:** Deploy a Private AI Chat Interface with Libre WebUI and Ollama on a GPU Server

**Summary:**
Step-by-step guide for deploying [Libre WebUI](https://github.com/libre-webui/libre-webui) with [Ollama](https://ollama.com) on Hetzner GPU dedicated servers (GEX44 / GEX131) using Docker and the NVIDIA Container Toolkit for CUDA acceleration.

**Topics covered:**
- NVIDIA driver and CUDA setup on Ubuntu 24.04
- Docker Engine and NVIDIA Container Toolkit installation
- Docker Compose deployment with GPU passthrough
- Model selection and VRAM/RAM offloading
- Optional HTTPS with Caddy reverse proxy

**Why this tutorial?**
Libre WebUI is an Apache 2.0 licensed, privacy-first AI chat interface with AES-256-GCM encrypted storage and zero telemetry. Combined with Hetzner's EU-based GPU servers, it provides a fully GDPR-compliant self-hosted AI solution.

All commands have been tested and verified on a local Docker + NVIDIA GPU setup.