### PR TITLE
Add tutorial: Automating SSL certificates with Certbot and Hetzner Cloud DNS

### DIFF
--- a/tutorials/automate-ssl-certbot-hetzner-dns/01.de.md
+++ b/tutorials/automate-ssl-certbot-hetzner-dns/01.de.md
@@ -1,0 +1,223 @@
+---
+SPDX-License-Identifier: MIT
+path: "/tutorials/automate-ssl-certbot-hetzner-dns/de"
+slug: "automate-ssl-certbot-hetzner-dns"
+date: "2026-03-20"
+title: "SSL-Zertifikate mit Certbot für Hetzner Cloud DNS automatisieren"
+short_description: "Certbot mit dem Hetzner Cloud DNS Plugin einrichten, um SSL-Zertifikate automatisch auszustellen und zu erneuern (inkl. Wildcard)."
+tags: ["SSL", "Certbot", "Let's Encrypt", "DNS", "Hetzner Cloud"]
+author: "FreakMediaLP"
+author_link: "https://github.com/FreakMediaLP"
+author_img: "https://avatars3.githubusercontent.com/u/131407675"
+author_description: "Curious software tinkerer"
+language: "de"
+available_languages: ["en", "de"]
+header_img: "header-5"
+cta: "cloud"
+---
+
+## Einführung
+
+Dieses Tutorial beschreibt die Einrichtung von **[Certbot](https://certbot.eff.org/)** mit dem **[Hetzner Cloud DNS Plugin](https://github.com/rolschewsky/certbot-dns-hetzner-cloud)**, um SSL/TLS-Zertifikate über **[Let's Encrypt](https://letsencrypt.org/)** automatisch auszustellen und zu erneuern. Das Tutorial beinhaltet auch den Prozess zur Ausstellung von **Multi-Domain**, sowie **Wildcard Zertifikaten**.
+
+Ein **Wildcard-Zertifikat** gilt für sämtliche Subdomains einer bestimmten Domain. Es wird mit einem Sternchen (`*`) angegeben, z. B. `*.example.com` und ermöglichtes, ein einziges Zertifikat für alle Subdomain ausstellen zu können.
+
+**Am Ende dieses Tutorials hast du ein vollständig automatisiertes Setup, das:**
+
+* SSL-Zertifikate (inkl. Wildcards) für verschiedene Domains innerhalb der Hetzner Cloud DNS ausstellt
+* Zertifikate automatisch vor Ablauf erneuert
+* Optional den Webserver nach der Erneuerung eines Zertifikats neu lädt, um die Änderung direkt anzuwenden
+
+**Voraussetzungen**
+
+* Ein Server mit Ubuntu/Debian (mit installiertem `snap`)
+* Einen laufenden Webserver, z. B. `nginx` oder `Apache` auf dem Linux Server
+* Eine oder mehrere Domains, deren DNS über Hetzner Cloud DNS verwaltet wird
+
+**Beispiel-Benennungen**
+
+* Domain: `<example.com>`
+
+
+## Schritt 1 - Certbot und Hetzner Cloud DNS Plugin installieren
+
+Falls Certbot zuvor bereits über einen anderen Paketmanager (z. B. `apt` oder `pip`) installiert wurde, sollte diese Version zuerst entfernt werden, um Konflikte mit der Snap-Version zu vermeiden.
+
+1. Certbot über Snap installieren:
+
+    ```bash
+    sudo snap install certbot --classic
+    sudo certbot # Certbot einmal ausführen, um das Verzeichnis `/etc/letsencrypt` anzulegen (falls certbot zum ersten Mal installiert wird)
+    ```
+
+2. Das Hetzner Cloud DNS Plugin installieren und mit Certbot verbinden:
+
+    ```bash
+    sudo snap install certbot-dns-hetzner-cloud
+    sudo snap set certbot trust-plugin-with-root=ok
+    sudo snap connect certbot:plugin certbot-dns-hetzner-cloud
+    ```
+
+3. Überprüfen, ob das Plugin installiert wurde
+
+    ```bash
+    sudo certbot plugins
+    ```
+
+   > In der Ausgabe sollte `dns-hetzner-cloud` als verfügbarer Authenticator aufgelistet sein.
+
+
+## Schritt 2 - Hetzner Cloud API-Token konfigurieren
+
+Damit Certbot das Hetzner Cloud DNS Plugin verwenden kann, muss eine Credential-Datei mit deinem API-Token angelegt werden.
+
+1. Eine Credential-Datei erstellen, die den Hetzner Cloud API-Token enthält:
+
+    ```bash
+    echo "dns_hetzner_cloud_api_token = <your-hetzner-cloud-api-token>" | sudo tee /etc/letsencrypt/hetzner-cloud.ini > /dev/null
+    ```
+
+   > Ersetze `<your-hetzner-cloud-api-token>` durch deinen API-Token, den du hier generieren kannst: **<a href="https://docs.hetzner.com/cloud/api/getting-started/generating-api-token/" target="_blank">Getting Started » Generating an API token</a>**
+
+2. Die Dateiberechtigungen einschränken, sodass nur root die Datei lesen kann:
+
+    ```bash
+    sudo chmod 600 /etc/letsencrypt/hetzner-cloud.ini
+    ```
+
+
+## Schritt 3 - Zertifikat anfordern
+
+Es gibt verschiedene Möglichkeiten, Zertifikate mit Certbot anzufordern, abhängig von deinen Anforderungen (z. B. **Einzelne Domain** vs. **Multi-Domain**, mit oder ohne **Wildcard**). Hier sind einige Beispiele, welche frei miteinander kombinierbar sind.
+
+### Option 1 - Einzelne Domain
+
+Um ein Zertifikat für eine einzelne Domain anzufordern:
+
+```bash
+sudo certbot certonly \
+  --authenticator dns-hetzner-cloud \
+  --dns-hetzner-cloud-credentials /etc/letsencrypt/hetzner-cloud.ini \
+  --dns-hetzner-cloud-propagation-seconds 60 \
+  --deploy-hook "systemctl reload nginx" \
+  -m mail@example.com \
+  --cert-name example.com \
+  -d example.com
+```
+
+> Anstatt `-m mail@example.com` kann auch `--register-unsafely-without-email` verwendet werden, um die Angabe einer Benachrichtungung E-Mail-Adresse zu überspringen.
+>
+> `--deploy-hook "systemctl reload nginx"` sorgt dafür, dass `nginx` nach Erneuerung eines Zertifikats automatisch neu geladen wird. Verwende den entsprechenden Befehl, wenn du einen anderen Webserver (z. B. `apache`) verwendest.
+
+### Option 2 - Einzelne Domain (mit einzelner Subdomain)
+
+Um eine spezifische Subdomain in das Zertifikat mit aufzunehmen, füge einen weiteren `-d` Parameter hinzu:
+
+```bash
+  -d example.com -d sub.example.com
+```
+
+### Option 3 - Einzelne Domain (mit Wildcard)
+
+Um ein Zertifikat für eine Domain inklusive aller Subdomains (Wildcard) anzufordern, verwende den zuvor beschriebenen Wildcard-Präfix (`*`):
+
+```bash
+  -d example.com -d *.example.com
+```
+
+### Option 4 - Multi-Domain Zertifikat (mit Wildcard)
+
+Um mehrere Domains (und deren Wildcards) in ein einzelnes Zertifikat aufzunehmen, gib alle Domains mit jeweils einem `-d` Parameter an. Verwende in diesem Fall jedoch `--cert-name`, um dem Zertifikat einen eigenen passenden Namen zu geben:
+
+```bash
+  --cert-name example-combined \
+  -d example.com -d *.example.com \
+  -d example.de -d *.example.de
+```
+
+
+## Weitere Infos (Optional)
+
+**Fertig!** Ein Zertifikat ist nach Ausstellung 90 Tage gültig. Zudem werden sämtliche Zertifikate von Certbot regelmäßig auf ihr Ablaufdatum überprüft und 30 Tage vor Ablauf automatisch erneuert. Diese Erneuerung ist automatisch aktiv und kann mit den Befehlen unter **[#Befehle zur Verwaltung](#Befehle-zur-Verwaltung)** eingesehen, getestet, gelöscht und verwaltet werden.
+
+### Argumente
+
+Hier sind die genauen Erklärungen der in den obigen Beispielen verwendeten Argumente, weitere Certbot Argumente können **[hier](https://eff-certbot.readthedocs.io/en/latest/using.html#certbot-commands)** nachgelesen werden:
+
+| Option | Beschreibung                                                                                                                             |
+| --- |------------------------------------------------------------------------------------------------------------------------------------------|
+| `--authenticator dns-hetzner-cloud` | Hetzner Cloud DNS Plugin für die DNS-01-Challenge verwenden                                                                              |
+| `--dns-hetzner-cloud-credentials` | Pfad zur Credentials-Datei                                                                                                               |
+| `--dns-hetzner-cloud-propagation-seconds` | Wartezeit für die DNS-Propagation (bis Let's Encrypt die vom Plugin erstellten Records zur Authentifizierung sehen kann)                 |
+| `--agree-tos` | Nutzungsbedingungen von Let's Encrypt automatisch akzeptieren                                                                            |
+| `-m` | E-Mail-Adresse für wichtige Benachrichtigungen (z. B. Erneuerungsfehler)                                                                 |
+| `--deploy-hook` | Befehl, der nach einer erfolgreichen Erneuerung ausgeführt wird (z. B. nginx neu laden)                                                  |
+| `--cert-name` | Benutzerdefinierter Name für das Zertifikat (bei einer einzelnen Domain wurd automatisch die Domain selbst verwendet) |
+| `-d` | Domain(s), die im Zertifikat enthalten sein sollen                                                                                       |
+
+### Befehle zur Verwaltung
+
+- Testen, ob alle Zertifikate erfolgreich ausgestellt werden, ohne die aktuellen zu überschreiben (Dry-Run):
+
+    ```bash
+    sudo certbot renew --dry-run
+    ```
+
+- Alle von Certbot verwalteten Zertifikate auflisten:
+
+    ```bash
+    sudo certbot certificates
+    ```
+
+- Ein Zertifikat (und die automatische Erneuerung) händisch löschen:
+
+    ```bash
+    sudo certbot delete --cert-name example.com
+    ```
+
+- Die Renewal-Konfiguration eines Zertifikats anzeigen (Wurde mit dem Ausstellungsbefehl angelegt):
+
+    ```bash
+    sudo cat /etc/letsencrypt/renewal/example.com.conf
+    ```
+
+## Ergebnis
+
+Du hast Certbot mit dem **[Hetzner Cloud DNS Plugin](https://github.com/rolschewsky/certbot-dns-hetzner-cloud)** installiert und konfiguriert sowie mit der Hetzner Cloud-API verbunden. Sobald du Zertifikate anforderst, legt Certbot einen Timer an, welcher die Zertifikate regelmäßig auf ihr Ablaufdatum überprüft und sie automatisch 30 Tage vor Ablauf erneuert. Mit dem `--deploy-hook` Argument kannst du außerdem sicherstellen, dass dein Webserver nach der Erneuerung eines Zertifikats automatisch neu geladen wird, um die Änderung direkt anzuwenden.
+
+**Nächste Schritte:**
+
+* Weitere Optionen im **[certbot-dns-hetzner-cloud](https://github.com/rolschewsky/certbot-dns-hetzner-cloud)** Plugin Repository entdecken
+* Mehr über **[Certbot](https://eff-certbot.readthedocs.io/en/latest/)** in der offiziellen Dokumentation erfahren
+
+##### License: MIT
+
+<!--
+
+Contributor's Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it under the license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate license and I have the
+    right under that license to submit that work with modifications,
+    whether created in whole or in part by me, under the same license
+    (unless I am permitted to submit under a different license), as
+    indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are
+    public and that a record of the contribution (including all personal
+    information I submit with it, including my sign-off) is maintained
+    indefinitely and may be redistributed consistent with this project
+    or the license(s) involved.
+
+Signed-off-by: FreakMediaLP <info@freakmedialp.de>
+
+-->
+

--- a/tutorials/automate-ssl-certbot-hetzner-dns/01.en.md
+++ b/tutorials/automate-ssl-certbot-hetzner-dns/01.en.md
@@ -1,0 +1,223 @@
+---
+SPDX-License-Identifier: MIT
+path: "/tutorials/automate-ssl-certbot-hetzner-dns"
+slug: "automate-ssl-certbot-hetzner-dns"
+date: "2026-03-20"
+title: "Automate SSL Certificates with Certbot for Hetzner Cloud DNS"
+short_description: "Set up Certbot with the Hetzner Cloud DNS plugin to automatically issue and renew SSL certificates (including wildcards)."
+tags: ["SSL", "Certbot", "Let's Encrypt", "DNS", "Hetzner Cloud"]
+author: "FreakMediaLP"
+author_link: "https://github.com/FreakMediaLP"
+author_img: "https://avatars3.githubusercontent.com/u/131407675"
+author_description: "Curious software tinkerer"
+language: "en"
+available_languages: ["en", "de"]
+header_img: "header-5"
+cta: "cloud"
+---
+
+## Introduction
+
+This tutorial describes how to set up **[Certbot](https://certbot.eff.org/)** with the **[Hetzner Cloud DNS Plugin](https://github.com/rolschewsky/certbot-dns-hetzner-cloud)** to automatically issue and renew SSL/TLS certificates via **[Let's Encrypt](https://letsencrypt.org/)**. The tutorial also covers the process of issuing **multi-domain** as well as **wildcard certificates**.
+
+A **wildcard certificate** covers all subdomains of a given domain. It is specified with an asterisk (`*`), e.g. `*.example.com`, and allows you to issue a single certificate for all subdomains.
+
+**By the end of this tutorial, you will have a fully automated setup that:**
+
+* Issues SSL certificates (including wildcards) for various domains managed via Hetzner Cloud DNS
+* Automatically renews certificates before they expire
+* Optionally reloads the web server after a certificate renewal to apply the changes immediately
+
+**Prerequisites**
+
+* A server running Ubuntu/Debian (with `snap` installed)
+* A running web server, e.g. `nginx` or `Apache`, on the Linux server
+* One or more domains whose DNS is managed via Hetzner Cloud DNS
+
+**Example terminology**
+
+* Domain: `<example.com>`
+
+
+## Step 1 - Install Certbot and the Hetzner Cloud DNS Plugin
+
+If Certbot was previously installed via another package manager (e.g. `apt` or `pip`), that version should be removed first to avoid conflicts with the Snap version.
+
+1. Install Certbot via Snap:
+
+    ```bash
+    sudo snap install certbot --classic
+    sudo certbot # Run Certbot once to create the `/etc/letsencrypt` directory (if Certbot is being installed for the first time)
+    ```
+
+2. Install the Hetzner Cloud DNS plugin and connect it with Certbot:
+
+    ```bash
+    sudo snap install certbot-dns-hetzner-cloud
+    sudo snap set certbot trust-plugin-with-root=ok
+    sudo snap connect certbot:plugin certbot-dns-hetzner-cloud
+    ```
+
+3. Verify that the plugin was installed:
+
+    ```bash
+    sudo certbot plugins
+    ```
+
+   > The output should list `dns-hetzner-cloud` as an available authenticator.
+
+
+## Step 2 - Configure the Hetzner Cloud API Token
+
+In order for Certbot to use the Hetzner Cloud DNS plugin, a credential-file containing your API token must be created.
+
+1. Create a credential-file that contains the Hetzner Cloud API token:
+
+    ```bash
+    echo "dns_hetzner_cloud_api_token = <your-hetzner-cloud-api-token>" | sudo tee /etc/letsencrypt/hetzner-cloud.ini > /dev/null
+    ```
+
+   > Replace `<your-hetzner-cloud-api-token>` with your API token, which you can generate here: **<a href="https://docs.hetzner.com/cloud/api/getting-started/generating-api-token/" target="_blank">Getting Started » Generating an API token</a>**
+
+2. Restrict the file permissions so only root can read the file:
+
+    ```bash
+    sudo chmod 600 /etc/letsencrypt/hetzner-cloud.ini
+    ```
+
+
+## Step 3 - Request a Certificate
+
+There are several ways to request certificates with Certbot, depending on your requirements (e.g. **single domain** vs. **multi-domain**, with or without **wildcard**). Below are some examples that can be freely combined with each other.
+
+### Option 1 - Single Domain
+
+To request a certificate for a single domain:
+
+```bash
+sudo certbot certonly \
+  --authenticator dns-hetzner-cloud \
+  --dns-hetzner-cloud-credentials /etc/letsencrypt/hetzner-cloud.ini \
+  --dns-hetzner-cloud-propagation-seconds 60 \
+  --deploy-hook "systemctl reload nginx" \
+  -m mail@example.com \
+  --cert-name example.com \
+  -d example.com
+```
+
+> Instead of `-m mail@example.com`, you can also use `--register-unsafely-without-email` to skip providing a notification email address.
+>
+> `--deploy-hook "systemctl reload nginx"` ensures that `nginx` is automatically reloaded after a certificate is renewed. Use the appropriate command if you are running a different web server (e.g. `apache`).
+
+### Option 2 - Single Domain (with a Specific Subdomain)
+
+To include a specific subdomain in the certificate, add another `-d` parameter:
+
+```bash
+  -d example.com -d sub.example.com
+```
+
+### Option 3 - Single Domain (with Wildcard)
+
+To request a certificate for a domain including all subdomains (wildcard), use the wildcard prefix (`*`) described earlier:
+
+```bash
+  -d example.com -d *.example.com
+```
+
+### Option 4 - Multi-Domain Certificate (with Wildcard)
+
+To include multiple domains (and their wildcards) in a single certificate, specify all domains with a separate `-d` parameter. In this case, use `--cert-name` to give the certificate a custom name:
+
+```bash
+  --cert-name example-combined \
+  -d example.com -d *.example.com \
+  -d example.de -d *.example.de
+```
+
+
+## Additional Information (Optional)
+
+**Done!** An issued certificate is valid for 90 days. All certificates are regularly checked by Certbot for their expiration date and are automatically renewed 30 days before they expire. This renewal is automatically active and can be viewed, tested, deleted, and managed using the commands under **[#Management Commands](#management-commands)**.
+
+### Arguments
+
+Below are the detailed explanations of the arguments used in the examples above. Additional Certbot arguments can be found **[here](https://eff-certbot.readthedocs.io/en/latest/using.html#certbot-commands)**:
+
+| Option | Description                                                               |
+| --- |---------------------------------------------------------------------------|
+| `--authenticator dns-hetzner-cloud` | Use the Hetzner Cloud DNS plugin for the DNS-01 challenge                 |
+| `--dns-hetzner-cloud-credentials` | Path to the credential-file                                               |
+| `--dns-hetzner-cloud-propagation-seconds` | Wait time for DNS propagation (until Let's Encrypt can see the records created by the plugin for authentication) |
+| `--agree-tos` | Automatically accept the Let's Encrypt terms of service                   |
+| `-m` | Email address for important notifications (e.g. renewal failures)         |
+| `--deploy-hook` | Command to run after a successful renewal (e.g. reload nginx)             |
+| `--cert-name` | Custom name for the certificate (for a single domain, the domain itself is automatically used) |
+| `-d` | Domain(s) to include in the certificate                                   |
+
+### Management Commands
+
+- Test whether all certificates can be successfully issued without overwriting the current ones (dry run):
+
+    ```bash
+    sudo certbot renew --dry-run
+    ```
+
+- List all certificates managed by Certbot:
+
+    ```bash
+    sudo certbot certificates
+    ```
+
+- Manually delete a certificate (and the automatic renewal):
+
+    ```bash
+    sudo certbot delete --cert-name example.com
+    ```
+
+- View the renewal configuration of a certificate (created along with the request command):
+
+    ```bash
+    sudo cat /etc/letsencrypt/renewal/example.com.conf
+    ```
+
+## Conclusion
+
+You have installed and configured Certbot with the **[Hetzner Cloud DNS Plugin](https://github.com/rolschewsky/certbot-dns-hetzner-cloud)** and connected it to the Hetzner Cloud API. Once you request certificates, Certbot sets up a timer that regularly checks the certificates for their expiration date and automatically renews them 30 days before they expire. With the `--deploy-hook` argument, you can also ensure that your web server is automatically reloaded after a certificate renewal, so the changes are applied immediately.
+
+**Next steps:**
+
+* Explore more options in the **[certbot-dns-hetzner-cloud](https://github.com/rolschewsky/certbot-dns-hetzner-cloud)** plugin repository
+* Learn more about **[Certbot](https://eff-certbot.readthedocs.io/en/latest/)** in the official documentation
+
+##### License: MIT
+
+<!--
+
+Contributor's Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it under the license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate license and I have the
+    right under that license to submit that work with modifications,
+    whether created in whole or in part by me, under the same license
+    (unless I am permitted to submit under a different license), as
+    indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are
+    public and that a record of the contribution (including all personal
+    information I submit with it, including my sign-off) is maintained
+    indefinitely and may be redistributed consistent with this project
+    or the license(s) involved.
+
+Signed-off-by: FreakMediaLP <info@freakmedialp.de>
+
+-->
+


### PR DESCRIPTION
## New Tutorial: Automate SSL Certificates with Certbot for Hetzner Cloud DNS

### Description
This tutorial explains how to set up **[Certbot](https://certbot.eff.org/)** with the **[Hetzner Cloud DNS Plugin](https://github.com/rolschewsky/certbot-dns-hetzner-cloud)**
(`certbot-dns-hetzner-cloud`) to automatically issue and renew SSL/TLS certificates
via **Let's Encrypt**, including support for wildcard and multi-domain certificates.

### Languages
- [x] English
- [x] German

### Checklist
- [x] Validated process on private VPS and fresh Hetzner VPS
- [x] Tutorial is original and not published elsewhere
- [x] Tutorial was not generated by AI
- [x] No existing tutorial covers this exact topic on community.hetzner.com
- [x] Content follows Markdown formatting guidelines
- [x] Links point to official websites and the used plugin

---

I have read and understood the Contributor's Certificate of Origin available at the end of 
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: FreakMediaLP <info@freakmedialp.de>