### PR TITLE
Persistent ip forward settings in sysctl

### DIFF
--- a/tutorials/install-and-configure-proxmox_ve/01.de.md
+++ b/tutorials/install-and-configure-proxmox_ve/01.de.md
@@ -131,9 +131,11 @@ Bei einem gerouteten Setup sind die Bridges (z.B. `vmbr0`) nicht mit der physika
 
 Für IPv4 und IPv6:
 ```bash
-echo 1 > /proc/sys/net/ipv4/ip_forward
-echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
-  ```
+cat << EOF > /etc/sysctl.d/ip-forwarding.conf
+net.ipv4.ip_forward = 1
+net.ipv6.conf.all.forwarding = 1
+EOF
+```
 Änderungen anwenden:
 ```bash
 systemctl restart systemd-sysctl

--- a/tutorials/install-and-configure-proxmox_ve/01.en.md
+++ b/tutorials/install-and-configure-proxmox_ve/01.en.md
@@ -133,8 +133,10 @@ With a routed setup, the bridges (`vmbr0`, for example) are not connected with t
 
 For IPv4 and IPv6:
 ```bash
-echo 1 > /proc/sys/net/ipv4/ip_forward
-echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
+cat << EOF > /etc/sysctl.d/ip-forwarding.conf
+net.ipv4.ip_forward = 1
+net.ipv6.conf.all.forwarding = 1
+EOF
 ```
 Apply the changes:
 ```bash


### PR DESCRIPTION
I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Philipp Felix Hoefler

Changed the echo to runtime settings to a cat which generates a persistant config file