### PR TITLE
Add tutorial: Private Network with NAT Gateway and Load Balancer using OpenTofu

### DIFF
--- a/tutorials/private-network-nat-lb-hetzner-opentofu/01.en.md
+++ b/tutorials/private-network-nat-lb-hetzner-opentofu/01.en.md
@@ -2,9 +2,9 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/private-network-nat-lb-hetzner-opentofu"
 slug: "private-network-nat-lb-hetzner-opentofu"
-date: "2026-03-09"
+date: "2026-03-10"
 title: "Private Network with NAT Gateway and Load Balancer on Hetzner Cloud using OpenTofu"
-short_description: "Set up private app servers behind a NAT gateway and public load balancer on Hetzner Cloud using OpenTofu — a ready-to-use template for your own app."
+short_description: "Set up private app servers behind a NAT gateway and public Load Balancer on Hetzner Cloud using OpenTofu — a ready-to-use template for your own app."
 tags: ["OpenTofu", "NAT", "Load Balancer", "Networking", "Ubuntu", "cloud-init"]
 author: "Salem Aljebaly"
 author_link: "https://github.com/salemaljebaly"
@@ -18,49 +18,47 @@ cta: "cloud"
 
 ## Introduction
 
-When running a backend application on Hetzner Cloud, a common pattern is to keep your app servers away from the public internet — no direct public IP, no exposure. Instead, a load balancer sits in front and handles all incoming traffic, while a NAT gateway handles outbound traffic from the private servers (package updates, API calls, etc.).
+When running a backend application on Hetzner Cloud, a common pattern is to keep your app servers away from the public internet — no direct public IP, no exposure. Instead, a Load Balancer sits in front and handles all incoming traffic, while a NAT gateway handles outbound traffic from the private servers (package updates, API calls, etc.).
 
 This tutorial walks through setting up that pattern fully automated using OpenTofu. By the end, you will have:
 
-- A private Hetzner network with two subnets
-- App servers with **no public IP** — only accessible through the load balancer or NAT gateway
+- A Hetzner Private Network with two subnets
+- App servers with **no public IP** — only accessible through the Load Balancer or NAT gateway
 - A NAT gateway that gives private servers outbound internet access
-- A public load balancer with health checks distributing traffic to the app servers
+- A public Hetzner Load Balancer with health checks distributing traffic to the app servers
 - Everything configured via cloud-init — swap the example web server for your own app
 
-This setup works as a **reusable template**. The core networking, NAT, and load balancer config stays the same — you only need to change the `cloud-init.yaml.tpl` file to run your own application.
+This setup works as a **reusable template**. The core networking, NAT, and Load Balancer config stays the same — you only need to change the `cloud-init.yaml.tpl` file to run your own application.
 
 **Prerequisites**
 
 - Hetzner Cloud [API token](https://docs.hetzner.com/cloud/api/getting-started/generating-api-token)
-- An SSH key added to your [Hetzner Cloud project](https://docs.hetzner.com/cloud/servers/getting-started/creating-a-server#adding-an-ssh-key)
+- An [SSH key](https://community.hetzner.com/tutorials/howto-ssh-key#step-1---generating-an-ssh-key) added to your [Hetzner Console project](https://console.hetzner.com/)
 - [OpenTofu](https://opentofu.org/docs/intro/install/) installed locally
 - Basic familiarity with the terminal
 
 **Example values used in this tutorial**
 
-| Resource | Value |
-|----------|-------|
-| Network CIDR | `10.42.0.0/16` |
-| Public subnet | `10.42.10.0/24` |
-| Private subnet | `10.42.20.0/24` |
-| Network gateway | `10.42.0.1` |
-| NAT gateway private IP | `10.42.20.2` |
-| App server 1 | `10.42.20.11` |
-| App server 2 | `10.42.20.12` |
-| Load balancer private IP | `10.42.20.10` |
-
----
+| Resource                 | Value          |
+| ------------------------ | -------------- |
+| Network CIDR             | `10.42.0.0/16` |
+| Public subnet            | `10.42.10.0/24`|
+| Private subnet           | `10.42.20.0/24`|
+| Network gateway          | `10.42.0.1`    |
+| NAT gateway private IP   | `10.42.20.2`   |
+| App server 1             | `10.42.20.11`  |
+| App server 2             | `10.42.20.12`  |
+| Load Balancer private IP | `10.42.20.10`  |
 
 ## Architecture
 
 Before writing any code, it helps to understand how the pieces connect:
 
-```
+```text
 Internet
     │
     ├── HTTP/HTTPS → Load Balancer (public IP)
-    │                     │ private network
+    │                     │ Private Network
     │                     ├── App Server 1 (10.42.20.11) ← no public IP
     │                     └── App Server 2 (10.42.20.12) ← no public IP
     │
@@ -74,28 +72,24 @@ App servers → outbound internet → NAT Gateway → Internet
 
 Key points:
 
-- App servers have **no public IP**. The only way in is through the load balancer (HTTP) or NAT gateway (SSH jump).
+- App servers have **no public IP**. The only way in is through the Load Balancer (HTTP) or NAT gateway (SSH jump).
 - The NAT gateway has both a public IP (for internet egress) and a private IP in the same subnet as the app servers.
 - Hetzner's SDN routes all `0.0.0.0/0` traffic from the private subnet through the NAT gateway using a network-level route.
-
----
 
 ## Step 1 - Project structure
 
 Create the project directory and all required files:
 
 ```bash
-mkdir hetzner-private-lb-nat && cd hetzner-private-lb-nat
-mkdir script
-touch main.tf variables.tf providers.tf network.tf \
-      nat.tf servers.tf firewall.tf load_balancer.tf \
-      outputs.tf terraform.tfvars \
-      script/cloud-init.yaml.tpl script/nat-cloud-init.yaml.tpl
+mkdir -p hetzner-private-lb-nat/script && cd hetzner-private-lb-nat
+touch {main,variables,providers,network,nat,servers,firewall,load_balancer,outputs}.tf \
+      terraform.tfvars \
+      script/{cloud-init,nat-cloud-init}.yaml.tpl
 ```
 
 The final structure should look like this:
 
-```
+```text
 hetzner-private-lb-nat/
 ├── main.tf
 ├── variables.tf
@@ -112,11 +106,11 @@ hetzner-private-lb-nat/
     └── nat-cloud-init.yaml.tpl   (NAT gateway bootstrap)
 ```
 
----
-
 ## Step 2 - Providers and variables
 
 **`providers.tf`**
+
+> This uses version 1.60 of the Terraform Provider for the Hetzner Cloud. You can find the latest version [here](https://registry.terraform.io/providers/hetznercloud/hcloud/latest).
 
 ```hcl
 terraform {
@@ -134,6 +128,10 @@ provider "hcloud" {
 }
 ```
 
+-------
+
+<br>
+
 **`main.tf`**
 
 ```hcl
@@ -146,7 +144,13 @@ locals {
 }
 ```
 
+-------
+
+<br>
+
 **`variables.tf`** — the key variables:
+
+> You don't need to edit any values in this file. We will add the values for these variables in `terraform.tfvars` below.
 
 ```hcl
 variable "hcloud_token" {
@@ -159,6 +163,12 @@ variable "project_name" {
   description = "Name prefix for all resources"
   type        = string
   default     = "hetzner-private-lb-nat"
+}
+
+variable "owner" {
+  description = "Owner of the resources"
+  type        = string
+  default     = "holu"
 }
 
 variable "location" {
@@ -182,16 +192,55 @@ variable "ssh_allowed_cidrs" {
   default     = []
 }
 
-variable "network_cidr"         { type = string; default = "10.42.0.0/16" }
-variable "network_gateway_ip"   { type = string; default = "10.42.0.1" }
-variable "public_subnet_cidr"   { type = string; default = "10.42.10.0/24" }
-variable "private_subnet_cidr"  { type = string; default = "10.42.20.0/24" }
-variable "nat_gateway_private_ip" { type = string; default = "10.42.20.2" }
-variable "lb_private_ip"        { type = string; default = "10.42.20.10" }
-variable "server_type"          { type = string; default = "cx23" }
-variable "server_image"         { type = string; default = "ubuntu-24.04" }
-variable "nat_gateway_server_type" { type = string; default = "cx23" }
-variable "nat_gateway_image"    { type = string; default = "ubuntu-24.04" }
+variable "network_cidr" {
+  type = string
+  default = "10.42.0.0/16"
+}
+
+variable "network_gateway_ip" {
+  type = string
+  default = "10.42.0.1"
+}
+
+variable "public_subnet_cidr" {
+  type = string
+  default = "10.42.10.0/24"
+}
+
+variable "private_subnet_cidr" {
+  type = string
+  default = "10.42.20.0/24"
+}
+
+variable "nat_gateway_private_ip" {
+  type = string
+  default = "10.42.20.2"
+}
+
+variable "lb_private_ip" {
+  type = string
+  default = "10.42.20.10"
+}
+
+variable "server_type" {
+  type = string
+  default = "cx23"
+}
+
+variable "server_image" {
+  type = string
+  default = "ubuntu-24.04"
+}
+
+variable "nat_gateway_server_type" {
+  type = string
+  default = "cx23"
+}
+
+variable "nat_gateway_image" {
+  type = string
+  default = "ubuntu-24.04"
+}
 
 variable "app_servers" {
   description = "Map of app servers with their private IPs"
@@ -206,15 +255,35 @@ variable "app_servers" {
 }
 ```
 
+-------
+
+<br>
+
+
 **`terraform.tfvars`**
+
+> Replace the example values below with:
+> * [Your own API token](https://docs.hetzner.com/cloud/api/getting-started/generating-api-token)
+> * Your own name which will be added as a label to each resource in the format `owner:my-name`
+> * Your SSH key that is added in Hetzner Console
+> * Your IP (`curl -4 https://ip.hetzner.com`)
 
 ```hcl
 hcloud_token      = "your-api-token"
+owner             = "my-name"
 ssh_key_name      = "your-ssh-key-name"
 ssh_allowed_cidrs = ["203.0.113.10/32"]  # replace with your IP
 ```
 
----
+The default value of `app_servers` includes `app1` and `app2`, meaning that two app servers without public IPs will be created. If you want a different number of app servers, add them in `terraform.tfvars` like this:
+
+```hcl
+app_servers       = {
+  app1 = { private_ip = "10.42.20.11" }
+  app2 = { private_ip = "10.42.20.12" }
+  app3 = { private_ip = "10.42.20.13" }
+}
+```
 
 ## Step 3 - Network and subnets
 
@@ -243,8 +312,6 @@ resource "hcloud_network_subnet" "private" {
 ```
 
 Both subnets live inside the same VPC (`10.42.0.0/16`). Servers in both subnets can communicate with each other — the separation is about access control (firewall rules) and internet access (public IP or not).
-
----
 
 ## Step 4 - NAT gateway
 
@@ -310,6 +377,10 @@ resource "hcloud_network_route" "private_default_egress" {
 
 The `hcloud_network_route` resource is what makes app servers reach the internet without their own public IP. Hetzner's SDN intercepts all outbound traffic and sends it to the NAT gateway's private IP.
 
+-------
+
+<br>
+
 **`script/nat-cloud-init.yaml.tpl`**
 
 This cloud-init config runs on first boot to configure the NAT gateway:
@@ -373,19 +444,17 @@ Three things worth noting here:
 2. `MASQUERADE` — rewrites the source IP of outgoing packets so the internet sees the NAT gateway's public IP, not the private server's IP.
 3. The systemd service re-applies the iptables rules on every reboot, so the NAT keeps working after a server restart.
 
----
-
 ## Step 5 - App servers
 
 **`firewall.tf`**
 
-App servers should not be reachable from the internet directly. The firewall allows HTTP only from the load balancer's private IP, and SSH only from the NAT gateway.
+App servers should not be reachable from the internet directly. The firewall allows HTTP only from the Load Balancer's private IP, and SSH only from the NAT gateway.
 
 ```hcl
 resource "hcloud_firewall" "app" {
   name = "${var.project_name}-app-fw"
 
-  # Allow HTTP from load balancer only
+  # Allow HTTP from Load Balancer only
   rule {
     direction  = "in"
     protocol   = "tcp"
@@ -404,6 +473,10 @@ resource "hcloud_firewall" "app" {
   labels = merge(local.common_labels, { role = "app" })
 }
 ```
+
+-------
+
+<br>
 
 **`servers.tf`**
 
@@ -442,6 +515,10 @@ resource "hcloud_server" "app" {
   depends_on = [hcloud_network_subnet.private]
 }
 ```
+
+-------
+
+<br>
 
 **`script/cloud-init.yaml.tpl`**
 
@@ -483,27 +560,33 @@ write_files:
       [Install]
       WantedBy=multi-user.target
 
+  - path: /etc/systemd/resolved.conf
+    content: |
+      [Resolve]
+      DNS=185.12.64.2 185.12.64.1
+      FallbackDNS=8.8.8.8
+    append: true
+
 runcmd:
-  # Set default route through the Hetzner private network gateway
-  - IFACE=$(ip route | awk '/^default/{print $5; exit}') && ip route replace default via ${network_gateway_ip} dev "$IFACE" || true
+  # Set default route through the Hetzner Private Network gateway
+  - IFACE=$(ip route | awk '/10\.42\.0\.0\/16/ {print $5; exit}') && ip route add default via ${network_gateway_ip} dev "$IFACE" || true
   - systemctl enable simple-web.service
   - systemctl restart simple-web.service
+  - systemctl restart systemd-resolved
 ```
 
 To deploy your own app, replace the `write_files` and `runcmd` sections. For example, to run a Node.js app:
 
 ```yaml
 runcmd:
-  - IFACE=$(ip route | awk '/^default/{print $5; exit}') && ip route replace default via ${network_gateway_ip} dev "$IFACE" || true
+  - IFACE=$(ip route | awk '/^default/{print $5; exit}') && ip route add default via ${network_gateway_ip} dev "$IFACE" || true
   - apt-get update -q && apt-get install -y nodejs npm
   - cd /opt/myapp && npm install && npm start
 ```
 
-The important line to keep in all cases is the `ip route replace` command — it tells the server to use the Hetzner private network gateway as its default route, which then forwards internet-bound traffic to the NAT gateway.
+The important line to keep in all cases is the `ip route add` command — it tells the server to use the Hetzner Private Network gateway as its default route, which then forwards internet-bound traffic to the NAT gateway.
 
----
-
-## Step 6 - Load balancer
+## Step 6 - Load Balancer
 
 **`load_balancer.tf`**
 
@@ -527,7 +610,7 @@ resource "hcloud_load_balancer_target" "app" {
   type             = "server"
   load_balancer_id = hcloud_load_balancer.public.id
   server_id        = each.value.id
-  use_private_ip   = true  # communicate with servers via private network
+  use_private_ip   = true  # communicate with servers via Private Network
 }
 
 resource "hcloud_load_balancer_service" "http" {
@@ -551,11 +634,9 @@ resource "hcloud_load_balancer_service" "http" {
 }
 ```
 
-`use_private_ip = true` is required here because the app servers have no public IP — the load balancer must reach them through the private network.
+`use_private_ip = true` is required here because the app servers have no public IP — the Load Balancer must reach them through the Private Network.
 
-The health check hits `/health` on each server. If a server returns anything other than `200`, the load balancer stops sending it traffic until it recovers.
-
----
+The health check hits `/health` on each server. If a server returns anything other than `200`, the Load Balancer stops sending it traffic until it recovers.
 
 ## Step 7 - Outputs
 
@@ -563,7 +644,7 @@ The health check hits `/health` on each server. If a server returns anything oth
 
 ```hcl
 output "load_balancer_public_ipv4" {
-  description = "Public IPv4 of the load balancer — use this to reach your app"
+  description = "Public IPv4 of the Load Balancer — use this to reach your app"
   value       = hcloud_load_balancer.public.ipv4
 }
 
@@ -580,13 +661,12 @@ output "app_server_private_ips" {
 }
 ```
 
----
-
 ## Step 8 - Deploy
 
 Initialize and apply:
 
 ```bash
+cd $HOME/hetzner-private-lb-nat
 tofu init
 tofu fmt -recursive
 tofu validate
@@ -596,7 +676,7 @@ tofu apply
 
 After `tofu apply` completes, you should see output similar to:
 
-```
+```text
 Outputs:
 
 app_server_private_ips = {
@@ -607,18 +687,18 @@ load_balancer_public_ipv4 = "203.0.113.10"
 nat_gateway_public_ipv4   = "203.0.113.20"
 ```
 
----
-
 ## Step 9 - Test
 
-**Test the load balancer:**
+Before you test the Load Balancer, wait a few minutes until everything is setup. In Hetzner Console, you can check if the targets are healthy.
+
+**Test the Load Balancer:**
 
 ```bash
 LB_IP=$(tofu output -raw load_balancer_public_ipv4)
 curl -i "http://$LB_IP/"
 ```
 
-You should get an HTTP 200 response. Run it a few times — the load balancer distributes requests between the two app servers, so you will see responses from `app1` and `app2` alternating.
+You should get an HTTP 200 response. Run it a few times — the Load Balancer distributes requests between the two app servers, so you will see responses from `app1` and `app2` alternating.
 
 **Test the health endpoint:**
 
@@ -636,7 +716,7 @@ NAT_IP=$(tofu output -raw nat_gateway_public_ipv4)
 ssh -J root@$NAT_IP root@10.42.20.11
 
 # From inside the private server, test outbound internet
-curl -s https://ifconfig.me
+curl -4 https://ip.hetzner.com
 # This should return the NAT gateway's public IP, not the private server's IP
 ```
 
@@ -644,7 +724,7 @@ This confirms the NAT gateway is working: the private server has no public IP of
 
 **SSH config for convenience:**
 
-```
+```text
 Host nat
   HostName 203.0.113.20
   User root
@@ -660,11 +740,9 @@ Host app2
   ProxyJump nat
 ```
 
----
-
 ## Step 10 - Use your own application
 
-The cloud-init template in `script/cloud-init.yaml.tpl` is the only file you need to change to deploy your own application. The network, NAT, load balancer, and firewall configuration stays exactly the same.
+The cloud-init template in `script/cloud-init.yaml.tpl` is the only file you need to change to deploy your own application. The network, NAT, Load Balancer, and firewall configuration stays exactly the same.
 
 The one requirement is that your app:
 
@@ -675,7 +753,7 @@ For example, to replace the Python web server with Nginx:
 
 ```yaml
 runcmd:
-  - IFACE=$(ip route | awk '/^default/{print $5; exit}') && ip route replace default via ${network_gateway_ip} dev "$IFACE" || true
+  - IFACE=$(ip route | awk '/^default/{print $5; exit}') && ip route add default via ${network_gateway_ip} dev "$IFACE" || true
   - apt-get update -q && apt-get install -y nginx
   - echo "ok" > /var/www/html/health
   - systemctl enable nginx
@@ -686,33 +764,31 @@ Or to run a Docker container:
 
 ```yaml
 runcmd:
-  - IFACE=$(ip route | awk '/^default/{print $5; exit}') && ip route replace default via ${network_gateway_ip} dev "$IFACE" || true
+  - IFACE=$(ip route | awk '/^default/{print $5; exit}') && ip route add default via ${network_gateway_ip} dev "$IFACE" || true
   - apt-get update -q && apt-get install -y docker.io
   - docker run -d -p 80:8080 your-image:latest
 ```
 
-The `ip route replace` line must always be there — it is what connects the private server to the internet through the NAT gateway.
-
----
+The `ip route add` line must always be there — it is what connects the private server to the internet through the NAT gateway.
 
 ## Cleanup
 
 ```bash
+cd $HOME/hetzner-private-lb-nat
+tofu init
 tofu destroy
 ```
-
----
 
 ## Conclusion
 
 You now have a production-style private network setup on Hetzner Cloud:
 
 - App servers are not directly reachable from the internet
-- Inbound traffic goes through the load balancer with health checks
+- Inbound traffic goes through the Load Balancer with health checks
 - Outbound traffic goes through the NAT gateway
 - SSH access is through the NAT gateway acting as a jump host
 
-The whole setup is defined in code, reproducible, and takes about two minutes to deploy. To use it for a real application, edit `cloud-init.yaml.tpl`, run `tofu apply`, and your app is live behind the load balancer.
+The whole setup is defined in code, reproducible, and takes about two minutes to deploy. To use it for a real application, edit `cloud-init.yaml.tpl`, run `tofu apply`, and your app is live behind the Load Balancer.
 
 Full source code: [hetzner-private-lb-nat-tofu](https://github.com/salemaljebaly/infra-labs/tree/main/hetzner-private-lb-nat-tofu)
 


### PR DESCRIPTION
## Description

This tutorial explains how to set up a production-style private network on Hetzner Cloud using OpenTofu — fully automated, no manual steps in the console.

It covers:
- A private Hetzner network with two subnets
- App servers with no public IP (only reachable through the load balancer or NAT jump host)
- A NAT gateway for outbound internet access from private servers
- A public load balancer with health checks
- cloud-init bootstrapping for the NAT gateway (iptables, ip_forward, systemd service)

The setup is designed as a **ready-to-use template** — the networking, NAT, and load balancer config stays the same, and the reader only needs to update `cloud-init.yaml.tpl` to deploy their own application.

## Why this is different from existing NAT tutorials

The existing tutorial ([how-to-set-up-nat-for-cloud-networks](https://community.hetzner.com/tutorials/how-to-set-up-nat-for-cloud-networks)) covers manual setup via the Hetzner Console across multiple Linux distributions. This tutorial takes a different angle — everything is defined as code using OpenTofu, including the load balancer and firewall, making it repeatable and version-controlled.

## Checklist

- [x] Written in English
- [x] Original content, not published elsewhere
- [x] All tools used are free and open source (OpenTofu, Ubuntu, iptables)
- [x] Tested and validated with `tofu validate` and `tofu fmt`
- [x] Previewed in the Hetzner Markdown test suite
- [x] License block included at the bottom
- [x] No sensitive data in the tutorial

I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Salem Aljebaly <salemaljebaly@gmail.com>