### PR TITLE
Ref #1429: Update VPC/WireGuard tutorial for 2026

### DIFF
--- a/tutorials/vpc-with-wireguard-pfsense/01.en.md
+++ b/tutorials/vpc-with-wireguard-pfsense/01.en.md
@@ -25,14 +25,14 @@ Network administrators of a medium sized company tasked with integrating Hetzner
 ### Abstract
 
 This tutorial describes how to set up a [Virtual Private Cloud](https://en.wikipedia.org/wiki/Virtual_private_cloud) (VPC for short) in [Hetzner Cloud](https://www.hetzner.com/cloud) and connecting it to your on-premises network via a site-to-site [WireGuard](https://www.wireguard.com/) VPN.
-Once set up, (virtual) machines in your office and the Cloud behave (mostly) like they are in the same location - the side-to-site VPN will be transparent for all your clients.
+Once set up, (virtual) machines in your office and the Cloud behave (mostly) like they are in the same location - the site-to-site VPN will be transparent for all your clients.
 
 Currently, Hetzner's offering lacks a separate router product, which means you have to set up your own with a little bit more legwork. However, once set up, you will have a lot more freedom and customizability. This guide does intentionally use browser GUI instead the [`hcloud` CLI](https://github.com/hetznercloud/cli) / APIs (as most of pfSense's config has to be done in a browser anyway).
 
 ### Scope
 
 - Planning our network segments, since we want to connect a medium / large network from *Example Corp* to Hetzner Cloud
-- Setup and configure a pfSense instance in Hetzner Clound
+- Setup and configure a pfSense instance in Hetzner Cloud
 - Connect both via a WireGuard tunnel
 - Add all the necessary IPv4 routes and handle NAT
 - Setting up firewall rules
@@ -58,7 +58,7 @@ This guide assumes you already have some experience with pfSense as well as a ba
 - Existing, working pfSense installation acting as your "default" external route
 - Working name resolution (DNS)
 - You need a [Hetzner Cloud account](https://accounts.hetzner.com/login) (obviously) with full access or access to an empty project
-- pfSense release 2.6 (for WireGuard to work)
+- pfSense CE 2.8.x or pfSense Plus 24.11+
 
 ### Terminology
 
@@ -104,44 +104,44 @@ Let's assume you are in charge of the network of *Example Corp*, and your main l
 
 ## Step 2 - Setting up Hetzner Cloud
 
-This part will get our pfSense VPC instance up and running.`
+This part will get our pfSense VPC instance up and running.
 
 1. [Create a new project](https://docs.hetzner.com/cloud/general/faq#what-are-projects-and-how-can-i-use-them) called `example-vpc`
 
 2. Go to the [network tap](https://docs.hetzner.com/cloud/networks/getting-started/creating-a-network) and create your primary network segment `example-vpc` - `<10.0.0.0/16>`</br>
-   
+
    ![Add network](images/vpc-main-network.png)
-   
-   - Make sure to select the *Network Zone* you want as all your future VPC machines need to be in this region. At the time of writing this, you can choose between `us-east`, `us-west`, `eu-central`, and `ap-southeast` here.
+
+   - Make sure to select the *Network Zone* you want as all your future VPC machines need to be in this region. At the time of writing this, you can choose between `eu-central` (Nuremberg, Falkenstein, Helsinki), `us-east` (Ashburn), `us-west` (Hillsboro), and `ap-southeast` (Singapore) here.
    - Note that the first address of the network will be your internal gateway: `<10.0.0.1>`
 
 3. Create the required subnets.
-   
+
    - Delete the default one (`<10.0.0.0/24>`) as it overlaps with our on-prem segment
    - Create the segment `<10.0.128.0/30>` for our pfSense VPC instance as well as any number of subnets you need for your machines later on. We start with one here (`<10.0.129.0/24>`) ; just for testing.</br>
-   
+
    ![VPC Subnets](images/vpc-subnets.png)
 
 4. Setup your static routes
-   
+
    - Add our main route to our on-prem network. Since our future pfSense VPC instance will handle this, it needs to be the nexthop: `<10.0.0.0/17 via <10.0.128.2>`
    - Add the default route as well: `<0.0.0.0/0 via <10.0.128.2>` as we want to use the VPC pfSense for "internet" traffic inside the VPC. Note the warning you get here: You need to add the default route manually to every client later (it saves a lot of money since you can get away without pricey public IPv4 addresses).
 
    ![VPC Routes](images/vpc-networks-routes.png)
 
 5. Spin up [your server](https://docs.hetzner.com/cloud/servers/getting-started/creating-a-server)
-   
+
    - Make sure to select public and private networking
    - The OS does not matter as we will erase it later
-   - **Note on instance sizing:** Since routing gigabit traffic and WireGuard crypto are no trivial task, you should *at least* choose a 2-Core instance here - `CPX11` is recommended and can handle 1 Gbit/s. You can switch between instance plans later on.</br>
+   - **Note on instance sizing:** Since routing gigabit traffic and WireGuard crypto are no trivial task, you should *at least* choose a 2-Core instance here - `CPX11` (2 vCPU AMD / 2 GB RAM) is recommended and can handle 1 Gbit/s. If you need more headroom, consider `CPX21` (3 vCPU / 4 GB). You can switch between instance plans later on. Check [Hetzner's current pricing](https://www.hetzner.com/cloud/) as prices may have changed since this guide was written.</br>
      ![VM networking](images/pfsense-vm-networking.png)
    - *Optionally* you might want to assign [Floating IPs](https://docs.hetzner.com/cloud/floating-ips/getting-started/adding-a-floating-ip) to get additional persistence
    - Order the server. It will boot up automatically
    - Head back to the Networking/Subnets tab and make sure the VPC pfSense instance is connected to the desired segment: `<10.0.128.0/30>`</br>
      ![Attach subnet](images/vpc-attach-subnet.png)
-   
+
 6. Attach the latest [pfSense ISO image](https://docs.hetzner.com/cloud/servers/iso-installation-gateway) Hetzner provides. Then, restart the VPC pfSense instance and connect to it via the [VNC console](https://docs.hetzner.com/cloud/servers/getting-started/vnc-console) on your Hetzner Console. Leave the browser window open since you need to detach the ISO in a few minutes.
-   
+
    ![Attach iso image](images/vpc-pfsense-attach-iso.2.7.2.png)
 
 ## Step 3 - Setting up VPC pfSense instance
@@ -155,22 +155,22 @@ In this step we will set up pfSense in Hetzner Cloud and install and configure W
 2. Remove the ISO when the VPC pfSense instance reboots (see above)
 
 3. Follow the initial wizard to set your pfSense WAN and LAN interfaces. `vtnet0` should be your WAN interface, `vtnet1` the LAN interface. Do not set up any VLANs and keep the default LAN IP:
-   
+
    ![pfSense console wizard](images/pfsense-console-setup.png)
 
 4. You should now be greeted by the main console menu. Note the DHCP WAN address you are getting.
-   
+
    ![pfSense easyrule](images/pfsense-easyrule-cli.png)
 
 5. Select `8` for the console and use `easyrule` to open port 443/tcp on the WAN interface form your current locations public IPv4:
-   
+
    ```shell
    easyrule pass WAN tcp <your_current_ip> any 443 tcp
    ```
 
    > You can use [ip.hetzner.com](https://ip.hetzner.com/), for example, to get your IP address.
 
-*Remember to delete this rule when the site-to-side tunnel is up and running!*
+*Remember to delete this rule when the site-to-site tunnel is up and running!*
 
 ### Continue in your web browser
 
@@ -179,28 +179,28 @@ In this step we will set up pfSense in Hetzner Cloud and install and configure W
 2. Complete the [setup wizard](https://docs.netgate.com/pfsense/en/latest/config/setup-wizard.html)
 
 3. In `System` / `Routing` / `Gateways`, set WAN_DHCP and WANGWv6 as default. Note the IPv4 gateway address<br>
-   
+
    ![pfSense Default Gateways](images/pfsense-default-gw.png)
 
-4. In `Services` / `DHCP Server`, disble "DHCP server on LAN interface". In `Services` / `DHCPv6 Server`, disable "DHCPv6 server on interface LAN". In `Services` / `Router Advertisements`, set the "Router Mode" to "disabled" (the services are not needed anyway). In `Interfaces` / `LAN`, set the LAN interface to DHCP:<br>
-   
+4. In `Services` / `DHCP Server`, disable "DHCP server on LAN interface". In `Services` / `DHCPv6 Server`, disable "DHCPv6 server on interface LAN". In `Services` / `Router Advertisements`, set the "Router Mode" to "disabled" (the services are not needed anyway). In `Interfaces` / `LAN`, set the LAN interface to DHCP:<br>
+
    ![pfSense LAN](images/pfsense-lan-dhcp.png)
-   
+
    - *Optional:* Set the IPv4 address *static* to your floating IPv4 address WAN interface and create a new gateway with the address from step (3)
 
 5. It is a good practice to add aliases for later use in rules. Add them in `Firewall` / `Aliases` for our network segments and addresses. You can also [import them form here](https://github.com/hetzneronline/community-content/tree/master/tutorials/vpc-with-wireguard-pfsense/configs/aliases-config-vpc-gw.example.com.xml).
-   
+
    **Tip:** You can also add these aliases directly to your on-prem pfSense instance, export all aliases there and import them in your VPC pfSense instance<br>
-   
+
    ![pfSense Aliases](images/pfsense-aliases.png)
 
-6. *Optional:* Add a static IPv6 address from your public prefix to your WAN interface (the gateway is `fe80::1`):<br>
-   
+6. *Optional:* Add a static IPv6 address from your public prefix to your WAN interface (the gateway is `fe80::1`)
+
    ![pfSense WAN IPv6](images/pfsense-wan-ipv6.png)
 
 ### Further recommended pfSense settings
 
-- In `System` / `Advanced` / `Miscellaneous` enable `AES-NI CPU based acceleration` in the "Cryptographic Hardware" section
+- In `System` / `Advanced` / `Miscellaneous`, check that `AES-NI CPU based acceleration` is enabled in the "Cryptographic Hardware" section. On current Hetzner Cloud instances (AMD EPYC), AES-NI should be auto-detected, but it is worth verifying.
 - It is *highly recommended* to set up proper public DNS records for the IP addresses of the WAN interface
 - Add a [floating quick rule](https://docs.netgate.com/pfsense/en/latest/firewall/floating-rules.html?highlight=quick%20rule#quick) *ICMP pass any* rule for your all interfaces
 - [Set up OpenVPN](https://docs.netgate.com/pfsense/en/latest/recipes/openvpn-ra.html) for the admin user
@@ -209,7 +209,7 @@ In this step we will set up pfSense in Hetzner Cloud and install and configure W
 
 In this step, we will install WireGuard on both of the pfSense instances - on-prem as well as VPC. [WireGuard](https://www.wireguard.com/) is a kernel module and it aims to be a modern, secure, high performance yet leaner VPN compared to OpenVPN, IPSec, etc.
 
-**Please note** that there has been [some controversy](https://www.netgate.com/blog/painful-lessons-learned-in-security-and-community) around Netgate's WireGuard implementation in the past. The current kmod-plugin for FreeBSD (what the [pfSense](https://github.com/pfsense/FreeBSD-ports/tree/devel/net/pfSense-pkg-WireGuard) uses in turn) is developed by the [same guy](https://git.zx2c4.com/wireguard-freebsd/) who maintains the Linux kmod. At the time of writing this, *wireguard-freebsd* is marked as *experimental* and has yet to see a 1.0 release. That said, in it's current state it already works well and I presume it only gets better with time.
+**Please note** that WireGuard support in pfSense is provided via the [pfSense WireGuard package](https://github.com/pfsense/FreeBSD-ports/tree/devel/net/pfSense-pkg-WireGuard), which uses the [wireguard-freebsd](https://git.zx2c4.com/wireguard-freebsd/) kernel module maintained by Jason Donenfeld (the original WireGuard author). As of pfSense 2.8, the package is mature and works reliably for production site-to-site setups. It is still installed via the Package Manager (not built into the base system).
 
 ### Overview
 
@@ -249,7 +249,7 @@ To clarify the guide from pfSense, make sure to follow all steps on both of your
 ### Optimizations
 
 - To optimize the performance, make our site-to-site VPN truly transparent, disable outbound NAT for the VPC tunnel and the segments on the LAN gateway on both instances. Enable *Hybrid Nat* and add these *Do Not NAT* rules:
-  
+
   ![pfsense-hybrid-nat.png](images/pfsense-hybrid-nat.png)
   ![pfsense-nat-rule-wg.png](images/pfsense-nat-rule-wg.png)
 
@@ -257,18 +257,18 @@ To clarify the guide from pfSense, make sure to follow all steps on both of your
 
 ## Step 5 - Setup clients and test the tunnel
 
-At this point, your site-to-site-vpn should be up and running. To demonstrate it and test the performance, let's set up a network test VM in Hetzner Cloud. The steps below are an example and *not* permanent as this is outside the scope.
+At this point, your site-to-site VPN should be up and running. To demonstrate it and test the performance, let's set up a network test VM in Hetzner Cloud. The steps below are an example and *not* permanent as this is outside the scope.
 
 1. Spin up a new server in our VPC project using the "default" Ubuntu distro (or any other you are comfortable with) . **Do not** attach a public network but only a private network.</br>
-   
+
    ![Spin up test machine](images/vpc-test-machine-net.png)
 
 2. Make sure the correct network is attached (since the pfSense network is so small, it should be automatically)</br>
-   
+
    ![Test machine network](images/vpc-test-machine.png)
 
 3. [Log into the machine](https://docs.hetzner.com/cloud/servers/getting-started/connecting-via-private-ip) using `ssh root@10.0.129.1`
-   
+
    1. Look at your routes, note we get the route to our VPC network automatically via DHCP but a default route is missing. Let's fix that and add a nameserver:
       ```bash
       root@10.0.129.1:~# ip route
@@ -296,7 +296,11 @@ At this point, your site-to-site-vpn should be up and running. To demonstrate it
       64 bytes from fra24s01-in-f14.1e100.net (216.58.212.174): icmp_seq=2 ttl=115 time=5.59 ms
       64 bytes from fra24s01-in-f14.1e100.net (216.58.212.174): icmp_seq=3 ttl=115 time=5.57 ms
       ```
-   
+
+      > **Important:** Since August 2025, Hetzner's DHCP server for private networks [no longer sends the Router Option (code 3)](https://docs.hetzner.com/networking/networks/changes/dhcp-bugfix/). This means client machines will **not** receive a default route via DHCP automatically. The `ip route add default` command above is required but is **not persistent** across reboots.
+      >
+      > For a persistent setup, you need to configure a **static default route** on each VPC client. See Hetzner's guide on [achieving a persistent configuration](https://community.hetzner.com/tutorials/how-to-set-up-nat-for-cloud-networks#step-4---achieving-a-persistent-configuration) for distribution-specific examples (netplan, networkd, NetworkManager).
+
    2. Now we have "internet" via our VPC pfSense instance and name resolution working. To test our network, install the `iperf3` package and run the server
       ```bash
       root@10.0.129.1:~# apt update && apt install iperf3
@@ -308,7 +312,7 @@ At this point, your site-to-site-vpn should be up and running. To demonstrate it
       Server listening on 5201
       -----------------------------------------------------------
       ```
-   
+
    3. Test the performance with any machine inside your on-prem network. Assuming your uplink is not too congested, you should see the nominal speed of your internet connection
       ```bash
       # iperf3 --format M -c 10.0.129.1
@@ -329,14 +333,13 @@ At this point, your site-to-site-vpn should be up and running. To demonstrate it
       [ ID] Interval           Transfer     Bitrate         Retr
       [  5]   0.00-10.00  sec  1014 MBytes   101 MBytes/sec  379             sender
       [  5]   0.00-10.00  sec  1014 MBytes   101 MBytes/sec                  receiver
-      
+
       iperf Done.
       ```
 
 ### Hints
 
-- If you do not reach the nominal speed if your connection then you might need to upgrade your VPC pfSense - instance tier (more CPU-cores) or even your local on-prem pfSense.
-- Should you have trouble with network persistence when using `NetworkManager`, remove the `hc-utils` package.
+- If you do not reach the nominal speed of your connection then you might need to upgrade your VPC pfSense instance tier (more CPU-cores) or even your local on-prem pfSense.
 
 ## Conclusion
 


### PR DESCRIPTION
- Bump pfSense prerequisite to 2.8.x
- Add note on Hetzner DHCP Router Option removal (Aug 2025) with persistent route guidance
- Update network zones with current locations (incl. Ashburn, Hillsboro, Singapore)
- Update WireGuard maturity status, remove old controversy disclaimer
- Add current instance specs/pricing link for CPX11/CPX21
- Fix AES-NI guidance (auto-detected on AMD EPYC)
- Fix typos (Clound, side-to-site)
- Remove hc-utils hint


I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Daniel Helgenberger