### PR TITLE
Add tutorial lb two servers pulumi hetzner

### DIFF
--- a/tutorials/pulumi-load-balancer-two-servers-hetzner/01.en.md
+++ b/tutorials/pulumi-load-balancer-two-servers-hetzner/01.en.md
@@ -105,8 +105,6 @@ pulumi config set sshPublicKeyPath ~/.ssh/id_rsa.pub
 pulumi config set --secret hcloudToken "$HCLOUD_TOKEN"
 ```
 
-> If you already have an SSH key added to your Hetzner project, you can use it directly instead of uploading a new one: `pulumi config set sshKeyName your-key-name`
-
 Whitelist your IP for SSH access. The command below fetches your current public IP automatically:
 
 ```bash


### PR DESCRIPTION
## Description

This tutorial explains how to provision a public Load Balancer with two app servers on a private network using Pulumi and TypeScript on Hetzner Cloud.

It covers:
  - Setting up a private network and subnet
  - Provisioning two app servers with firewall rules — HTTP accepted only from the Load Balancer's private IP, SSH only from allowed CIDRs
  - Attaching a public Load Balancer to the private network with health checks
  - Verifying round-robin traffic distribution between both servers

This tutorial is designed as the **next step** after [Getting Started with Pulumi and TypeScript on Hetzner Cloud](https://community.hetzner.com/tutorials/getting-started-pulumi-hetzner-typescript).
It follows the same project structure and config approach, and introduces networking, firewall segmentation, and load balancing as a natural progression.

  > **Note:** The prerequisite tutorial is currently under review in [#1403](https://github.com/hetzneronline/community-content/pull/1403).
  > The link in this tutorial points to the URL it will have once published.

  The cloud-init setup is intentionally kept as a replaceable template — readers
  can swap it for their own application while keeping the Load Balancer and
  network config unchanged.

## Checklist
  - [x] Written in English
  - [x] Original content, not published elsewhere
  - [x] All tools used are free and open source (Pulumi CLI, Node.js, TypeScript)
  - [x] Tested and validated on a real Hetzner Cloud project
  - [x] Previewed in the Hetzner Markdown test suite
  - [x] License block included at the bottom
  - [x] No sensitive data in the tutorial

I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Salem Aljebaly <salemaljebaly@gmail.com>