### PR TITLE
Add tutorial: Deploying Single-Node OKD on Hetzner Dedicated Servers

### DIFF
--- a/tutorials/okd-on-hetzner-dedicated/01.en.md
+++ b/tutorials/okd-on-hetzner-dedicated/01.en.md
@@ -1,0 +1,196 @@
+---
+SPDX-License-Identifier: MIT
+path: "/tutorials/okd-on-hetzner-dedicated"
+slug: "okd-on-hetzner-dedicated"
+date: "2026-03-20"
+title: "Deploying Single-Node OKD on Hetzner Dedicated Servers"
+short_description: "Deploy Single-Node OKD on Hetzner Dedicated Root Servers using Ansible, the Hetzner Robot API, and Rescue System automation."
+tags: ["Kubernetes", "OKD", "OpenShift", "Bare Metal", "Ansible", "Hetzner Dedicated"]
+author: "Tosin Akinsoho"
+author_link: "https://github.com/tosin2013"
+author_img: "https://github.com/tosin2013.png"
+author_description: "Platform engineer focused on Kubernetes, bare-metal automation, and reproducible infrastructure."
+language: "en"
+available_languages: ["en"]
+header_img: "header-4"
+cta: "dedicated"
+---
+
+## Introduction
+
+Running Kubernetes on bare metal can be challenging, and it is even trickier when the server is hosted remotely and you cannot physically mount installation media.
+
+In this tutorial, you will deploy a Single-Node OKD (SNO) cluster on a Hetzner Dedicated Root Server using the `okd-metal-installer` project and Ansible automation. Instead of manual ISO mounting, the deployment uses the Hetzner Robot API and the Hetzner Rescue System to install Fedora CoreOS and apply the generated Ignition configuration.
+
+The focus is SNO for depth and simplicity. The same installer also supports compact and HA topologies through inventory-driven role assignment.
+
+**Prerequisites**
+
+* A Hetzner Dedicated Root Server with at least 4 vCPUs and 32 GB RAM
+* Hetzner Robot webservice credentials
+* A Linux control host with Python 3.12+ and `ansible-core` 2.16+
+* A domain name you control
+* The `oc` CLI installed on the control host for cluster verification
+
+## Step 1 - Prepare the automation environment
+
+Clone the installer project and install the Ansible collections.
+
+```bash
+git clone https://github.com/tosin2013/okd-metal-installer.git
+cd okd-metal-installer
+ansible-galaxy collection install -r requirements.yml
+```
+
+> If you plan to use this in production, pin to a tested tag or commit instead of always using the default branch.
+
+## Step 2 - Create an inventory for SNO
+
+Copy the SNO inventory and host variable examples.
+
+```bash
+cp inventory/examples/sno.ini inventory/mycluster.ini
+mkdir -p host_vars
+cp inventory/examples/host_vars/sno-node.yml host_vars/sno-node.yml
+```
+
+Now edit `inventory/mycluster.ini`:
+
+```ini
+[masters]
+sno-node ansible_host=<203.0.113.1>
+
+[workers]
+# Empty for Single-Node OKD
+```
+
+## Step 3 - Configure Hetzner host variables
+
+Edit `host_vars/sno-node.yml` and define your server-specific settings.
+
+```yaml
+ansible_host: <203.0.113.1>
+
+# Installation target disk
+# Verify using lsblk in rescue mode before running the playbook
+dest_device: /dev/nvme0n1
+
+# Use Hetzner Robot API + Rescue System flow
+boot_method: hetzner
+
+# Recommended: store credentials with Ansible Vault
+hetzner_robot_user: "<robot-username>"
+hetzner_robot_password: "<robot-password>"
+
+# Optional install mode (if your workflow requires it)
+# hetzner_install_method: rescue_install
+
+# NMState networking
+network_interfaces:
+  - name: eno1
+    type: ethernet
+    mac_address: "<aa:bb:cc:dd:ee:ff>"
+    ip: <203.0.113.1>
+    prefix: 26
+    gateway: <192.0.2.254>
+    dns:
+      - <192.0.2.53>
+      - <198.51.100.53>
+```
+
+To verify interface names, MAC addresses, and disk names, boot the server into Hetzner Rescue mode once and run:
+
+```bash
+ip a
+lsblk
+```
+
+## Step 4 - Run the deployment
+
+Start the installation from your control host:
+
+```bash
+ansible-playbook -i inventory/mycluster.ini playbooks/site.yml
+```
+
+When `boot_method: hetzner` is used, the automation performs the full server lifecycle:
+
+1. Generates the required Ignition artifacts
+2. Calls the Hetzner Robot API to enable Rescue mode
+3. Triggers a hardware reset
+4. Connects to the Rescue environment via SSH
+5. Installs CoreOS and applies the generated bootstrap configuration
+6. Reboots into the installed system
+
+## Step 5 - Monitor cluster bring-up
+
+After reboot, the node starts the OKD bootstrap sequence.
+
+Use the generated kubeconfig from your control host:
+
+```bash
+export KUBECONFIG=<path-to-ignition-output>/auth/kubeconfig
+oc get clusterversion
+oc get nodes -w
+```
+
+If you need to troubleshoot early bootstrap services:
+
+```bash
+ssh core@<203.0.113.1>
+sudo journalctl -b -f -u release-image.service -u bootkube.service
+```
+
+## Step 6 - Understand topology options beyond SNO
+
+This tutorial uses SNO because it is the fastest way to get a working cluster on a single dedicated server.
+
+The same installer also supports:
+
+* Compact clusters (3 schedulable control-plane nodes)
+* Full HA clusters (3+ control-plane nodes plus worker nodes)
+
+Those modes are selected by inventory host counts and role groups (`masters` and `workers`), so your process can evolve from SNO to multi-node without changing tools.
+
+## Conclusion
+
+You deployed a Single-Node OKD cluster on a Hetzner Dedicated Root Server using a fully automated flow built on Ansible, the Hetzner Robot API, and the Rescue System.
+
+This approach removes most of the manual console and media-mounting work and makes deployments reproducible across environments.
+
+**Next steps:**
+
+* Store all sensitive variables in Ansible Vault
+* Add DNS automation for API and application endpoints
+* Create a compact or HA inventory as your workload grows
+
+##### License: MIT
+
+<!--
+
+Contributor's Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it under the license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate license and I have the
+    right under that license to submit that work with modifications,
+    whether created in whole or in part by me, under the same license
+    (unless I am permitted to submit under a different license), as
+    indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are
+    public and that a record of the contribution (including all personal
+    information I submit with it, including my sign-off) is maintained
+    indefinitely and may be redistributed consistent with this project
+    or the license(s) involved.
+
+Signed-off-by: Tosin Akinsoho <tosin.akinosho@gmail.com>
+
+-->


### PR DESCRIPTION
## Summary
- add a new English tutorial at tutorials/okd-on-hetzner-dedicated/01.en.md
- cover a full Single-Node OKD deployment flow on Hetzner Dedicated Root Servers
- document Hetzner Robot API + Rescue System automation and monitoring steps
- include notes that the installer also supports compact and HA topologies

## Compliance
I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Tosin Akinsoho <tosin.akinosho@gmail.com>