### PR TITLE
Fix typo in "How to install Ubuntu 24.04 with full disk encryption"

### DIFF
--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
@@ -287,7 +287,7 @@ update-initramfs -u
 
 <details>
 
-<summary>Für Debian 12</summary>
+<summary>Für Debian 13</summary>
 
 <blockquote>
 


### PR DESCRIPTION
> I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Svenja