### PR TITLE
New tutorial: Running a CrowdSec AppSec WAF with Nginx on a Hetzner Cloud server

### DIFF
--- a/tutorials/crowdsec-appsec-waf-nginx-hetzner-cloud/01.en.md
+++ b/tutorials/crowdsec-appsec-waf-nginx-hetzner-cloud/01.en.md
@@ -1,0 +1,356 @@
+---
+SPDX-License-Identifier: MIT
+path: "/tutorials/crowdsec-appsec-waf-nginx-hetzner-cloud"
+slug: "crowdsec-appsec-waf-nginx-hetzner-cloud"
+date: "2026-04-23"
+title: "Running a CrowdSec AppSec WAF with Nginx on a Hetzner Cloud server"
+short_description: "Turn a Hetzner Cloud server into a Web Application Firewall for your site using CrowdSec AppSec, Nginx, and the OWASP Core Rule Set."
+tags: ["CrowdSec", "AppSec", "WAF", "Nginx", "OWASP", "Security", "Ubuntu"]
+author: "Egemen KEYDAL"
+author_link: "https://github.com/KEYDALTR"
+author_img: "https://avatars.githubusercontent.com/u/274326765"
+author_description: "Software developer and security researcher."
+language: "en"
+available_languages: ["en"]
+header_img: "header-4"
+cta: "cloud"
+---
+
+## Introduction
+
+CrowdSec's firewall bouncers are great at blocking brute-force attackers at the IP layer, but they cannot see *inside* an HTTP request. A bot hitting your website with `/?id=1 UNION SELECT ...` is just "an IP sending traffic" to the host firewall, which means the attack goes straight through to your application until enough log lines have been generated for a scenario to fire.
+
+[CrowdSec AppSec](https://doc.crowdsec.net/docs/next/appsec/intro) is a different component of the same engine. It is an in-process Web Application Firewall (WAF): your reverse proxy forwards each request to AppSec *before* serving it, and AppSec decides whether to let the request through, block it, or trigger a CAPTCHA. AppSec ships with support for the [OWASP Core Rule Set (CRS)](https://coreruleset.org/), the de-facto open-source rule set used by ModSecurity and many commercial WAFs.
+
+In this tutorial, you turn a Hetzner Cloud server into a public WAF using:
+
+* Nginx as the reverse proxy (with the `crowdsec-nginx-bouncer` module)
+* CrowdSec as the security engine (already battle-tested for SSH and log-based protection)
+* The CrowdSec AppSec component, listening on `127.0.0.1:7422`
+* The OWASP CRS rule set, installed as inband rules so matching requests get blocked in real time
+
+By the end of the tutorial, requests containing SQL injection, XSS, path traversal, or Log4Shell payloads are answered with HTTP `403` by Nginx before ever reaching your backend application.
+
+**Prerequisites**
+
+* A Hetzner Cloud server (this tutorial was tested on a **CX22**, 2 vCPU / 4 GB RAM)
+* **Ubuntu 24.04 LTS**
+* Root access (commands in this guide use the root user; prepend `sudo` if you use a sudo account)
+* A Hetzner Cloud Firewall that allows ports 22 (SSH), 80 (HTTP), and 443 (HTTPS), or equivalent `iptables`/`nftables` rules
+* Basic familiarity with Nginx virtual hosts
+
+If you plan to put this in front of an existing web application, you can install everything on the same server as the app or on a dedicated reverse-proxy host. The latter is recommended on busy sites because CrowdSec AppSec does real per-request work.
+
+## Step 1 - Install CrowdSec
+
+Update the package index and install CrowdSec using the upstream repository script:
+
+```bash
+apt update
+apt install -y curl gnupg ca-certificates jq
+curl -sS https://install.crowdsec.net | bash
+apt install -y crowdsec
+```
+
+Verify:
+
+```bash
+cscli version
+systemctl is-active crowdsec
+```
+
+You should see a version string of `v1.7.x` or newer and `active` for the systemd unit.
+
+If you want a deeper introduction to the base CrowdSec concepts (collections, parsers, scenarios), check the existing community tutorial ["Installing and setting up CrowdSec to protect SSH"](/tutorials/how-to-set-up-crowdsec-and-protect-ssh). The rest of this tutorial focuses specifically on the AppSec component.
+
+## Step 2 - Install Nginx and the CrowdSec Nginx bouncer
+
+Install the Nginx web server and the CrowdSec Lua bouncer that hooks into it:
+
+```bash
+apt install -y nginx crowdsec-nginx-bouncer
+```
+
+The package manager pulls in the Nginx Lua module dependencies automatically. Check that Nginx is running:
+
+```bash
+systemctl is-active nginx
+nginx -v
+```
+
+At the time of writing, Ubuntu 24.04 ships Nginx 1.24.
+
+The bouncer installs two important files:
+
+* `/etc/crowdsec/bouncers/crowdsec-nginx-bouncer.conf` - bouncer configuration (API URL, API key, and AppSec settings)
+* `/etc/nginx/conf.d/crowdsec_nginx.conf` - the Lua hooks that intercept every HTTP request and check it against CrowdSec
+
+Register the bouncer was done automatically by the post-install script. Confirm the registration:
+
+```bash
+cscli bouncers list
+```
+
+You should see an entry of type `crowdsec-nginx-bouncer` with `Valid` set to `✔️`.
+
+## Step 3 - Enable the AppSec listener in CrowdSec
+
+The AppSec component is loaded as an acquisition source, just like file or journald sources. Create an acquisition file that tells CrowdSec to start an AppSec listener on `127.0.0.1:7422` using a config we will define in the next step:
+
+```bash
+cat > /etc/crowdsec/acquis.d/appsec.yaml <<'EOF'
+appsec_config: custom/crs-inband
+labels:
+  type: appsec
+listen_addr: 127.0.0.1:7422
+source: appsec
+EOF
+```
+
+Nothing will reload yet because `custom/crs-inband` does not exist. We create it in the next step.
+
+## Step 4 - Install OWASP CRS and create an inband rules config
+
+Install the AppSec base collections plus the OWASP Core Rule Set:
+
+```bash
+cscli collections install crowdsecurity/appsec-virtual-patching
+cscli collections install crowdsecurity/appsec-generic-rules
+cscli collections install crowdsecurity/appsec-crs
+```
+
+The CRS collection pulls several hundred rules covering SQL injection, cross-site scripting, local file inclusion, remote code execution, common scanner signatures, and more.
+
+The CRS collection only registers those rules as *out-of-band* by default, meaning they generate alerts but do not block the request in real time. For a WAF that stops attacks, you want the rules to run *inband*. Create a custom AppSec config:
+
+```bash
+cat > /etc/crowdsec/appsec-configs/crs-inband.yaml <<'EOF'
+name: custom/crs-inband
+default_remediation: ban
+inband_rules:
+  - crowdsecurity/base-config
+  - crowdsecurity/crs
+  - crowdsecurity/vpatch-*
+outofband_rules:
+  - crowdsecurity/appsec-generic-test
+EOF
+```
+
+* `base-config` sets sane defaults (maximum request size, required headers, ...)
+* `crowdsecurity/crs` is the whole OWASP CRS bundle
+* `vpatch-*` are virtual patches for specific CVEs (Log4Shell, ConnectWise, Fortinet, and many others)
+* The out-of-band section only keeps the generic test scenario so you can later verify the pipeline from the CrowdSec Console if you enroll the instance
+
+Restart CrowdSec so it loads the new acquisition source and config:
+
+```bash
+systemctl restart crowdsec
+sleep 3
+ss -tlnp | grep 7422
+```
+
+The last command should show that `crowdsec` is listening on `127.0.0.1:7422`. You can also tail the log to see the rule counts:
+
+```bash
+journalctl -u crowdsec --since "1 minute ago" | grep -E "inband|appsec"
+```
+
+You should see something similar to:
+
+```
+msg="Loaded 185 inband rules"   component=appsec_config
+msg="Appsec listening on 127.0.0.1:7422"
+```
+
+## Step 5 - Point the Nginx bouncer at the AppSec listener
+
+The bouncer knows how to forward requests to AppSec, but you need to tell it where to go. Edit `/etc/crowdsec/bouncers/crowdsec-nginx-bouncer.conf`:
+
+```bash
+sed -i 's|^APPSEC_URL=.*|APPSEC_URL=http://127.0.0.1:7422|' \
+  /etc/crowdsec/bouncers/crowdsec-nginx-bouncer.conf
+sed -i 's|^ALWAYS_SEND_TO_APPSEC=.*|ALWAYS_SEND_TO_APPSEC=true|' \
+  /etc/crowdsec/bouncers/crowdsec-nginx-bouncer.conf
+grep -E '^APPSEC|^ALWAYS_SEND' \
+  /etc/crowdsec/bouncers/crowdsec-nginx-bouncer.conf
+```
+
+`APPSEC_URL` points to the listener you started in Step 4. `ALWAYS_SEND_TO_APPSEC=true` forces the bouncer to consult AppSec on every request while you are testing. On a production server with heavy traffic you can set it back to `false` later, in which case the bouncer only forwards requests coming from IPs that are already suspicious according to other CrowdSec scenarios.
+
+The bouncer is an `init_by_lua` module, so Nginx must be *restarted* (not just reloaded) to reinitialize the Lua VM:
+
+```bash
+systemctl restart nginx
+tail -5 /var/log/nginx/error.log
+```
+
+You should see a line similar to:
+
+```
+[lua] crowdsec.lua:229: init(): APPSEC is enabled on '127.0.0.1:7422'
+[Crowdsec] Initialisation done
+```
+
+## Step 6 - Verify the WAF with simulated attacks
+
+The default Nginx site on Ubuntu serves `/var/www/html/index.nginx-debian.html` on port 80. Send it a handful of requests containing payloads that the OWASP CRS should detect. Replace `<SERVER_IP>` with your server's public IPv4 address:
+
+```bash
+SERVER=http://<SERVER_IP>
+
+# A harmless request - should return 200
+curl -sS -o /dev/null -w "normal:    HTTP %{http_code}\n" "$SERVER/"
+
+# SQL injection - should return 403
+curl -sS -o /dev/null -w "sqli:      HTTP %{http_code}\n" \
+  "$SERVER/?id=1+UNION+SELECT+1,2,3--"
+
+# Cross-site scripting - should return 403
+curl -sS -o /dev/null -w "xss:       HTTP %{http_code}\n" \
+  "$SERVER/?q=%3Cscript%3Ealert(1)%3C/script%3E"
+
+# Path traversal / local file inclusion - should return 403
+curl -sS -o /dev/null -w "traversal: HTTP %{http_code}\n" \
+  "$SERVER/?f=../../etc/passwd"
+
+# Log4Shell (CVE-2021-44228) payload - should return 403
+curl -sS -o /dev/null -w "log4shell: HTTP %{http_code}\n" \
+  "$SERVER/?x=%24%7Bjndi%3Aldap%3A//x/y%7D"
+```
+
+The expected output is:
+
+```
+normal:    HTTP 200
+sqli:      HTTP 403
+xss:       HTTP 403
+traversal: HTTP 403
+log4shell: HTTP 403
+```
+
+Every blocked request matches one or more CRS rules on the server side. If you run the tests from a public IP, CrowdSec writes an alert with the anomaly score per category (`sql_injection`, `xss`, `lfi`, `rce`) visible via `cscli alerts list`.
+
+## Step 7 - Observe metrics and triggered rules
+
+CrowdSec exposes a rich set of metrics through `cscli`. The AppSec section shows how many requests were processed, how many were blocked, and which rules fired:
+
+```bash
+cscli metrics
+```
+
+Look for the following tables in the output:
+
+* **Appsec Metrics** - processed / blocked counters per listener
+* **Appsec 'listener/' Rules Metrics** - the CRS rule IDs that were triggered (for example `942100` for SQL injection, `941100` for XSS, `930100` for path traversal)
+* **Local API Alerts** - one line per anomaly-score block, including the attack category
+
+You can also list the alerts directly:
+
+```bash
+cscli alerts list
+```
+
+Each entry includes the client IP, the country, the AS, the triggered categories, and the anomaly score. The default CRS anomaly threshold is 5 for a single request, but you can tune it per category if you see false positives.
+
+## Step 8 - Reduce false positives with CRS exclusion plugins
+
+The OWASP CRS is intentionally strict. A vanilla WordPress admin or a Nextcloud sharing URL will trigger some of the rules even though the request is legitimate. CrowdSec ships a set of "exclusion plugin" collections that disable only the CRS rules that are known to produce false positives for a given application. They are pre-built from the upstream CRS plugin repository.
+
+Install the ones that match the applications on your server:
+
+```bash
+# WordPress
+cscli collections install crowdsecurity/appsec-crs-exclusion-plugin-wordpress
+
+# Nextcloud
+cscli collections install crowdsecurity/appsec-crs-exclusion-plugin-nextcloud
+
+# phpMyAdmin
+cscli collections install crowdsecurity/appsec-crs-exclusion-plugin-phpmyadmin
+```
+
+Other available plugins include Drupal, phpBB, XenForo, DokuWiki, and cPanel. Add the plugin as an `inband_rules` entry in your `custom/crs-inband.yaml` and restart CrowdSec:
+
+```yaml
+inband_rules:
+  - crowdsecurity/base-config
+  - crowdsecurity/crs
+  - crowdsecurity/crs-exclusion-plugin-wordpress
+  - crowdsecurity/vpatch-*
+```
+
+```bash
+systemctl restart crowdsec
+```
+
+For your own web application, the simplest path is usually to put AppSec in "detection-only" mode at first, let it run on real traffic for a few days with `ALWAYS_SEND_TO_APPSEC=true` and `default_remediation: allow`, review the alerts in `cscli alerts list`, and only switch back to `default_remediation: ban` once the false positives are understood.
+
+## Step 9 - Operations and next steps
+
+A few commands cover most of the operational work around the WAF:
+
+```bash
+# Rule triggers and global numbers
+cscli metrics
+
+# Most recent blocks (top = newest)
+cscli alerts list --limit 20
+
+# Details for a single alert (including the exact request body and the rules it hit)
+cscli alerts inspect <ALERT_ID>
+
+# Restart both pieces after a config change
+systemctl restart crowdsec
+systemctl restart nginx
+
+# Keep the rules and AppSec plugins up to date
+cscli hub update && cscli hub upgrade
+systemctl restart crowdsec
+```
+
+Two natural next steps:
+
+* Put Nginx behind HTTPS with [Let's Encrypt via acme.sh](/tutorials/automating-ssl-certificates-with-acmesh-dns) and add a proper `server_name` block for your domain.
+* Add the `crowdsec-firewall-bouncer-nftables` package so that repeated offenders are also blocked at the host firewall layer, not just at the HTTP layer. Once they accumulate enough AppSec alerts, CrowdSec will create a `ban` decision and the firewall bouncer will drop their packets for four hours by default.
+
+## Conclusion
+
+Your Hetzner Cloud server is now running a proper application-layer firewall:
+
+* Nginx handles every inbound HTTP request.
+* The `crowdsec-nginx-bouncer` sends each request to CrowdSec AppSec before passing it to the upstream application.
+* CrowdSec AppSec evaluates the request against the OWASP Core Rule Set and virtual patches, blocks matches with HTTP `403`, and stores the event for observability.
+* The same CrowdSec agent still protects the SSH service and anything else whose logs it parses, and it can correlate WAF events with IP-level brute-force behavior.
+
+Compared with legacy WAF stacks based on ModSecurity, this setup stays entirely on Hetzner Cloud, requires no external SaaS subscription, and benefits from CrowdSec's community threat intelligence feed if you enroll the instance at [app.crowdsec.net](https://app.crowdsec.net/).
+
+##### License: MIT
+
+<!--
+
+Contributor's Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it under the license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate license and I have the
+    right under that license to submit that work with modifications,
+    whether created in whole or in part by me, under the same license
+    (unless I am permitted to submit under a different license), as
+    indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are
+    public and that a record of the contribution (including all personal
+    information I submit with it, including my sign-off) is maintained
+    indefinitely and may be redistributed consistent with this project
+    or the license(s) involved.
+
+Signed-off-by: Egemen KEYDAL <egemenkeydaltr@gmail.com>
+
+-->

--- a/tutorials/crowdsec-appsec-waf-nginx-hetzner-cloud/01.en.md
+++ b/tutorials/crowdsec-appsec-waf-nginx-hetzner-cloud/01.en.md
@@ -2,9 +2,9 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/crowdsec-appsec-waf-nginx-hetzner-cloud"
 slug: "crowdsec-appsec-waf-nginx-hetzner-cloud"
-date: "2026-04-23"
-title: "Running a CrowdSec AppSec WAF with Nginx on a Hetzner Cloud server"
-short_description: "Turn a Hetzner Cloud server into a Web Application Firewall for your site using CrowdSec AppSec, Nginx, and the OWASP Core Rule Set."
+date: "2026-04-27"
+title: "Running a CrowdSec AppSec WAF with Nginx"
+short_description: "Turn a server into a Web Application Firewall for your site using CrowdSec AppSec, Nginx, and the OWASP Core Rule Set."
 tags: ["CrowdSec", "AppSec", "WAF", "Nginx", "OWASP", "Security", "Ubuntu"]
 author: "Egemen KEYDAL"
 author_link: "https://github.com/KEYDALTR"
@@ -22,7 +22,7 @@ CrowdSec's firewall bouncers are great at blocking brute-force attackers at the 
 
 [CrowdSec AppSec](https://doc.crowdsec.net/docs/next/appsec/intro) is a different component of the same engine. It is an in-process Web Application Firewall (WAF): your reverse proxy forwards each request to AppSec *before* serving it, and AppSec decides whether to let the request through, block it, or trigger a CAPTCHA. AppSec ships with support for the [OWASP Core Rule Set (CRS)](https://coreruleset.org/), the de-facto open-source rule set used by ModSecurity and many commercial WAFs.
 
-In this tutorial, you turn a Hetzner Cloud server into a public WAF using:
+In this tutorial, you turn a server into a public WAF using:
 
 * Nginx as the reverse proxy (with the `crowdsec-nginx-bouncer` module)
 * CrowdSec as the security engine (already battle-tested for SSH and log-based protection)
@@ -33,10 +33,11 @@ By the end of the tutorial, requests containing SQL injection, XSS, path travers
 
 **Prerequisites**
 
-* A Hetzner Cloud server (this tutorial was tested on a **CX22**, 2 vCPU / 4 GB RAM)
+* A server (this tutorial was tested on the Hetzner cloud server **CX23**, 2 vCPU / 4 GB RAM)
 * **Ubuntu 24.04 LTS**
 * Root access (commands in this guide use the root user; prepend `sudo` if you use a sudo account)
-* A Hetzner Cloud Firewall that allows ports 22 (SSH), 80 (HTTP), and 443 (HTTPS), or equivalent `iptables`/`nftables` rules
+* A firewall (e.g. Hetzner Cloud Firewall, or `iptables`/`nftables`) that allows ports:  
+  22 (SSH) · 80 (HTTP) · 443 (HTTPS)
 * Basic familiarity with Nginx virtual hosts
 
 If you plan to put this in front of an existing web application, you can install everything on the same server as the app or on a dedicated reverse-proxy host. The latter is recommended on busy sites because CrowdSec AppSec does real per-request work.
@@ -315,7 +316,7 @@ Two natural next steps:
 
 ## Conclusion
 
-Your Hetzner Cloud server is now running a proper application-layer firewall:
+Your server is now running a proper application-layer firewall:
 
 * Nginx handles every inbound HTTP request.
 * The `crowdsec-nginx-bouncer` sends each request to CrowdSec AppSec before passing it to the upstream application.


### PR DESCRIPTION
## Summary

This PR adds a new English-language tutorial, `crowdsec-appsec-waf-nginx-hetzner-cloud`, that shows how to set up **CrowdSec AppSec** as a Web Application Firewall in front of **Nginx** on a Hetzner Cloud CX22 running **Ubuntu 24.04 LTS**, using the **OWASP Core Rule Set (CRS)** for inband blocking of SQLi, XSS, LFI, RCE, and Log4Shell payloads.

## Why this tutorial

The repository currently has one tutorial dedicated to CrowdSec — [`how-to-set-up-crowdsec-and-protect-ssh`](https://github.com/hetzneronline/community-content/tree/master/tutorials/how-to-set-up-crowdsec-and-protect-ssh) — which covers the log-based firewall bouncer for SSH. It does not cover the AppSec (WAF) component, which is a separate part of the CrowdSec stack that works at the HTTP layer instead of the IP layer. The Coolify-specific CrowdSec tutorials in the repo also do not cover standalone Nginx + AppSec.

This tutorial complements the existing SSH-focused content by walking through:

- Installing Nginx and the `crowdsec-nginx-bouncer`
- Enabling the AppSec listener (`127.0.0.1:7422`)
- Installing the OWASP CRS collection and creating an **inband** AppSec config (the default CRS config in the CrowdSec hub only registers rules as out-of-band, which does not block requests in real time — the tutorial explains this)
- Wiring the bouncer's `APPSEC_URL` and `ALWAYS_SEND_TO_APPSEC` to the listener
- Verifying with SQLi / XSS / path traversal / Log4Shell payloads that actually return `HTTP 403`
- Reading `cscli metrics` to see which CRS rule IDs fired
- Reducing false positives with the CRS exclusion plugins (WordPress, Nextcloud, phpMyAdmin, …)

## Testing

Every command in the tutorial was executed end-to-end on a fresh Hetzner Cloud **CX22** running **Ubuntu 24.04.3 LTS**. The verification section in Step 6 reports the exact HTTP codes observed during the test run (`normal: 200`, `sqli/xss/traversal/log4shell: 403`). `cscli metrics` and `cscli alerts list` outputs match the expected CRS anomaly-score block behaviour.

## Files added

```
tutorials/crowdsec-appsec-waf-nginx-hetzner-cloud/01.en.md
```

~2150 words, one language (English). Frontmatter follows the repository template. No images are used.

## DCO

I have read and understood the Contributor's Certificate of Origin available at the end of https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md and I hereby certify that I meet the contribution criteria described in it.

Signed-off-by: Egemen KEYDAL <egemenkeydaltr@gmail.com>