### PR TITLE
Update FDE tutorials for cloud instances

### DIFF
--- a/tutorials/install-almalinux-10-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-almalinux-10-with-full-disk-encryption/01.de.md
@@ -32,11 +32,11 @@ Dieses Tutorial verwendet zwei Beispieldateien:
 **Voraussetzungen**
 
 * Hetzner-Konto
-* Server welcher in das Rescue-System gebootet ist und eine IPv4 Adresse besitzt
+* Server, welcher in das Rescue-System gebootet ist und eine IPv4-Adresse besitzt
 * Öffentlicher RSA, ECDSA oder ED25519 SSH-Schlüssel
 * Keine privaten Netzwerke über die Hetzner Cloud an den Servern angeschlossen
 
-> Bei Servern welche nur eine IPv6 Adresse besitzen muss die Konfiguration über einen vollen Networkprovider (z.B. systemd-networkd oder NetworkManager) durchgeführt werden da der IP Parameter des Kernels nur IPv4 und nur Gateways im gleichen Netz unterstützt.
+> Bei Servern, welche nur eine IPv6-Adresse besitzen, muss die Konfiguration über einen vollen Networkprovider (z.B. systemd-networkd oder NetworkManager) durchgeführt werden, da der IP-Parameter des Kernels nur IPv4 und nur Gateways im gleichen Netz unterstützt.
 
 **Hinweis: Diese Anleitung ist explizit nur für AlmaLinux 10 geschrieben. Es könnte sein, dass diese nicht auf anderen Distributionen funktioniert.**
 
@@ -44,7 +44,7 @@ Dieses Tutorial verwendet zwei Beispieldateien:
 
 Es wird ein SSH-Schlüssel benötigt, um das verschlüsselte System während dem Boot aus der Ferne entsperren zu können. Dieser Schlüssel wird auch für die spätere Anmeldung am gebooteten System verwendet.
 
-> Falls das Rescuesystem bereits mit hinterlegten SSH-Schlüsseln gestartet wurde kann kann auch direkt der Pfad `/root/.ssh/authorized_keys` in installimage genutzt werden.
+> Falls das Rescuesystem bereits mit hinterlegten SSH-Schlüsseln gestartet wurde, kann auch direkt der Pfad `/root/.ssh/authorized_keys` in installimage genutzt werden.
 
 Wenn du keinen solchen Schlüssel hast, musst du einen auf deinem lokalen Gerät generieren. **Wir empfehlen die Nutzung von ED25519 oder ECDSA Schlüsseln**
 

--- a/tutorials/install-almalinux-10-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-almalinux-10-with-full-disk-encryption/01.en.md
@@ -32,11 +32,11 @@ This tutorial will use the following example files:
 **Prerequisites**
 
 * Hetzner account
-* Server with an IPv4 Address booted into the Rescue System
+* Server with an IPv4 address booted into the Rescue System
 * RSA, ECDSA or ED25519 SSH public key
 * No private networks attached on Hetzner Cloud
 
-> For servers which only have an IPv6 Address the configuration needs to be done with a full network provider (e.g. systemd-networkd or NetworkManager) as the IP parameter of the Kernel does not support IPv6 or out-of-network gateways.
+> For servers which only have an IPv6 address, the configuration needs to be done with a full network provider (e.g. systemd-networkd or NetworkManager), as the IP parameter of the Kernel does not support IPv6 or out-of-network gateways.
 
 **Note: This guide is explicitly written for AlmaLinux 10 only. It might not work on other distributions.**
 
@@ -44,7 +44,7 @@ This tutorial will use the following example files:
 
 You will need an SSH key to remotely unlock the disk during boot. You will also use this key later to login to the booted system.
 
-> If the rescue system was activated with an active SSH-Key you can also directly use `/root/.ssh/authorized_keys` within installimage.
+> If the rescue system was activated with an active SSH key, you can also directly use `/root/.ssh/authorized_keys` within installimage.
 
 If you don't have such an SSH key, you need to generate one now on your local system. **We recommend the use of ED25519 or ECDSA keys**.
 

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
@@ -32,11 +32,11 @@ Dieses Tutorial verwendet zwei Beispieldateien:
 **Voraussetzungen**
 
 * Hetzner-Konto
-* Server welcher in das Rescue-System gebootet ist und eine IPv4 Adresse besitzt
+* Server, welcher in das Rescue-System gebootet ist und eine IPv4-Adresse besitzt
 * Öffentlicher RSA, ECDSA oder ED25519 SSH-Schlüssel
 * Keine privaten Netzwerke über die Hetzner Cloud an den Servern angeschlossen
 
-> Bei Servern welche nur eine IPv6 Adresse besitzen muss die Konfiguration über einen vollen Networkprovider (z.B. systemd-networkd oder NetworkManager) durchgeführt werden da der IP Parameter des Kernels nur IPv4 und nur Gateways im gleichen Netz unterstützt.
+> Bei Servern, welche nur eine IPv6-Adresse besitzen, muss die Konfiguration über einen vollen Networkprovider (z.B. systemd-networkd oder NetworkManager) durchgeführt werden, da der IP-Parameter des Kernels nur IPv4 und nur Gateways im gleichen Netz unterstützt.
 
 **Hinweis: Diese Anleitung ist explizit nur für Ubuntu 24.04 geschrieben. Es könnte sein, dass diese nicht auf anderen Distributionen funktioniert.**
 
@@ -44,7 +44,7 @@ Dieses Tutorial verwendet zwei Beispieldateien:
 
 Es wird ein SSH-Schlüssel benötigt, um das verschlüsselte System während dem Boot aus der Ferne entsperren zu können. Dieser Schlüssel wird auch für die spätere Anmeldung am gebooteten System verwendet. Der in Ubuntu 24.04 enthaltene SSH-Daemon dropbear unterstützt RSA, ED25519 und ECDSA-Schlüssel.
 
-> Falls das Rescuesystem bereits mit hinterlegten SSH-Schlüsseln gestartet wurde kann kann auch direkt der Pfad `/root/.ssh/authorized_keys` in installimage genutzt werden.
+> Falls das Rescuesystem bereits mit hinterlegten SSH-Schlüsseln gestartet wurde, kann auch direkt der Pfad `/root/.ssh/authorized_keys` in installimage genutzt werden.
 
 Wenn du keinen solchen Schlüssel hast, musst du einen auf deinem lokalen Gerät generieren. **Wir empfehlen die Nutzung von ED25519 oder ECDSA Schlüsseln**
 

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
@@ -32,11 +32,11 @@ This tutorial will use the following example files:
 **Prerequisites**
 
 * Hetzner account
-* Server with an IPv4 Address booted into the Rescue System
+* Server with an IPv4 address booted into the Rescue System
 * RSA, ECDSA or ED25519 SSH public key
 * No private networks attached on Hetzner Cloud
 
-> For servers which only have an IPv6 Address the configuration needs to be done with a full network provider (e.g. systemd-networkd or NetworkManager) as the IP parameter of the Kernel does not support IPv6 or out-of-network gateways.
+> For servers which only have an IPv6 address, the configuration needs to be done with a full network provider (e.g. systemd-networkd or NetworkManager), as the IP parameter of the Kernel does not support IPv6 or out-of-network gateways.
 
 **Note: This guide is explicitly written for Ubuntu 24.04 only. It might not work on other distributions.**
 
@@ -44,7 +44,7 @@ This tutorial will use the following example files:
 
 You will need an SSH key to remotely unlock the disk during boot. You will also use this key later to login to the booted system. The dropbear SSH daemon included in Ubuntu 24.04 only supports RSA and ECDSA keys.
 
-> If the rescue system was activated with an active SSH-Key you can also directly use `/root/.ssh/authorized_keys` within installimage.
+> If the rescue system was activated with an active SSH key, you can also directly use `/root/.ssh/authorized_keys` within installimage.
 
 If you don't have such an SSH key, you need to generate one now on your local system. **We recommend the use of ED25519 or ECDSA keys**.
 


### PR DESCRIPTION
My last update overlooked that cloud instances have out-of-network gateways, luckily DHCP is not being deprecated for them so there wasn't a big overhaul necessary.

I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Nils github@nils.lol