### PR TITLE
Update "Kubernetes with Claudie" tutorial

### DIFF
--- a/tutorials/kubernetes-with-claudie/01.en.md
+++ b/tutorials/kubernetes-with-claudie/01.en.md
@@ -2,10 +2,10 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/kubernetes-with-claudie"
 slug: "kubernetes-with-claudie"
-date: "2024-10-30"
+date: "2026-03-23"
 title: "Kubernetes on Hetzner with Claudie!"
-short_description: "Learn how to deploy a Hetzner-based Kubernetes cluster using Claudie, a hybrid and multi-cloud management Kubernetes management tool."
-tags: ["Kubernetes", "Multicloud", "Hybridcloud", "Lang:YAML", "Lang:Go"]
+short_description: "Deploy a Kubernetes cluster across multiple Hetzner regions for high availability using Claudie, a hybrid and multi-cloud Kubernetes management tool."
+tags: ["Kubernetes", "Multicloud", "Hybridcloud", "HA", "Lang:YAML", "Lang:Go"]
 author: "Cloudziu"
 author_link: "https://github.com/cloudziu"
 author_img: "https://avatars.githubusercontent.com/u/8597467"
@@ -18,8 +18,10 @@ cta: "cloud"
 
 ## Introduction
 
-This tutorial explains the process of setting up a Kubernetes cluster on Hetzner Cloud using a tool called "[Claudie](https://docs.claudie.io/)". Claudie is a platform for managing multi-cloud and hybrid-cloud Kubernetes clusters with support for 
-nodepools across different cloud-providers and on-premise data centers, including Hetzner Cloud. 
+This tutorial explains the process of setting up a Kubernetes cluster across multiple regions on Hetzner Cloud using a tool called [Claudie](https://docs.claudie.io/). Claudie is a platform for managing multi-cloud and hybrid-cloud Kubernetes clusters with support for 
+nodepools across different cloud providers and on-premise data centers, including Hetzner Cloud. 
+
+This type of setup is resilient to regional cloud disruptions and also helps address resource shortages within a single or even multiple regions.
 
 **Prerequisites**
 * [Hetzner Cloud](https://console.hetzner.cloud) account
@@ -54,7 +56,7 @@ Claudie needs to be installed on an existing Kubernetes cluster, referred to as 
    holu@<your_host>:~# export KUBECONFIG=~/.kube/claudie
    holu@<your_host>:~# kubectl get nodes
    NAME                         STATUS   ROLES           AGE    VERSION
-   claudie-mgmt-control-plane   Ready    control-plane   3m8s   v1.27.3
+   claudie-mgmt-control-plane   Ready    control-plane   3m8s   v1.33.1
    ```
 
 2. Install cert-manager as it is a requirement for the Claudie Management cluster.
@@ -66,29 +68,28 @@ Claudie needs to be installed on an existing Kubernetes cluster, referred to as 
 3. Deploy Claudie
    
    ```shellsession
-   holu@<your_host>:~# kubectl apply -f https://github.com/berops/claudie/releases/latest/download/claudie.yaml
+   holu@<your_host>:~# kubectl apply -f https://github.com/berops/claudie/releases/download/v0.10.0/claudie.yaml
    ```
 
 4. Wait for all Pods to get into **Ready** state
-   
    ```shellsession
-    holu@<your_host>:~# kubectl -n claudie get pods
-    NAME                                READY   STATUS      RESTARTS   AGE
-    ansibler-86d69dc6c7-j2v8w           1/1     Running     0          90s
-    builder-69f8c5f8ff-lrzdp            1/1     Running     0          90s
-    claudie-operator-576595dcfc-nvchm   1/1     Running     0          90s
-    create-table-job-bthcm              0/1     Completed   0          90s
-    dynamodb-6d65df988-dpsbd            1/1     Running     0          90s
-    kube-eleven-5f649b7-xkjbk           1/1     Running     0          90s
-    kuber-6fdc7b5578-bldl6              1/1     Running     0          90s
-    make-bucket-job-zv497               0/1     Completed   0          90s
-    manager-d49f456fd-sjd4k             1/1     Running     0          90s
-    minio-0                             1/1     Running     0          90s
-    minio-1                             1/1     Running     0          90s
-    minio-2                             1/1     Running     0          90s
-    minio-3                             1/1     Running     0          90s
-    mongodb-6ccb5f5dff-nv2pr            1/1     Running     0          90s
-    terraformer-7c7bfffc4b-2wnqf        1/1     Running     0          90s
+   holu@<your_host>:~# kubectl get pods -n claudie
+   NAME                                READY   STATUS    RESTARTS     AGE
+   ansibler-594c67f799-p6rtp           1/1     Running   0            60s
+   claudie-operator-56f4b6767f-smr2x   1/1     Running   0            60s
+   kube-eleven-547645865f-4tls2        1/1     Running   0            60s
+   kuber-7764ffb5df-d826z              1/1     Running   0            60s
+   manager-59fc97fd48-n8cvj            1/1     Running   0            60s
+   minio-0                             1/1     Running   0            60s
+   minio-1                             1/1     Running   0            60s
+   minio-2                             1/1     Running   0            60s
+   minio-3                             1/1     Running   0            60s
+   mongodb-6d59c69c99-gjrv2            1/1     Running   0            60s
+   nack-5bbb756857-rhxx2               1/1     Running   0            60s
+   nats-0                              2/2     Running   0            60s
+   nats-1                              2/2     Running   0            60s
+   nats-2                              2/2     Running   0            60s
+   terraformer-6c88c87f8c-b9gtn        1/1     Running   0            60s
    ```
 
 ## Step 2 - Create Hetzner API Key
@@ -98,12 +99,12 @@ Claudie needs to be installed on an existing Kubernetes cluster, referred to as 
 2. Create a Kubernetes Secret that will contain the Hetzner API Token.
    
    ```shellsession
-   holu@<your_host>:~# kubectl create secret generic hetzner-secret --from-literal=credentials='YOUR_API_TOKEN'
+   holu@<your_host>:~# kubectl create secret generic hetzner-secret --from-literal=credentials='YOUR_API_TOKEN' -n claudie
    ```
 
 ## Step 3 - Create a Claudie manifest file
 
-Now, let's create a Claudie manifest file that describes the Kubernetes cluster you want to create on Hetzner. You can use the example manifest below as a starting point.
+Now, let's create a Claudie manifest file that describes the Kubernetes cluster you want to create across multiple Hetzner regions. You can use the example manifest below as a starting point.
 
 * Create the file:
   
@@ -117,147 +118,136 @@ Now, let's create a Claudie manifest file that describes the Kubernetes cluster 
   apiVersion: claudie.io/v1beta1
   kind: InputManifest
   metadata:
-    name: kubernetes-hetzner
+    name: multi-cloud-k8s
   spec:
     providers:
       - name: hetzner-secret
         providerType: hetzner
         secretRef:
           name: hetzner-secret
-          namespace: default
+          namespace: claudie
     nodePools:
       dynamic:
-        - name: hetzner-ctrl
-          providerSpec:
-            name: hetzner-secret
-            region: fsn1
-            zone: fsn1-dc14
-          count: 1
-          serverType: cpx21
-          image: ubuntu-22.04
-
-        - name: hetzner-cmpt
+        - name: ctrl-fsn
           providerSpec:
             name: hetzner-secret
             region: fsn1
             zone: fsn1-dc14
           count: 3
-          serverType: cpx21
-          image: ubuntu-22.04
+          serverType: cx23
+          image: ubuntu-24.04
+
+        - name: cmpt-fsn
+          providerSpec:
+            name: hetzner-secret
+            region: fsn1
+            zone: fsn1-dc14
+          count: 2
+          serverType: cx23
+          image: ubuntu-24.04
+          storageDiskSize: 50
+
+        - name: cmpt-nbg
+          providerSpec:
+            name: hetzner-secret
+            region: nbg1
+            zone: nbg1-dc3
+          autoscaler:
+            min: 1
+            max: 2
+          serverType: cx23
+          image: ubuntu-24.04
           storageDiskSize: 50
     kubernetes:
       clusters:
         - name: hetzner-cluster
-          version: v1.30.0
+          version: v1.34.0
           network: 192.168.2.0/24
           pools:
             control:
-              - hetzner-ctrl
+              - ctrl-fsn
             compute:
-              - hetzner-cmpt
+              - cmpt-fsn
+              - cmpt-nbg
   ```
 
-The above manifest file is used for defining a Kubernetes cluster. Let's break down some of the key fields in it:
+This `InputManifest` will provision:
+- 3 Kubernetes control plane nodes in the Falkenstein region
+- 2 Kubernetes worker nodes in the Falkenstein region
+- 1 to 2 auto-scaled Kubernetes worker nodes in the Nuremberg region, depending on workload demand
+
+Let's break down some of the key fields:
 
 * `spec.providers` » Contains configurations for supported cloud providers. It is referencing access credentials (previously created in a *Secret* object) and terraform template files for Hetzner (see [more](https://github.com/berops/claudie-config))
 * `spec.nodePools.dynamic` » Defines dynamic nodepools. Those are cloud provider VMs that Claudie is expected to create.
 * `spec.kubernetes.clusters` » Describes the Kubernetes cluster that will be created.
 
-Provided example is relatively simple and deploys a Kubernetes cluster with one control node and three worker nodes. However, Claudie can be used for more advanced cluster scenarios, including deploying clusters across different cloud providers 
-and on-premise in multi-cloud/hybrid architecture. Additionally, it's worth noting that the nodes will be connected using a WireGuard network, eliminating the need for a virtual network resource. For more in-depth understanding of Claudie `inputmanifest` definition, visit the [documentation site](https://docs.claudie.io).
+Communication between regional nodes runs over the overlay network `192.168.2.0/24`, which we defined in the `InputManifest`. All inter-node traffic within this network is encrypted using WireGuard, eliminating the need for a virtual network resource.
+
+This infrastructure can be modified at any time. You can add a new region, scale nodes up or down within existing regions, or even attach physical machines to the cluster. For more in-depth understanding of the Claudie `InputManifest` definition, visit the [documentation site](https://docs.claudie.io).
 
 ## Step 4 - Deploy the cluster
 
-------
-
-**Important:** Please note that applying the YAML file from above will automatically create:
-* 4 Hetzner Cloud servers of type CPX21 that **will be charged**
-* 3 Hetzner Cloud Volumes with a storage capacity of 50 GB each that **will be charged**
-* 1 Hetzner Cloud Firewall (free)
-* It will also add an SSH key to the project
-
-------
-
-Save the example above to an `inputmanifest.yml` file, and apply it to the *kind* cluster. If you are not prepared to pay for 4 servers of type CPX21 and 3 Volumes, you can adapt the YAML file above as needed before you run the following command:
+Apply the `InputManifest` to the Management Cluster:
 
 ```shellsession
-holu@<your_host>:~# kubectl apply -f inputmanifest.yml
-inputmanifest.claudie.io/kubernetes-hetzner created
+holu@<your_host>:~# kubectl apply -f inputmanifest.yml -n claudie
+inputmanifest.claudie.io/multi-cloud-k8s created
 ```
 
-Now you can follow the cluster deployment status. When the cluster is deployed, the status will state **DONE**.
+Verify that the infrastructure is being deployed:
 
 ```shellsession
-holu@<your_host>:~# kubectl get inputmanifest
-NAME                 STATUS
-kubernetes-hetzner   IN_PROGRESS
-
-holu@<your_host>:~# kubectl get inputmanifest
-NAME                 STATUS
-kubernetes-hetzner   DONE
-```
-## Step 5 - Access the cluster
-
-The *kubeconfig* will be saved to a Secret object in the `claudie` namespace. 
-
-```shellsession
-holu@<your_host>:~# kubectl get secrets -A
-NAMESPACE      NAME                                      TYPE                            DATA   AGE
-cert-manager   cert-manager-webhook-ca              Opaque                          3      36m
-claudie        claudie-webhook-certificate          kubernetes.io/tls               3      32m
-claudie        dynamo-secret-6tffbf8bc7             Opaque                          2      32m
-claudie        hetzner-cluster-b87z4jq-kubeconfig   Opaque                          1      57s
-claudie        hetzner-cluster-b87z4jq-metadata     Opaque                          1      57s
-claudie        minio-secret-6tffbf8bc7              Opaque                          2      32m
-claudie        mongo-secret-k479ht772f              Opaque                          3      32m
-default        hetzner-secret                       Opaque                          1      29m
-kube-system    bootstrap-token-abcdef               bootstrap.kubernetes.io/token   6      37m
+holu@<your_host>:~# kubectl get inputmanifest -n claudie
+NAME              STATUS
+multi-cloud-k8s   IN_PROGRESS
 ```
 
-> Run the following command to obtain the kubeconfig of the built cluster
+Wait until you see `WATCHING_FOR_CHANGES` in the STATUS column. You can follow the deployment progress by checking the operator logs:
 
 ```shellsession
-holu@<your_host>:~# kubectl get secrets -n claudie -l claudie.io/cluster=hetzner-cluster,claudie.io/output=kubeconfig -ojsonpath='{.items[0].data.kubeconfig}' | base64 -d
-apiVersion: v1
-clusters:
-- cluster:
-    certificate-authority-data: <your_data>
-    server: https://<203.0.113.1>:6443
-  name: hetzner-cluster
-contexts:
-- context:
-    cluster: hetzner-cluster
-    user: kubernetes-admin
-  name: kubernetes-admin@hetzner-cluster
-current-context: kubernetes-admin@hetzner-cluster
-kind: Config
-preferences: {}
-users:
-- name: kubernetes-admin
-  user:
-    client-certificate-data: <your_data>
-    client-key-data: <your_data>
+holu@<your_host>:~# kubectl logs -f -l app.kubernetes.io/name=claudie-operator -n claudie
 ```
 
-Confirm that the cluster is up and running:
-
-> By running the commands below you can store the kubeconfig of the built cluster to your filesystem and check if the cluster is healthy.
+Once deployment is complete:
 
 ```shellsession
-holu@<your_host>:~# kubectl get secrets -n claudie -l claudie.io/cluster=hetzner-cluster,claudie.io/output=kubeconfig -ojsonpath='{.items[0].data.kubeconfig}' | base64 -d > ~/.kube/hetzner
-holu@<your_host>:~# export KUBECONFIG=~/.kube/hetzner
+holu@<your_host>:~# kubectl get inputmanifest -n claudie
+NAME              STATUS
+multi-cloud-k8s   WATCHING_FOR_CHANGES
+```
+
+## Step 5 - Access the Cluster
+
+The *kubeconfig* will be saved to a Secret object in the `claudie` namespace.
+
+Export the kubeconfig for the deployed cluster:
+
+```shellsession
+holu@<your_host>:~# kubectl get secrets -n claudie -l claudie.io/cluster=hetzner-cluster,claudie.io/output=kubeconfig -ojsonpath='{.items[0].data.kubeconfig}' | base64 -d > hetzner-cluster.yaml
+```
+
+Verify the deployed cluster:
+
+```shellsession
+holu@<your_host>:~# export KUBECONFIG=hetzner-cluster.yaml
 holu@<your_host>:~# kubectl get nodes
-NAME                          STATUS   ROLES    AGE   VERSION
-hetzner-cmpt-qpxeb6w-01   Ready    <none>          7m59s   v1.30.0
-hetzner-cmpt-qpxeb6w-02   Ready    <none>          7m59s   v1.30.0
-hetzner-cmpt-qpxeb6w-03   Ready    <none>          7m59s   v1.30.0
-hetzner-ctrl-78u39wr-01   Ready    control-plane   9m10s   v1.30.0
+NAME                  STATUS   ROLES           AGE   VERSION
+cmpt-fsn-vjh754v-01   Ready    <none>          9m   v1.34.0
+cmpt-fsn-vjh754v-02   Ready    <none>          9m   v1.34.0
+cmpt-nbg-46oaf10-01   Ready    <none>          9m   v1.34.0
+ctrl-fsn-lkd2o3o-01   Ready    control-plane   9m   v1.34.0
+ctrl-fsn-lkd2o3o-02   Ready    control-plane   9m   v1.34.0
+ctrl-fsn-lkd2o3o-03   Ready    control-plane   9m   v1.34.0
 ```
+
+As can be seen from the output above, we have three control plane nodes and two worker nodes in the Falkenstein region, and one worker node in the Nuremberg region which can be horizontally autoscaled up to two nodes.
 
 ## Conclusion
 
-In this tutorial we walked through the process of deploying a Kubernetes cluster on Hetzner Cloud using Claudie. We began by setting up Claudie in a local *kind* cluster, created a Hetzner API key for authentication, and defined a Claudie manifest 
-file. After applying the manifest, we successfully created a Kubernetes cluster on Hetzner Cloud. 
+In this tutorial we walked through the process of deploying a Kubernetes cluster across two Hetzner regions using [Claudie](https://docs.claudie.io/) to manage the infrastructure. We began by setting up Claudie in a local *kind* cluster, created a Hetzner API key for authentication, and defined a Claudie manifest. After applying the manifest, we successfully created a Kubernetes cluster on Hetzner Cloud.
+
+Using Claudie gives us flexibility in determining how many nodes to deploy and where to place them. It also improves resilience against cloud outages, helps mitigate resource shortages within a region, and enhances overall high availability.
 
 ##### License: MIT
 
@@ -286,6 +276,6 @@ By making a contribution to this project, I certify that:
     indefinitely and may be redistributed consistent with this project
     or the license(s) involved.
 
-Signed-off-by: JKBGIT1 jakub.hlavacka@berops.com
+Signed-off-by: matus.brandys@berops.com
 
 -->

--- a/tutorials/kubernetes-with-claudie/01.en.md
+++ b/tutorials/kubernetes-with-claudie/01.en.md
@@ -40,7 +40,7 @@ Claudie needs to be installed on an existing Kubernetes cluster, referred to as 
    ```shellsession
    holu@<your_host>:~# kind create cluster --name claudie-mgmt
    Creating cluster "claudie-mgmt" ...
-    ✓ Ensuring node image (kindest/node:v1.27.3) 🖼
+    ✓ Ensuring node image (kindest/node:v1.35.0) 🖼
     ✓ Preparing nodes 📦
     ✓ Writing configuration 📜
     ✓ Starting control-plane 🕹️
@@ -56,7 +56,7 @@ Claudie needs to be installed on an existing Kubernetes cluster, referred to as 
    holu@<your_host>:~# export KUBECONFIG=~/.kube/claudie
    holu@<your_host>:~# kubectl get nodes
    NAME                         STATUS   ROLES           AGE    VERSION
-   claudie-mgmt-control-plane   Ready    control-plane   3m8s   v1.33.1
+   claudie-mgmt-control-plane   Ready    control-plane   3m8s   v1.35.1
    ```
 
 2. Install cert-manager as it is a requirement for the Claudie Management cluster.

--- a/tutorials/kubernetes-with-claudie/01.en.md
+++ b/tutorials/kubernetes-with-claudie/01.en.md
@@ -56,13 +56,18 @@ Claudie needs to be installed on an existing Kubernetes cluster, referred to as 
    holu@<your_host>:~# export KUBECONFIG=~/.kube/claudie
    holu@<your_host>:~# kubectl get nodes
    NAME                         STATUS   ROLES           AGE    VERSION
-   claudie-mgmt-control-plane   Ready    control-plane   3m8s   v1.35.1
+   claudie-mgmt-control-plane   Ready    control-plane   3m8s   v1.35.0
    ```
 
 2. Install cert-manager as it is a requirement for the Claudie Management cluster.
    
    ```shellsession
-   holu@<your_host>:~# kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
+   holu@<your_host>:~# kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.0/cert-manager.yaml
+   ```
+
+   Wait until cert-manager is ready before you continue with the next step:
+   ```bash
+   kubectl get pods -n cert-manager
    ```
 
 3. Deploy Claudie
@@ -94,7 +99,7 @@ Claudie needs to be installed on an existing Kubernetes cluster, referred to as 
 
 ## Step 2 - Create Hetzner API Key
 
-1. Login to your [Hetzner Cloud Console](https://console.hetzner.cloud) to generate a new API token with *Read & Write* permissions. For more information you can follow [this guide](https://docs.hetzner.com/cloud/api/getting-started/generating-api-token/) on creating an API Token.
+1. Login to your [Hetzner Console](https://console.hetzner.com) to generate a new API token with *Read & Write* permissions. For more information you can follow [this guide](https://docs.hetzner.com/cloud/api/getting-started/generating-api-token/) on creating an API Token.
 
 2. Create a Kubernetes Secret that will contain the Hetzner API Token.
    
@@ -128,20 +133,20 @@ Now, let's create a Claudie manifest file that describes the Kubernetes cluster 
           namespace: claudie
     nodePools:
       dynamic:
-        - name: ctrl-fsn
+        - name: ctrl-hel
           providerSpec:
             name: hetzner-secret
-            region: fsn1
-            zone: fsn1-dc14
+            region: hel1
+            zone: hel1-dc14
           count: 3
           serverType: cx23
           image: ubuntu-24.04
 
-        - name: cmpt-fsn
+        - name: cmpt-hel
           providerSpec:
             name: hetzner-secret
-            region: fsn1
-            zone: fsn1-dc14
+            region: hel1
+            zone: hel1-dc14
           count: 2
           serverType: cx23
           image: ubuntu-24.04
@@ -165,15 +170,15 @@ Now, let's create a Claudie manifest file that describes the Kubernetes cluster 
           network: 192.168.2.0/24
           pools:
             control:
-              - ctrl-fsn
+              - ctrl-hel
             compute:
-              - cmpt-fsn
+              - cmpt-hel
               - cmpt-nbg
   ```
 
 This `InputManifest` will provision:
-- 3 Kubernetes control plane nodes in the Falkenstein region
-- 2 Kubernetes worker nodes in the Falkenstein region
+- 3 Kubernetes control plane nodes in the Helsinki region
+- 2 Kubernetes worker nodes in the Helsinki region
 - 1 to 2 auto-scaled Kubernetes worker nodes in the Nuremberg region, depending on workload demand
 
 Let's break down some of the key fields:
@@ -233,15 +238,15 @@ Verify the deployed cluster:
 holu@<your_host>:~# export KUBECONFIG=hetzner-cluster.yaml
 holu@<your_host>:~# kubectl get nodes
 NAME                  STATUS   ROLES           AGE   VERSION
-cmpt-fsn-vjh754v-01   Ready    <none>          9m   v1.34.0
-cmpt-fsn-vjh754v-02   Ready    <none>          9m   v1.34.0
+cmpt-hel-vjh754v-01   Ready    <none>          9m   v1.34.0
+cmpt-hel-vjh754v-02   Ready    <none>          9m   v1.34.0
 cmpt-nbg-46oaf10-01   Ready    <none>          9m   v1.34.0
-ctrl-fsn-lkd2o3o-01   Ready    control-plane   9m   v1.34.0
-ctrl-fsn-lkd2o3o-02   Ready    control-plane   9m   v1.34.0
-ctrl-fsn-lkd2o3o-03   Ready    control-plane   9m   v1.34.0
+ctrl-hel-lkd2o3o-01   Ready    control-plane   9m   v1.34.0
+ctrl-hel-lkd2o3o-02   Ready    control-plane   9m   v1.34.0
+ctrl-hel-lkd2o3o-03   Ready    control-plane   9m   v1.34.0
 ```
 
-As can be seen from the output above, we have three control plane nodes and two worker nodes in the Falkenstein region, and one worker node in the Nuremberg region which can be horizontally autoscaled up to two nodes.
+As can be seen from the output above, we have three control plane nodes and two worker nodes in the Helsinki region, and one worker node in the Nuremberg region which can be horizontally autoscaled up to two nodes.
 
 ## Conclusion
 


### PR DESCRIPTION
- This tutorial is an update to the existing [guide](https://community.hetzner.com/tutorials/kubernetes-with-claudie). It takes into account the major changes introduced in Claudie from version 0.9.x to 0.10.x. 
- Updates non-existent server types previously provided by Hetzner in yaml definition
- I am member of claudie development team https://github.com/berops/claudie/graphs/contributors


I have read and understood the Contributor's Certificate of Origin available at the end of 
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Matus Brandys matus.brandys@berops.com