### PR TITLE
Adjust from debian 12 to debian 13 in ubuntu 20.04 encryption tutorial 

### DIFF
--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
@@ -286,7 +286,7 @@ update-initramfs -u
 
 <details>
 
-<summary>For Debian 12</summary>
+<summary>For Debian 13</summary>
 
 <blockquote>
 


### PR DESCRIPTION
This is a very minor fix as debian 13 is mentioned first on line 80, but not consistent. This PR just adjusts it to be flush as to prevent confusion.


>I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Kokomo123 jyvkcxe1@duck.com 