### PR TITLE
📝 Add amneziawg-installer to "Making Your Website Accessible from Restricted Regions" Resources

### DIFF
--- a/tutorials/making-website-accessible-from-restricted-regions/01.en.md
+++ b/tutorials/making-website-accessible-from-restricted-regions/01.en.md
@@ -789,6 +789,7 @@ The key insight is that neither a CDN nor a simple reverse proxy is sufficient w
 - [AmneziaWG Linux Kernel Module](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module)
 - [AmneziaWG Tools](https://github.com/amnezia-vpn/amneziawg-tools)
 - [EDIS Global AmneziaWG Guide](https://docs.edisglobal.com/advanced-setup-guides/install-amneziawg-on-ubuntu-22_04/install-amneziawg-on-ubuntu-2204)
+- [amneziawg-installer](https://github.com/bivlked/amneziawg-installer) — Automated AmneziaWG 2.0 server installer (Ubuntu/Debian, ARM support)
 
 ---
 


### PR DESCRIPTION
## Summary

Single line added to the `## Resources` section of `making-website-accessible-from-restricted-regions/01.en.md`, linking to [amneziawg-installer](https://github.com/bivlked/amneziawg-installer).

## Context

Proposed in #1442 and approved by the tutorial author:

> @bivlked nice work, sure you can extend the docs by submitting the pr
> — @khashashin

## Disclosure

I maintain [amneziawg-installer](https://github.com/bivlked/amneziawg-installer) — an MIT-licensed Bash installer for AmneziaWG 2.0 on Ubuntu 24.04 / 25.10 and Debian 12 / 13, with arm64 prebuilts that work on Hetzner CAX ARM VPS (added in v5.9.0, released 2026-04-15). The repo is actively maintained (latest release v5.10.2, 2026-04-20), 327 stars, 33 forks, bilingual documentation (English and Russian).

## Diff

One line appended after the existing EDIS Global entry. Tutorial content, examples, and structure are unchanged.

---

I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.

Signed-off-by: Ivan Bondarev <ndt.ltd.pvl@gmail.com>
