### PR TITLE
Minor fix to sed-command for patching dropbear options

### DIFF
--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
@@ -280,7 +280,7 @@ add_initramfs_network
 
 # Copy SSH keys for dropbear and change the port
 cp /root/.ssh/authorized_keys /etc/dropbear/initramfs/
-sed -ie 's/#DROPBEAR_OPTIONS=/DROPBEAR_OPTIONS="-I 600 -j -k -p 2222 -s"/' /etc/dropbear/initramfs/dropbear.conf
+sed -ie 's/#DROPBEAR_OPTIONS=.*/DROPBEAR_OPTIONS="-I 600 -j -k -p 2222 -s"/' /etc/dropbear/initramfs/dropbear.conf
 dpkg-reconfigure dropbear-initramfs
 update-initramfs -u
 ```
@@ -312,7 +312,7 @@ add_initramfs_network
 
 # Copy SSH keys for dropbear and change the port
 cp /root/.ssh/authorized_keys /etc/dropbear/initramfs/
-sed -ie 's/#DROPBEAR_OPTIONS=/DROPBEAR_OPTIONS="-I 600 -j -k -p 2222 -s"/' /etc/dropbear/initramfs/dropbear.conf
+sed -ie 's/#DROPBEAR_OPTIONS=.*/DROPBEAR_OPTIONS="-I 600 -j -k -p 2222 -s"/' /etc/dropbear/initramfs/dropbear.conf
 dpkg-reconfigure dropbear-initramfs
 update-initramfs -u
 ```

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
@@ -279,7 +279,7 @@ add_initramfs_network
 
 # Copy SSH keys for dropbear and change the port
 cp /root/.ssh/authorized_keys /etc/dropbear/initramfs/
-sed -ie 's/#DROPBEAR_OPTIONS=/DROPBEAR_OPTIONS="-I 600 -j -k -p 2222 -s"/' /etc/dropbear/initramfs/dropbear.conf
+sed -ie 's/#DROPBEAR_OPTIONS=.*/DROPBEAR_OPTIONS="-I 600 -j -k -p 2222 -s"/' /etc/dropbear/initramfs/dropbear.conf
 dpkg-reconfigure dropbear-initramfs
 update-initramfs -u
 ```
@@ -311,7 +311,7 @@ add_initramfs_network
 
 # Copy SSH keys for dropbear and change the port
 cp /root/.ssh/authorized_keys /etc/dropbear/initramfs/
-sed -ie 's/#DROPBEAR_OPTIONS=/DROPBEAR_OPTIONS="-I 600 -j -k -p 2222 -s"/' /etc/dropbear/initramfs/dropbear.conf
+sed -ie 's/#DROPBEAR_OPTIONS=.*/DROPBEAR_OPTIONS="-I 600 -j -k -p 2222 -s"/' /etc/dropbear/initramfs/dropbear.conf
 dpkg-reconfigure dropbear-initramfs
 update-initramfs -u
 ```


### PR DESCRIPTION
If the (commented-out) dropbear options in template dropbear.conf that get replaced here already contain an empty string as value (two double quotes, which is at least true on Ubuntu 24.04), the command leaves the config line after replacement like so: 

> DROPBEAR_OPTIONS="-I 600 -j -k -p 2222 -s"""

While the triple trailing double-quotes don't actually pose problems, they clutter the config and might cause later confusion. They make it seem as if the '-s' option had an argument, which it does not.

The fixed command ensures to replace the entire template line.

> I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Ralph Weires