### PR TITLE
Add: Active-Active infrastructure accross muliple regions

### DIFF
--- a/tutorials/active-active-infra-accross-regions/01.en.md
+++ b/tutorials/active-active-infra-accross-regions/01.en.md
@@ -1,0 +1,214 @@
+---
+SPDX-License-Identifier: MIT
+path: "/tutorials/active-active-infra-accross-regions"
+slug: "active-active-infra-accross-regions"
+date: "2026-02-26"
+title: "Active-Active infrastructure accross muliple regions"
+short_description: "Running infrastructure accross multiple Hetzner regions for High Availability using Claudie"
+tags: ["k8s", "Multicloud", "Hybridcloud", "HA", "Lang:YAML",]
+author: "Matúš Brandýs"
+author_link: "https://github.com/m-brando"
+author_img: "https://avatars.githubusercontent.com/m-brando"
+author_description: ""
+language: "en"
+available_languages: ["en"]
+header_img: "header-2"
+cta: "cloud"
+---
+
+## Introduction
+
+This article demonstrates how to run Kubernetes workloads across multiple regions in Hetzner, showcasing an active-active architecture using a tool [Claudie](https://docs.claudie.io/). This type of setup is resilient to regional cloud disruptions and also helps address resource shortages within a single or even multiple regions.
+
+**Prerequisites**
+
+* Hetzner Cloud [API token](https://docs.hetzner.com/cloud/api/getting-started/generating-api-token)
+* Installed [kubectl binary](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
+* Running local [kind](https://kind.sigs.k8s.io/docs/user/quick-start) cluster
+
+## Step 1 - Management cluster
+
+To manage a desired cluster across multiple regions, we need a smaller Kubernetes cluster where we will install Claudie, which we will refer to as the `Management Cluster`. For testing, we can use an ephemeral cluster like `kind`. One prerequisite before installing `Claudie` is to have cert-manager running inside `Managemet Cluster`.
+
+1. Install cert-manager.
+   ```shellsession
+   holu@<your_host>:~# kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
+   ```
+2. Deploy Claudie.
+   ```shellsession
+   holu@<your_host>:~# kubectl apply -f https://github.com/berops/claudie/releases/download/v0.10.0/claudie.yaml
+   ```
+3. Wait and verify that all pods are running in the `claudie` namespace inside the `Management Cluster`.
+
+    ```shellsession
+    holu@<your_host>:~# kubectl get pods -n claudie
+    NAME                                READY   STATUS    RESTARTS     AGE
+    ansibler-594c67f799-p6rtp           1/1     Running   0            60s
+    claudie-operator-56f4b6767f-smr2x   1/1     Running   0            60s
+    kube-eleven-547645865f-4tls2        1/1     Running   0            60s
+    kuber-7764ffb5df-d826z              1/1     Running   0            60s
+    manager-59fc97fd48-n8cvj            1/1     Running   0            60s
+    minio-0                             1/1     Running   0            60s
+    minio-1                             1/1     Running   0            60s
+    minio-2                             1/1     Running   0            60s
+    minio-3                             1/1     Running   0            60s
+    mongodb-6d59c69c99-gjrv2            1/1     Running   0            60s
+    nack-5bbb756857-rhxx2               1/1     Running   0            60s
+    nats-0                              2/2     Running   0            60s
+    nats-1                              2/2     Running   0            60s
+    nats-2                              2/2     Running   0            60s
+    terraformer-6c88c87f8c-b9gtn        1/1     Running   0            60s
+    ```
+
+## Step 2 - Desired cluster
+
+To create the `Desired cluster`, first we need to store the authentication credentials for Hetzner Cloud in the `Management Cluster` as a Kubernetes secret.
+Next, we create a Claudie manifest that describes our infrastructure and is used to provision the cloud resources.
+
+1. Create a Kubernetes Secret with Hetzner API Token inside.
+   
+   ```shellsession
+   holu@<your_host>:~# kubectl create secret generic hetzner-secret --from-literal=credentials='YOUR_API_TOKEN' -n claudie
+   ```
+
+2. Create an `InputManifest` that defines your infrastructure. This `InputManifest` will provision:
+   - 3 Kubernetes control plane nodes in the Falkenstein region
+   - 2 Kubernetes worker nodes in the Falkenstein region
+   - 1 to 2 auto-scaled Kubernetes worker nodes in the Nuremberg region, depending on workload demand
+
+  ```yaml
+  apiVersion: claudie.io/v1beta1
+  kind: InputManifest
+  metadata:
+    name: multi-cloud-k8s
+  spec:
+    providers:
+      - name: hetzner-secret
+        providerType: hetzner
+        secretRef:
+          name: hetzner-secret
+          namespace: claudie
+    nodePools:
+      dynamic:
+        - name: ctrl-fsn
+          providerSpec:
+            name: hetzner-secret
+            region: fsn1
+            zone: fsn1-dc14
+          count: 3
+          serverType: cx23
+          image: ubuntu-24.04
+
+        - name: cmpt-fsn
+          providerSpec:
+            name: hetzner-secret
+            region: fsn1
+            zone: fsn1-dc14
+          count: 2
+          serverType: cx23
+          image: ubuntu-24.04
+          storageDiskSize: 50
+
+        - name: cmpt-nbg
+          providerSpec:
+            name: hetzner-secret
+            region: nbg1
+            zone: nbg1-dc3
+          autoscaler:
+            min: 1
+            max: 2
+          serverType: cx23
+          image: ubuntu-24.04
+          storageDiskSize: 50
+    kubernetes:
+      clusters:
+        - name: hetzner-cluster
+          version: v1.34.0
+          network: 192.168.2.0/24
+          pools:
+            control:
+              - ctrl-fsn
+            compute:
+              - cmpt-fsn
+              - cmpt-nbg
+
+  ```
+Communication between regional nodes runs over the overlay network `192.168.2.0/24`, which we defined in the `InputManifest`. All inter-node traffic within this network is encrypted.
+This infrastructure can be modified at any time. You can add a new region, scale nodes up or down within existing regions or even attach physical machines to the cluster.
+More information about the features provided by Claudie can be found in the official [documentation](https://docs.claudie.io)
+
+3. Run `InputManifest` inside `Management Cluster`.
+```shellsession
+holu@<your_host>:~# kubectl apply -f inputmanifest.yml -n claudie
+inputmanifest.claudie.io/multi-cloud-k8s created
+```
+
+4. Verify that infrastructure is deployed.
+```shellsession
+holu@<your_host>:~# kubectl get inputmanifest -n claudie
+NAME              STATUS
+multi-cloud-k8s   WATCHING_FOR_CHANGES
+```
+
+Wait until you see `WATCHING_FOR_CHANGES` in the STATUS column. If the status shows `IN_PROGRESS`, it means that infrastructure is still being provisioned. You can always check in which stage you are in running:
+
+```shellsession
+holu@<your_host>:~# kubectl logs -f -l app.kubernetes.io/name=claudie-operator -n claudie
+```
+
+5. Export kubeconfig for `Desired cluster`.
+```shellsession
+holu@<your_host>:~# kubectl get secrets -n claudie -l claudie.io/cluster=hetzner-cluster,claudie.io/output=kubeconfig -ojsonpath='{.items[0].data.kubeconfig}' | base64 -d > hetzner-cluster.yaml
+```
+
+6. Verify deployed `Desired cluster`.
+```shellsession
+holu@<your_host>:~# export KUBECONFIG=hetzner-cluster.yaml 
+holu@<your_host>:~# kubectl get node
+NAME                  STATUS   ROLES           AGE   VERSION
+cmpt-fsn-vjh754v-01   Ready    <none>          9m   v1.34.0
+cmpt-fsn-vjh754v-02   Ready    <none>          9m   v1.34.0
+cmpt-nbg-46oaf10-01   Ready    <none>          9m   v1.34.0
+ctrl-fsn-lkd2o3o-01   Ready    control-plane   9m   v1.34.0
+ctrl-fsn-lkd2o3o-02   Ready    control-plane   9m   v1.34.0
+ctrl-fsn-lkd2o3o-03   Ready    control-plane   9m   v1.34.0
+```
+
+As can be seen from the output above, we have two worker nodes in Falkenstein region and one worker node in Nuremberg which can be horizontally autoscaled.
+
+## Conclusion
+
+Through this tutorial, we demonstrate how to provision a Kubernetes cluster across two Hetzner regions using [`Claudie`]((https://docs.claudie.io/)) to manage the infrastructure.
+
+Using `Claudie` gives us flexibility in determining how many nodes to deploy and where to place them. It also improves resilience against cloud outages, helps mitigate resource shortages within a region, and enhances overall high availability.
+
+##### License: MIT
+
+<!--
+
+Contributor's Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it under the license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate license and I have the
+    right under that license to submit that work with modifications,
+    whether created in whole or in part by me, under the same license
+    (unless I am permitted to submit under a different license), as
+    indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are
+    public and that a record of the contribution (including all personal
+    information I submit with it, including my sign-off) is maintained
+    indefinitely and may be redistributed consistent with this project
+    or the license(s) involved.
+
+Signed-off-by: matus.brandys@berops.com
+
+-->


### PR DESCRIPTION
This tutorial  demonstrates how to run Kubernetes workloads across multiple regions in Hetzner using [Claudie](https://docs.claudie.io/) tool.

```
I have read and understood the Contributor's Certificate of Origin available at the end of 
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Matúš Brandýs <matus.brandys@berops.com>
```