### PR TITLE
Update "Kubernetes with Claudie" tutorial

### DIFF
--- a/tutorials/kubernetes-with-claudie/01.en.md
+++ b/tutorials/kubernetes-with-claudie/01.en.md
@@ -73,7 +73,7 @@ Claudie needs to be installed on an existing Kubernetes cluster, referred to as 
 3. Deploy Claudie
    
    ```shellsession
-   holu@<your_host>:~# kubectl apply -f https://github.com/berops/claudie/releases/download/v0.10.0/claudie.yaml
+   holu@<your_host>:~# kubectl apply -f https://github.com/berops/claudie/releases/download/v0.12.0/claudie.yaml
    ```
 
 4. Wait for all Pods to get into **Ready** state
@@ -128,6 +128,10 @@ Now, let's create a Claudie manifest file that describes the Kubernetes cluster 
     providers:
       - name: hetzner-secret
         providerType: hetzner
+        templates:
+          repository: "https://github.com/berops/claudie-config"
+          tag: "v0.11.0"
+          path: "templates/terraformer/hetzner"
         secretRef:
           name: hetzner-secret
           namespace: claudie
@@ -137,7 +141,7 @@ Now, let's create a Claudie manifest file that describes the Kubernetes cluster 
           providerSpec:
             name: hetzner-secret
             region: hel1
-            zone: hel1-dc14
+            zone: hel1-dc2
           count: 3
           serverType: cx23
           image: ubuntu-24.04
@@ -146,7 +150,7 @@ Now, let's create a Claudie manifest file that describes the Kubernetes cluster 
           providerSpec:
             name: hetzner-secret
             region: hel1
-            zone: hel1-dc14
+            zone: hel1-dc2
           count: 2
           serverType: cx23
           image: ubuntu-24.04


### PR DESCRIPTION
- This tutorial is an update to the existing [guide](https://community.hetzner.com/tutorials/kubernetes-with-claudie)
- Fix incorrect Helsinki zone configuration
- Update Terraform template reference which uses location parameter instead of deprecated datacenter parameter (scheduled for removal)

I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Matus Brandys [matus.brandys@berops.com](mailto:matus.brandys@berops.com)