### PR TITLE
Add AmneziaWG VPN tutorial for CAX ARM

### DIFF
--- a/tutorials/self-host-dpi-resistant-vpn-on-hetzner-cax-arm/01.en.md
+++ b/tutorials/self-host-dpi-resistant-vpn-on-hetzner-cax-arm/01.en.md
@@ -1,0 +1,294 @@
+---
+SPDX-License-Identifier: MIT
+path: "/tutorials/self-host-dpi-resistant-vpn-on-hetzner-cax-arm"
+slug: "self-host-dpi-resistant-vpn-on-hetzner-cax-arm"
+date: "2026-05-05"
+title: "Self-Host a DPI-Resistant VPN on Hetzner CAX ARM"
+short_description: "Set up a personal AmneziaWG 2.0 VPN server on a Hetzner CAX ARM in around ten minutes — designed to resist DPI that fingerprints plain WireGuard."
+tags: ["VPN", "AmneziaWG", "WireGuard", "ARM", "Self-hosted", "Privacy"]
+author: "Ivan Bondarev"
+author_link: "https://github.com/bivlked"
+author_img: "https://avatars.githubusercontent.com/u/50226185"
+author_description: "Self-hosted VPN infrastructure engineer. Maintainer of amneziawg-installer."
+language: "en"
+available_languages: ["en"]
+header_img: "header-x"
+cta: "product"
+---
+
+## Introduction
+
+If you have tried to use a self-hosted WireGuard VPN from Russia, Iran, China, or several other countries with state-level network filtering, you have probably watched it stop working without warning. Modern Deep Packet Inspection systems fingerprint WireGuard's distinctive 148-byte handshake and silently drop the traffic — the connection appears to establish, but no data flows through.
+
+[AmneziaWG](https://docs.amnezia.org/documentation/amnezia-wg/) is a fork of WireGuard designed to resist that fingerprinting. It randomizes packet sizes, replaces magic headers with per-install random values, and prepends decoy traffic patterns that look like common UDP protocols. To DPI systems that look for plain WireGuard, traffic from an AmneziaWG tunnel is no longer recognizable.
+
+This tutorial walks you through running an AmneziaWG 2.0 VPN server on Hetzner's ARM-based CAX servers using [amneziawg-installer](https://github.com/bivlked/amneziawg-installer), an automation script I maintain. By the end you will have a working personal VPN, two ready-to-use client configurations with QR codes, and a CLI for managing additional clients.
+
+A `CAX11` (around four euro per month) is sufficient for one to fifty active clients. The installer takes care of installing the AmneziaWG kernel module, randomizing the obfuscation parameters, and hardening the system.
+
+If your goal is making a hosted **website** accessible from restricted regions rather than tunnelling individual end-user devices, see [Yusuf Khasbulatov's companion tutorial](https://community.hetzner.com/tutorials/making-website-accessible-from-restricted-regions) — different architecture, different use case.
+
+**Prerequisites**
+
+- A Hetzner Cloud account and an [SSH key](https://community.hetzner.com/tutorials/howto-ssh-key) added to your project
+- Basic SSH and Linux command-line knowledge
+- A few minutes for two automatic reboots during installation
+
+**Example terminology**
+
+In this tutorial I use the placeholders below in line with the [Hetzner tutorial conventions](https://github.com/hetzneronline/community-content/blob/master/tutorial-template.md):
+
+- Username on the server: `root` (only used during initial setup)
+- Hostname: `<your_host>` (for example `awg-vpn`)
+- Server public IPv4: `<10.0.0.1>`
+- VPN tunnel subnet (installer default): `10.9.9.0/24`, where `10.9.9.1` is the server and `10.9.9.2` and onwards are clients
+
+## Step 1 - Create the Hetzner CAX server
+
+Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud/), open or create a project, and click **Add Server**.
+
+Fill in the form as follows:
+
+| Field          | Value                                                                                       |
+|----------------|---------------------------------------------------------------------------------------------|
+| Location       | Any EU location works — Falkenstein, Nuremberg, or Helsinki give you the best latency from European clients |
+| Image          | Ubuntu 24.04                                                                                |
+| Type           | **Shared vCPU** → tab **Arm64 (Ampere)** → **CAX11** (2 vCPU / 4 GB RAM / 40 GB SSD)        |
+| Networking     | Public IPv4 and Public IPv6 enabled                                                         |
+| SSH keys       | Select your previously uploaded key                                                         |
+| Volumes / Firewalls / Backups | Leave empty — the installer configures UFW for you                           |
+| Name           | `<your_host>` (any name you like)                                                           |
+
+Click **Create & Buy now**. After roughly thirty seconds the server is provisioned and you have a public IPv4 address (referred to below as `<10.0.0.1>`).
+
+> If you also enable a Hetzner Cloud Firewall in the console (separate from the OS-level UFW), remember to allow inbound `UDP/39743` there too — otherwise it will silently drop AmneziaWG handshake packets before they reach the server.
+
+> **Why CAX11?** AmneziaWG runs as a Linux kernel module. On ARM64 Ampere CPUs the installer ships a prebuilt kernel module package and falls back to a DKMS rebuild only if the prebuilt does not match your running kernel. The 2 vCPU and 4 GB RAM are comfortable for one to fifty active clients; bump up to `CAX21` if you plan more.
+
+## Step 2 - Connect and prepare
+
+SSH into the new server:
+
+```bash
+ssh root@<10.0.0.1>
+```
+
+Update the system before installing anything else:
+
+```bash
+apt update && apt upgrade -y
+```
+
+If `apt` shows the daemon-restart prompt, accept the defaults. If a kernel package was upgraded, reboot once before continuing — this keeps the running kernel and the headers in sync, which the next step depends on:
+
+```bash
+reboot
+```
+
+Wait about thirty seconds and reconnect with the same `ssh` command.
+
+## Step 3 - Run the amneziawg-installer
+
+`amneziawg-installer` takes care of the things that are easy to get wrong by hand: installing the AmneziaWG kernel module (prebuilt on ARM64 with a DKMS fallback), generating per-install random values for the H1-H4 obfuscation parameters (so every server you install has a different signature), setting up UFW with the right rules, configuring Fail2Ban, and creating two ready-to-use clients (`my_phone` and `my_laptop`) with `.conf`, `.png`, `.vpnuri`, and `.vpnuri.png` files.
+
+Download and run the installer in non-interactive mode:
+
+```bash
+wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/main/install_amneziawg_en.sh
+chmod +x install_amneziawg_en.sh
+sudo bash install_amneziawg_en.sh --route-all --disallow-ipv6 --yes
+```
+
+The flags above pick the defaults that work for almost everyone:
+
+- `--route-all` — all client traffic goes through the VPN (the typical choice for a personal VPN)
+- `--disallow-ipv6` — keeps the tunnel IPv4-only, which avoids surprises with leaked IPv6 traffic
+- `--yes` — auto-confirms the two reboots the installer needs
+
+The script runs in three phases separated by two automatic reboots:
+
+1. **Phase 1** (around one minute) — system update, base packages, sysctl hardening
+2. *Reboot — wait around thirty seconds and reconnect*
+3. **Phase 2** (around three to ten minutes on `CAX11`, depending on whether the kernel module is pulled prebuilt or built locally) — PPA setup, AmneziaWG package install, kernel module load
+4. *Reboot — wait around thirty seconds and reconnect*
+5. **Phase 3** (under a minute) — UFW rules, server config, default client generation, service start
+
+After each reboot, run the same `bash install_amneziawg_en.sh ...` command again. The installer keeps state in `/root/awg/setup_state` and resumes from the right phase automatically. End-to-end the whole installation takes around five to fifteen minutes on `CAX11`, with most of the variance coming from package mirrors and kernel-headers download speed.
+
+When the installer finishes you should see something close to this:
+
+```text
+=== Installation complete ===
+Server endpoint: <10.0.0.1>:39743
+Default clients created: my_phone, my_laptop
+Client configs: /root/awg/<name>.conf
+QR codes:       /root/awg/<name>.png
+vpn:// URIs:    /root/awg/<name>.vpnuri (text), /root/awg/<name>.vpnuri.png (QR)
+Service:        awg-quick@awg0 (active)
+```
+
+> **What just happened?** Behind the scenes the installer added the `ppa:amnezia/ppa` repository, installed the AmneziaWG kernel module package, generated random H1-H4 ranges and S1-S4 padding for obfuscation, created two pairs of WireGuard keys, generated a `/etc/amnezia/amneziawg/awg0.conf`, opened UDP port 39743 in UFW, set up rate-limited SSH, and started the `awg-quick@awg0` service.
+
+## Step 4 - Get the client config
+
+Each default client has four files in `/root/awg/`:
+
+| File                      | Purpose                                                         | Used by                                |
+|---------------------------|-----------------------------------------------------------------|----------------------------------------|
+| `<name>.conf`             | AmneziaWG-format text config                                    | `awg-quick` CLI on Linux               |
+| `<name>.png`              | QR code with the same `.conf` content                           | Amnezia VPN mobile / desktop apps      |
+| `<name>.vpnuri`           | `vpn://` URI as text (URL-style, single line)                   | Manual paste into the Amnezia VPN app  |
+| `<name>.vpnuri.png`       | QR code for the `vpn://` URI                                    | One-tap QR scan in the Amnezia VPN app |
+
+> **Note:** The `.conf` files generated by this installer use AmneziaWG 2.0 fields (`Jc`, `Jmin`, `Jmax`, `S1`-`S4`, `H1`-`H4`, `I1`). The standard upstream WireGuard client (`wg-quick` from `wireguard-tools`, the iOS/Android *WireGuard* app, the official desktop *WireGuard* clients) does not understand these fields and will refuse the config. Use the [Amnezia VPN](https://amnezia.org/downloads) app on phones/desktops, or `awg-quick` from the `amneziawg` package on Linux.
+
+The simplest way to get a client config onto your phone is to print the QR code in the terminal and scan it directly:
+
+```bash
+manage_amneziawg.sh show my_phone
+```
+
+This prints the endpoint info plus both QR codes side-by-side in the terminal — first the `.conf` QR, then the `vpn://` URI QR. If your terminal is too small for the QR codes to scan reliably, copy the `.png` files to your local machine instead:
+
+```bash
+scp root@<10.0.0.1>:/root/awg/my_phone.vpnuri.png ./
+```
+
+Then open the image and scan from your phone.
+
+## Step 5 - Connect from your device
+
+You have two options for the client side, depending on the platform:
+
+### Mobile and desktop - Amnezia VPN app (recommended)
+
+1. Install [Amnezia VPN](https://amnezia.org/downloads) from Google Play, the App Store, or the official site (also available for Windows, macOS, and Linux desktops)
+2. Open the app, tap the **+** button, choose **Scan QR**, and scan the `<name>.vpnuri.png` QR
+3. The configuration is imported automatically; tap to connect
+
+This is the recommended graphical and mobile client. It supports the full AmneziaWG 2.0 feature set — including the `I1` CPS concealment parameter that aggressive mobile-carrier DPI tends to look for. On Linux, the `awg-quick` CLI option below covers the same parameter set without a GUI.
+
+### Linux from the command line
+
+On a Linux client (laptop, server, router) install the `amneziawg` package from the same PPA the server uses, then drop the `.conf` in place:
+
+```bash
+sudo add-apt-repository ppa:amnezia/ppa
+sudo apt update
+sudo apt install -y amneziawg
+scp root@<10.0.0.1>:/root/awg/my_laptop.conf ./
+sudo cp my_laptop.conf /etc/amnezia/amneziawg/awg-client.conf
+sudo awg-quick up awg-client
+```
+
+`awg-quick` is the AmneziaWG-aware sibling of WireGuard's `wg-quick` and ships in the same package as the server-side AmneziaWG tools.
+
+### Verify the connection
+
+From your client device with the VPN active:
+
+- Open <https://check-host.net/ip-info> — the IP shown should be your server's IP, not your home/mobile IP
+- Open <https://www.dnsleaktest.com/> — the DNS resolver should resolve via the server's network, not your local ISP
+
+On the server side:
+
+```bash
+manage_amneziawg.sh check
+```
+
+prints whether the service is up, lists active peers, and shows the latest handshake timestamp for each client.
+
+## Step 6 - Add more clients
+
+Adding clients is one command:
+
+```bash
+manage_amneziawg.sh add alice
+```
+
+Multiple clients in a single command are also supported:
+
+```bash
+manage_amneziawg.sh add bob carol dave
+```
+
+Other common operations:
+
+```bash
+manage_amneziawg.sh list                     # show all clients with their tunnel IPs
+manage_amneziawg.sh show alice               # re-print Alice's QR codes
+manage_amneziawg.sh remove bob               # revoke Bob, drop him from the live tunnel
+manage_amneziawg.sh add temp --expires=7d    # auto-revoke after seven days (cron handles cleanup)
+manage_amneziawg.sh stats                    # bytes sent/received per client
+```
+
+The live tunnel stays up while you add or remove clients — connected peers are not interrupted.
+
+## Step 7 - Operating notes
+
+A few things worth knowing once your VPN is in regular use.
+
+**Backups.** The CLI bundles all configs and keys into a tarball:
+
+```bash
+manage_amneziawg.sh backup
+# outputs: /root/awg/awg_backup_2026-05-05_10-30-00.000.tar.gz
+```
+
+Copy the tarball off-server. Restore on a new server with:
+
+```bash
+manage_amneziawg.sh restore /path/to/awg_backup_<timestamp>.tar.gz
+```
+
+**Logs.** The service journal is at `journalctl -u awg-quick@awg0`. Management-command activity is logged to `/root/awg/manage_amneziawg.log`.
+
+**Updates.** When a new installer version is released, re-download `install_amneziawg_en.sh` and run it again. It pulls fresh `manage_amneziawg.sh` and `awg_common.sh` (with SHA256 verification) without touching the existing server config or any of your clients.
+
+**Kernel upgrades.** The AmneziaWG kernel module is kept in sync with new kernels automatically (prebuilt package or DKMS rebuild, whichever applies). If for some reason the module is missing after a reboot, run `manage_amneziawg.sh repair-module` to rebuild it on demand.
+
+**Firewall.** UFW is configured to deny all incoming traffic except SSH (rate-limited) and the AmneziaWG UDP port (`39743` by default). If you also enable a Hetzner Cloud Firewall in the console, mirror the same rule there.
+
+**Uninstall.** If you want to remove the VPN cleanly:
+
+```bash
+sudo bash install_amneziawg_en.sh --uninstall
+```
+
+## Step 8 - Cost
+
+Hetzner CAX pricing scales as follows:
+
+| Server  | vCPU / RAM / Disk    | Monthly cost              | Suggested client count   |
+|---------|----------------------|---------------------------|--------------------------|
+| `CAX11` | 2 / 4 GB / 40 GB     | around four euro per month | 1-50 active clients     |
+| `CAX21` | 4 / 8 GB / 80 GB     | around seven euro per month | 50-150 active clients  |
+| `CAX31` | 8 / 16 GB / 160 GB   | around fourteen euro per month | high-throughput, small team |
+
+All CAX servers include 20 TB of outgoing traffic per month. AmneziaWG's kernel-module implementation runs natively on ARM64, so you do not pay a userspace performance penalty.
+
+If you only need the VPN occasionally — for example during travel — Hetzner's hourly billing means a `CAX11` running for a few hours costs a few cents.
+
+## Conclusion
+
+You now have a personal VPN that:
+
+- Tunnels traffic in a form that is not recognizable as plain WireGuard to common DPI systems
+- Costs around four euro per month (or a few cents per hour of actual use)
+- Runs on hardware you control, in a jurisdiction you choose
+- Imports onto the Amnezia VPN app with a QR scan
+- Lets you add, remove, or expire clients with a single command
+
+If your needs grow beyond a single VPN — for example, you also want to make a hosted website accessible from restricted regions — see the [companion tutorial by Yusuf Khasbulatov](https://community.hetzner.com/tutorials/making-website-accessible-from-restricted-regions), which solves a related but different problem with a reverse-proxy + AmneziaWG-tunnel architecture.
+
+For deeper customization (mobile-carrier specific obfuscation presets, traffic-limit per client, custom routing) see [`ADVANCED.en.md`](https://github.com/bivlked/amneziawg-installer/blob/main/ADVANCED.en.md) in the installer repository.
+
+## Resources
+
+- [amneziawg-installer GitHub](https://github.com/bivlked/amneziawg-installer) — the installer used in this tutorial
+- [AmneziaVPN Project](https://amnezia.org/) — creators of AmneziaWG, including the recommended client app
+- [AmneziaWG Protocol Documentation](https://docs.amnezia.org/documentation/amnezia-wg/) — protocol-level details
+- [Making Your Website Accessible from Restricted Regions](https://community.hetzner.com/tutorials/making-website-accessible-from-restricted-regions) — companion tutorial for the website-hosting use case
+- [Hetzner SSH key tutorial](https://community.hetzner.com/tutorials/howto-ssh-key) — if you need to set up your SSH key first
+
+##### License: MIT


### PR DESCRIPTION
## Summary

Adds a new tutorial `tutorials/self-host-dpi-resistant-vpn-on-hetzner-cax-arm/01.en.md` covering how to set up a personal AmneziaWG 2.0 VPN server on a Hetzner CAX ARM cloud server using `amneziawg-installer`.

## Affiliation disclosure

I am the author and maintainer of [amneziawg-installer](https://github.com/bivlked/amneziawg-installer), the open-source Bash installer used in this tutorial (MIT-licensed). The installer is the core of the walkthrough; the rest of the tutorial is Hetzner-specific guidance (Cloud Console fields, Cloud Firewall note, ARM `aarch64` specifics, Hetzner CAX pricing tier mapping).

## Scope

End-user use case: someone in a network where plain WireGuard is fingerprinted and dropped wants to run their own VPN endpoint on a small ARM server in the EU and connect their phone or laptop to it. The tutorial walks through:

- Creating a `CAX11` ARM server with Ubuntu 24.04
- Running the `amneziawg-installer` script in non-interactive mode
- Importing the generated client config into the Amnezia VPN app or `awg-quick`
- Adding/removing/expiring additional clients via the management CLI
- Backup, logs, kernel-upgrade behaviour, uninstall

Total length around eight to twelve minutes of reading.

## Relationship to the existing AmneziaWG tutorial

@khashashin's [Making Your Website Accessible from Restricted Regions](https://community.hetzner.com/tutorials/making-website-accessible-from-restricted-regions) (Feb 2026) covers a different use case — a website operator on Hetzner who needs to serve users in DPI-throttled regions through a reverse-proxy + AmneziaWG tunnel between two servers. My tutorial is a single-server personal-VPN scenario.

The two tutorials are explicitly cross-linked in both directions: this one points readers with a website-hosting need to @khashashin's tutorial in the introduction and the conclusion; @khashashin's tutorial already references `amneziawg-installer` in its Resources section after [PR #1443](https://github.com/hetzneronline/community-content/pull/1443) was merged on 2026-04-27.

## Pre-submission checks

- Frontmatter follows tutorial-template.md (YAML between `---`, all required fields populated, `short_description` 145 chars under the 160-char limit)
- Hetzner placeholder terminology used (`<10.0.0.1>`, `<your_host>`, no real IPs from the test box)
- License: MIT (matches repo standard)
- All technical claims verified against `amneziawg-installer` v5.11.4 release behaviour

## Credit attribution

A heads-up for the Hetzner Community tutorial credit: my Hetzner account is registered under `ivan@bondarev.net`, which is different from the commit author email visible on GitHub. Please attach the credit to the `ivan@bondarev.net` account if accepted.

## What I am asking for

A review for fit and any required changes before merge. Happy to revise:
- Tone, length, or structure
- Header image choice (currently `header-x` placeholder per template — I do not have a strong preference)
- CTA value (currently `product`; can change to `cloud` or other if more appropriate)
- Any factual or formatting issue you notice
