### PR TITLE
Update existing tutorial for AmneziaWG 2.0 (CPS / I1-I5)

### DIFF
--- a/tutorials/making-website-accessible-from-restricted-regions/01.en.md
+++ b/tutorials/making-website-accessible-from-restricted-regions/01.en.md
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/making-website-accessible-from-restricted-regions"
 slug: "making-website-accessible-from-restricted-regions"
-date: "2026-05-15"
+date: "2026-02-27"
 title: "Making Your Website Accessible from Restricted Regions"
 short_description: "A Complete Guide to Bypassing ISP-Level Throttling with a Reverse Proxy and AmneziaWG Tunnel."
 tags: ["reverse proxy", "amneziagw", "tunnel", "bypassing throttling", "ISP-level throttling", "restricted regions", "network optimization"]
@@ -131,7 +131,7 @@ ORIGIN_IP=123.123.123.123
 
 Then create the config file:
 ```bash
-cat > /etc/nginx/sites-available/your-site << EOF
+sudo tee /etc/nginx/sites-available/your-site > /dev/null << EOF
 server {
     listen 80;
     server_name ${DOMAIN};

--- a/tutorials/making-website-accessible-from-restricted-regions/01.en.md
+++ b/tutorials/making-website-accessible-from-restricted-regions/01.en.md
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/making-website-accessible-from-restricted-regions"
 slug: "making-website-accessible-from-restricted-regions"
-date: "2026-02-27"
+date: "2026-05-15"
 title: "Making Your Website Accessible from Restricted Regions"
 short_description: "A Complete Guide to Bypassing ISP-Level Throttling with a Reverse Proxy and AmneziaWG Tunnel."
 tags: ["reverse proxy", "amneziagw", "tunnel", "bypassing throttling", "ISP-level throttling", "restricted regions", "network optimization"]
@@ -32,27 +32,27 @@ The architecture that actually works:
 
 ```
 ┌──────────────┐         ┌──────────────────┐          ┌──────────────────┐
-│  User in     │  HTTPS  │  In-Region VPS   │  AWG     │  Your Origin     │
-│  restricted  │────────▶│  (Nginx reverse  │─tunnel─▶│  Server          │
-│  region      │         │   proxy)         │  (UDP)   │  (e.g. Hetzner)  │
+│  User in     │  HTTPS  │  In-Region VPS   │   AWG    │  Your Origin     │
+│  restricted  │────────>│  (Nginx reverse  │──tunnel─>│  Server          │
+│  region      │         │   proxy)         │   (UDP)  │  (e.g. Hetzner)  │
 └──────────────┘         └──────────────────┘          └──────────────────┘
       No DPI issues            │                            │
       (domestic traffic)       │    Encrypted tunnel        │
-                               │    disguised as QUIC       │
+                               │    disguised as SIP/TLS    │
                                │    DPI can't inspect       │
 ```
 
 **Why this works:**
 
 1. **User → In-Region VPS:** Domestic traffic within the same country — no throttling
-2. **In-Region VPS → Your origin:** Traffic flows through an AmneziaWG tunnel on UDP port 443, which looks like QUIC (HTTP/3) to DPI systems. The DPI can't identify the destination or inspect the content
+2. **In-Region VPS → Your origin:** Traffic flows through an AmneziaWG 2.0 tunnel on UDP port 443. The CPS (Custom Protocol Signature) parameters disguise the handshake as a real protocol session — SIP, TLS, HTTP, depending on which cycle you pick. The DPI can't identify the destination or inspect the content
 3. **Completely transparent** — your users don't need to install anything or change any settings
 
 <br>
 
 | What is AmneziaWG?  |
 | ------------------- |
-| [AmneziaWG](https://docs.amnezia.org/documentation/amnezia-wg/) is a fork of WireGuard that adds DPI-resistant obfuscation. It modifies packet headers, randomizes handshake sizes, and can disguise traffic as common UDP protocols like QUIC. It was built specifically to defeat sophisticated DPI systems.<br><br>Key parameters:<br><ul><li><b>Jc, Jmin, Jmax</b> — Sends junk packets before the handshake to blur the traffic pattern</li><li><b>S1, S2</b> — Adds random data to handshake packets, changing their recognizable size</li><li><b>H1-H4</b> — Replaces WireGuard's well-known magic headers with random values</li><li><b>I1</b> — <b>(Critical)</b> Prepends a real protocol signature (e.g., a QUIC Initial packet) to the handshake. Without this, sophisticated DPI still detects and kills the tunnel within seconds</li></ul> |
+| [AmneziaWG](https://docs.amnezia.org/documentation/amnezia-wg/) is a fork of WireGuard that adds DPI-resistant obfuscation. It modifies packet headers, randomizes handshake sizes, and can disguise traffic as common protocols. This guide uses [**AmneziaWG 2.0**](https://amnezia.org/blog/amneziawg-2-0-available-for-self-hosted) (released April 2026). The big change in 2.0 is that every deployment generates a unique parameter fingerprint, so there is no universal signature for DPI to match against.<br><br>Key parameters:<br><ul><li><b>Jc, Jmin, Jmax</b> — Sends junk packets before the handshake to blur the traffic pattern</li><li><b>S1, S2, S3, S4</b> — Adds random padding to init / response / cookie / transport messages, changing their recognizable sizes</li><li><b>H1-H4</b> (ranges in 2.0) — Replaces WireGuard's well-known magic headers with values picked from random ranges</li><li><b>I1-I5 (CPS — Custom Protocol Signature)</b> — <b>(Critical)</b> Prepends real protocol bytes (SIP, TLS, HTTP, etc.) to each handshake phase. Without these, sophisticated DPI detects and kills the tunnel within seconds</li></ul><b>Note on AmneziaWG 1.x:</b> earlier versions of this guide (and the canonical QUIC <code>I1</code> signature once recommended) are now reliably fingerprinted by modern DPI systems. If you find an older guide, treat its config templates as deprecated — use the 2.0 format below. |
 
 ### Who This Tutorial Is For
 
@@ -245,9 +245,14 @@ sudo apt install -y amneziawg amneziawg-tools
 # Load kernel module and verify
 sudo modprobe amneziawg
 lsmod | grep amnezia
+
+# Verify packages are AmneziaWG 2.0-capable
+# (the version string still reads "v1.0.20210914" — that's just the
+# upstream wireguard-tools fork date. Check the package build date instead.)
+dpkg -l amneziawg-tools | tail -1
 ```
 
-You should see `amneziawg` in the module list. If not, check that your kernel headers match your running kernel.
+You should see `amneziawg` in the module list and a package build date of `2026-02-23` or later (the 2.0 release line). If not, check that your kernel headers match your running kernel and that your PPA is up to date.
 
 ## Step 6 - Generate Keys
 
@@ -305,36 +310,83 @@ sudo mv ~/server_public.key /etc/amnezia/amneziawg/
 
 ## Step 7 - Configure AmneziaWG on the Origin Server
 
-Create the config file:
+### Step 7.1 - Generate AmneziaWG 2.0 obfuscation parameters
+
+AmneziaWG 2.0 expects each deployment to have a unique set of obfuscation values — `H1-H4` are *ranges* (not single integers like in 1.x), and CPS signatures `I1-I5` should be chosen to disguise as a real protocol session. Generate one shared set on the origin server; you'll copy the file to the in-region VPS in Step 8.
+
+Install the helpers you'll need:
 
 ```bash
-sudo bash -c 'cat > /etc/amnezia/amneziawg/awg0.conf << EOF
+sudo apt install -y jq curl
+```
+
+Then generate the parameters:
+
+```bash
+sudo bash -c '
+JMIN=$((RANDOM % 50 + 40))                    # 40-89
+JMAX=$((JMIN + RANDOM % 200 + 50))            # JMIN+50..JMIN+249
+S1=$((RANDOM % 135 + 15))                     # 15-150
+S2=$((RANDOM % 135 + 15))
+while [ "$S2" -eq "$((S1+56))" ]; do S2=$((RANDOM % 135 + 15)); done  # S1+56 != S2
+
+# Random non-overlapping H1-H4 ranges in uint32 space
+H1_LO=$((RANDOM * 40000 + 100000000));  H1_HI=$((H1_LO + 100000))
+H2_LO=$((RANDOM * 40000 + 1000000000)); H2_HI=$((H2_LO + 100000))
+H3_LO=$((RANDOM * 40000 + 2000000000)); H3_HI=$((H3_LO + 100000))
+H4_LO=$((RANDOM * 40000 + 3000000000)); H4_HI=$((H4_LO + 100000))
+
+# Pick one cycle (1-800) of CPS signatures from the maintained list at
+# https://github.com/VoidWaifu/Special-Junk-Packet-List
+# Each cycle disguises the AmneziaWG handshake phases as a coherent
+# SIP / TLS / HTTP session against a public service.
+CYCLE=$((RANDOM % 800 + 1))
+SIGS=$(curl -sL "https://raw.githubusercontent.com/VoidWaifu/Special-Junk-Packet-List/main/I-list1.json" \
+    | jq -r --arg c "$CYCLE" \
+        ".packets | to_entries[] | select(.key|endswith(\"_c\"+\$c)) | \"\(.key|sub(\"_c.*\";\"\")) = \(.value)\"")
+
+cat > /etc/amnezia/amneziawg/obfuscation.params <<INNER
+# AmneziaWG 2.0 obfuscation parameters — same on both peers
+Jc = $((RANDOM % 4 + 3))
+Jmin = $JMIN
+Jmax = $JMAX
+S1 = $S1
+S2 = $S2
+S3 = $((RANDOM % 47 + 8))
+S4 = $((RANDOM % 23 + 4))
+H1 = $H1_LO-$H1_HI
+H2 = $H2_LO-$H2_HI
+H3 = $H3_LO-$H3_HI
+H4 = $H4_LO-$H4_HI
+$SIGS
+INNER
+chmod 600 /etc/amnezia/amneziawg/obfuscation.params
+'
+
+sudo cat /etc/amnezia/amneziawg/obfuscation.params
+```
+
+You should see 12 short lines (Jc, Jmin, Jmax, S1-S4, H1-H4 ranges) followed by 5 long `I1-I5` lines containing hex blobs. If `I1-I5` are missing, the curl or jq step failed — re-run the block.
+
+### Step 7.2 - Write the tunnel config
+
+Embed the parameter file into the AmneziaWG config:
+
+```bash
+sudo bash -c "cat > /etc/amnezia/amneziawg/awg0.conf" <<EOF
 [Interface]
 Address = 10.10.0.1/24
 ListenPort = 443
-PrivateKey = $(cat /etc/amnezia/amneziawg/server_private.key)
+PrivateKey = $(sudo cat /etc/amnezia/amneziawg/server_private.key)
 MTU = 1280
 
-# Obfuscation parameters (must match on both sides)
-Jc = 4
-Jmin = 50
-Jmax = 1000
-S1 = 55
-S2 = 155
-H1 = 1953034736
-H2 = 752945292
-H3 = 3945748733
-H4 = 1666444888
-
-# QUIC protocol signature — makes the tunnel look like QUIC (HTTP/3)
-# Without this, sophisticated DPI detects and kills the tunnel in seconds
-I1 = <b 0xc70000000108ce1bf31eec7d93360000449e227e4596ed7f75c4d35ce31880b4133107c822c6355b51f0d7c1bba96d5c210a48aca01885fed0871cfc37d59137d73b506dc013bb4a13c060ca5b04b7ae215af71e37d6e8ff1db235f9fe0c25cb8b492471054a7c8d0d6077d430d07f6e87a8699287f6e69f54263c7334a8e144a29851429bf2e350e519445172d36953e96085110ce1fb641e5efad42c0feb4711ece959b72cc4d6f3c1e83251adb572b921534f6ac4b10927167f41fe50040a75acef62f45bded67c0b45b9d655ce374589cad6f568b8475b2e8921ff98628f86ff2eb5bcce6f3ddb7dc89e37c5b5e78ddc8d93a58896e530b5f9f1448ab3b7a1d1f24a63bf981634f6183a21af310ffa52e9ddf5521561760288669de01a5f2f1a4f922e68d0592026bbe4329b654d4f5d6ace4f6a23b8560b720a5350691c0037b10acfac9726add44e7d3e880ee6f3b0d6429ff33655c297fee786bb5ac032e48d2062cd45e305e6d8d8b82bfbf0fdbc5ec09943d1ad02b0b5868ac4b24bb10255196be883562c35a713002014016b8cc5224768b3d330016cf8ed9300fe6bf39b4b19b3667cddc6e7c7ebe4437a58862606a2a66bd4184b09ab9d2cd3d3faed4d2ab71dd821422a9540c4c5fa2a9b2e6693d411a22854a8e541ed930796521f03a54254074bc4c5bca152a1723260e7d70a24d49720acc544b41359cfc252385bda7de7d05878ac0ea0343c77715e145160e6562161dfe2024846dfda3ce99068817a2418e66e4f37dea40a21251c8a034f83145071d93baadf050ca0f95dc9ce2338fb082d64fbc8faba905cec66e65c0e1f9b003c32c943381282d4ab09bef9b6813ff3ff5118623d2617867e25f0601df583c3ac51bc6303f79e68d8f8de4b8363ec9c7728b3ec5fcd5274edfca2a42f2727aa223c557afb33f5bea4f64aeb252c0150ed734d4d8eccb257824e8e090f65029a3a042a51e5cc8767408ae07d55da8507e4d009ae72c47ddb138df3cab6cc023df2532f88fb5a4c4bd917fafde0f3134be09231c389c70bc55cb95a779615e8e0a76a2b4d943aabfde0e394c985c0cb0376930f92c5b6998ef49ff4a13652b787503f55c4e3d8eebd6e1bc6db3a6d405d8405bd7a8db7cefc64d16e0d105a468f3d33d29e5744a24c4ac43ce0eb1bf6b559aed520b91108cda2de6e2c4f14bc4f4dc58712580e07d217c8cca1aaf7ac04bab3e7b1008b966f1ed4fba3fd93a0a9d3a27127e7aa587fbcc60d548300146bdc126982a58ff5342fc41a43f83a3d2722a26645bc961894e339b953e78ab395ff2fb854247ad06d446cc2944a1aefb90573115dc198f5c1efbc22bc6d7a74e41e666a643d5f85f57fde81b87ceff95353d22ae8bab11684180dd142642894d8dc34e402f802c2fd4a73508ca99124e428d67437c871dd96e506ffc39c0fc401f666b437adca41fd563cbcfd0fa22fbbf8112979c4e677fb533d981745cceed0fe96da6cc0593c430bbb71bcbf924f70b4547b0bb4d41c94a09a9ef1147935a5c75bb2f721fbd24ea6a9f5c9331187490ffa6d4e34e6bb30c2c54a0344724f01088fb2751a486f425362741664efb287bce66c4a544c96fa8b124d3c6b9eaca170c0b530799a6e878a57f402eb0016cf2689d55c76b2a91285e2273763f3afc5bc9398273f5338a06d>
+$(sudo cat /etc/amnezia/amneziawg/obfuscation.params)
 
 [Peer]
-PublicKey = $(cat /etc/amnezia/amneziawg/client_public.key)
-PresharedKey = $(cat /etc/amnezia/amneziawg/preshared.key)
+PublicKey = $(sudo cat /etc/amnezia/amneziawg/client_public.key)
+PresharedKey = $(sudo cat /etc/amnezia/amneziawg/preshared.key)
 AllowedIPs = 10.10.0.2/32
-EOF'
+EOF
 
 sudo chmod 600 /etc/amnezia/amneziawg/awg0.conf
 ```
@@ -348,36 +400,39 @@ sudo ufw allow in on awg0
 
 ## Step 8 - Configure AmneziaWG on the In-Region VPS
 
-Replace `<ORIGIN_SERVER_IP>` with the IP of your server.
+The obfuscation parameters from Step 7.1 **must be identical on both peers**. Copy the file from the origin server to the in-region VPS, then write the in-region config.
+
+**On the origin server**, copy the parameter file to the in-region VPS:
 
 ```bash
-sudo bash -c 'cat > /etc/amnezia/amneziawg/awg0.conf << EOF
+sudo scp /etc/amnezia/amneziawg/obfuscation.params <user>@<IN_REGION_VPS_IP>:~/
+```
+
+**On the in-region VPS**, move it into place:
+
+```bash
+sudo mv ~/obfuscation.params /etc/amnezia/amneziawg/obfuscation.params
+sudo chmod 600 /etc/amnezia/amneziawg/obfuscation.params
+```
+
+Then write the in-region config. Replace `<ORIGIN_SERVER_IP>` with the IP of your origin server:
+
+```bash
+sudo bash -c "cat > /etc/amnezia/amneziawg/awg0.conf" <<EOF
 [Interface]
 Address = 10.10.0.2/24
-PrivateKey = $(cat /etc/amnezia/amneziawg/client_private.key)
+PrivateKey = $(sudo cat /etc/amnezia/amneziawg/client_private.key)
 MTU = 1280
 
-# Obfuscation parameters — must match origin server exactly
-Jc = 4
-Jmin = 50
-Jmax = 1000
-S1 = 55
-S2 = 155
-H1 = 1953034736
-H2 = 752945292
-H3 = 3945748733
-H4 = 1666444888
-
-# Same QUIC signature as origin
-I1 = <b 0xc70000000108ce1bf31eec7d93360000449e227e4596ed7f75c4d35ce31880b4133107c822c6355b51f0d7c1bba96d5c210a48aca01885fed0871cfc37d59137d73b506dc013bb4a13c060ca5b04b7ae215af71e37d6e8ff1db235f9fe0c25cb8b492471054a7c8d0d6077d430d07f6e87a8699287f6e69f54263c7334a8e144a29851429bf2e350e519445172d36953e96085110ce1fb641e5efad42c0feb4711ece959b72cc4d6f3c1e83251adb572b921534f6ac4b10927167f41fe50040a75acef62f45bded67c0b45b9d655ce374589cad6f568b8475b2e8921ff98628f86ff2eb5bcce6f3ddb7dc89e37c5b5e78ddc8d93a58896e530b5f9f1448ab3b7a1d1f24a63bf981634f6183a21af310ffa52e9ddf5521561760288669de01a5f2f1a4f922e68d0592026bbe4329b654d4f5d6ace4f6a23b8560b720a5350691c0037b10acfac9726add44e7d3e880ee6f3b0d6429ff33655c297fee786bb5ac032e48d2062cd45e305e6d8d8b82bfbf0fdbc5ec09943d1ad02b0b5868ac4b24bb10255196be883562c35a713002014016b8cc5224768b3d330016cf8ed9300fe6bf39b4b19b3667cddc6e7c7ebe4437a58862606a2a66bd4184b09ab9d2cd3d3faed4d2ab71dd821422a9540c4c5fa2a9b2e6693d411a22854a8e541ed930796521f03a54254074bc4c5bca152a1723260e7d70a24d49720acc544b41359cfc252385bda7de7d05878ac0ea0343c77715e145160e6562161dfe2024846dfda3ce99068817a2418e66e4f37dea40a21251c8a034f83145071d93baadf050ca0f95dc9ce2338fb082d64fbc8faba905cec66e65c0e1f9b003c32c943381282d4ab09bef9b6813ff3ff5118623d2617867e25f0601df583c3ac51bc6303f79e68d8f8de4b8363ec9c7728b3ec5fcd5274edfca2a42f2727aa223c557afb33f5bea4f64aeb252c0150ed734d4d8eccb257824e8e090f65029a3a042a51e5cc8767408ae07d55da8507e4d009ae72c47ddb138df3cab6cc023df2532f88fb5a4c4bd917fafde0f3134be09231c389c70bc55cb95a779615e8e0a76a2b4d943aabfde0e394c985c0cb0376930f92c5b6998ef49ff4a13652b787503f55c4e3d8eebd6e1bc6db3a6d405d8405bd7a8db7cefc64d16e0d105a468f3d33d29e5744a24c4ac43ce0eb1bf6b559aed520b91108cda2de6e2c4f14bc4f4dc58712580e07d217c8cca1aaf7ac04bab3e7b1008b966f1ed4fba3fd93a0a9d3a27127e7aa587fbcc60d548300146bdc126982a58ff5342fc41a43f83a3d2722a26645bc961894e339b953e78ab395ff2fb854247ad06d446cc2944a1aefb90573115dc198f5c1efbc22bc6d7a74e41e666a643d5f85f57fde81b87ceff95353d22ae8bab11684180dd142642894d8dc34e402f802c2fd4a73508ca99124e428d67437c871dd96e506ffc39c0fc401f666b437adca41fd563cbcfd0fa22fbbf8112979c4e677fb533d981745cceed0fe96da6cc0593c430bbb71bcbf924f70b4547b0bb4d41c94a09a9ef1147935a5c75bb2f721fbd24ea6a9f5c9331187490ffa6d4e34e6bb30c2c54a0344724f01088fb2751a486f425362741664efb287bce66c4a544c96fa8b124d3c6b9eaca170c0b530799a6e878a57f402eb0016cf2689d55c76b2a91285e2273763f3afc5bc9398273f5338a06d>
+$(sudo cat /etc/amnezia/amneziawg/obfuscation.params)
 
 [Peer]
-PublicKey = $(cat /etc/amnezia/amneziawg/server_public.key)
-PresharedKey = $(cat /etc/amnezia/amneziawg/preshared.key)
+PublicKey = $(sudo cat /etc/amnezia/amneziawg/server_public.key)
+PresharedKey = $(sudo cat /etc/amnezia/amneziawg/preshared.key)
 Endpoint = <ORIGIN_SERVER_IP>:443
 AllowedIPs = 10.10.0.1/32
 PersistentKeepalive = 25
-EOF'
+EOF
 
 sudo chmod 600 /etc/amnezia/amneziawg/awg0.conf
 ```
@@ -559,7 +614,7 @@ Use [check-host.net](https://check-host.net) to test your website from locations
 <td>
 <br>
 
-We use UDP port 443 because this is the standard **QUIC (HTTP/3)** port. DPI systems expect to see UDP traffic on this port. Combined with AmneziaWG's QUIC protocol signature (`I1` parameter), the tunnel traffic is indistinguishable from legitimate QUIC connections. A random high port would be more suspicious and more likely to be blocked.
+We use UDP port 443 because this is the standard **QUIC (HTTP/3)** port. DPI systems expect to see UDP traffic on this port, so the flow is not suspicious by virtue of its destination. Combined with AmneziaWG 2.0's CPS signatures (`I1-I5`) shaping the handshake as a real protocol session, the tunnel traffic blends in with legitimate UDP/443 conversations. A random high port would be more suspicious and more likely to be blocked.
 
 </td>
 </tr>
@@ -573,13 +628,17 @@ AmneziaWG adds overhead to each packet (obfuscation headers, junk data prefix). 
 </td>
 </tr>
 
-<tr><td>Why the I1 Parameter is Critical</td>
+<tr><td>Why I1-I5 (CPS) Parameters Are Critical</td>
 <td>
 <br>
 
-This was our most important discovery. Basic AmneziaWG obfuscation (S1/S2/H1-H4 parameters only) randomizes headers and packet sizes, but sophisticated DPI can still detect the tunnel by analyzing traffic patterns. The tunnel would connect, work for 10-30 seconds, then get killed.
+This was our most important discovery. Basic AmneziaWG obfuscation (S1-S4, H1-H4 ranges) randomizes headers and packet sizes, but sophisticated DPI can still detect the tunnel by analyzing traffic patterns. Without CPS the tunnel would connect, work for 10-30 seconds, then get killed.
 
-Adding the `I1` parameter — which prepends a real QUIC Initial packet signature to the handshake — was the difference between a tunnel that lasted seconds and one that runs indefinitely. The DPI sees what looks like a legitimate QUIC connection being established and leaves it alone.
+**Custom Protocol Signature (CPS)** is the AmneziaWG 2.0 system that uses `I1`, `I2`, `I3`, `I4`, `I5` to prepend real protocol bytes to each handshake phase (init / response / cookie / transport / keep-alive). The DPI sees what looks like a legitimate SIP / TLS / HTTP session and lets it pass.
+
+**Historical note:** earlier versions of AmneziaWG used a single static `I1` (commonly a QUIC Initial packet). By mid-2026 this canonical QUIC signature was reliably fingerprinted by modern DPI systems. AmneziaWG 2.0 (April 2026) added `I2-I5`, and the community-maintained [VoidWaifu/Special-Junk-Packet-List](https://github.com/VoidWaifu/Special-Junk-Packet-List) provides 800+ disguise cycles you can rotate through.
+
+**If your tunnel dies after working briefly:** the current cycle is fingerprinted — regenerate `obfuscation.params` (Step 7.1) with a different `CYCLE` value, copy it back to the in-region VPS, restart the tunnel.
 
 </td>
 </tr>
@@ -590,9 +649,9 @@ Adding the `I1` parameter — which prepends a real QUIC Initial packet signatur
 
 **Must be identical on both servers:**
 
-- S1, S2 — Handshake padding sizes
-- H1, H2, H3, H4 — Magic header replacement values
-- I1 — Protocol signature
+- S1, S2, S3, S4 — Handshake / cookie / transport padding sizes
+- H1, H2, H3, H4 — Header value ranges (each range, bound-for-bound)
+- I1, I2, I3, I4, I5 — Custom Protocol Signature components
 
 **Can differ (but simplest to keep the same):**
 
@@ -680,7 +739,19 @@ To prevent this permanently, set up the `awg-module-ensure` systemd service desc
 <td>
 <br>
 
-You're missing the `I1` parameter or it doesn't match on both sides. Add the QUIC protocol signature to both configs.
+Your `I1-I5` signatures (CPS) are either missing, mismatched between peers, or have been fingerprinted by current DPI rules. Two checks:
+
+1. **Verify match:** `I1`-`I5` must be byte-identical on both peers. The simplest guarantee is to copy `/etc/amnezia/amneziawg/obfuscation.params` from one peer to the other (Step 8).
+2. **Rotate signatures:** if both sides already match, the current cycle is fingerprinted. Re-run Step 7.1 on the origin (which picks a new random `CYCLE` from 1-800), re-copy the file to the in-region VPS, restart the tunnel on both sides.
+
+</td>
+</tr>
+
+<tr><td>Tunnel worked initially but stopped after hours / days</td>
+<td>
+<br>
+
+DPI has caught up to your signature cycle. Regenerate `obfuscation.params` on the origin (Step 7.1) — this picks a fresh CPS cycle from the [VoidWaifu list](https://github.com/VoidWaifu/Special-Junk-Packet-List) — copy the new file to the in-region VPS (Step 8), then restart `awg-quick@awg0` on both servers. **Keys do not need to rotate** — only the obfuscation parameters. For more variety, swap `I-list1.json` in the curl URL for `I-list2.json` or `I-list3.json`.
 
 </td>
 </tr>
@@ -778,16 +849,19 @@ The complete solution has three layers:
 
 1. **DNS** points to the in-region VPS
 2. **Nginx** on the in-region VPS handles TLS termination and reverse proxying
-3. **AmneziaWG** tunnel with QUIC obfuscation carries the proxy-to-origin traffic through the DPI undetected
+3. **AmneziaWG 2.0** tunnel with per-deployment unique obfuscation and CPS (Custom Protocol Signature) disguise carries the proxy-to-origin traffic through the DPI undetected
 
-The key insight is that neither a CDN nor a simple reverse proxy is sufficient when DPI throttles both direct and proxied connections to foreign IPs. You need an encrypted, obfuscated tunnel between the in-region proxy and your origin — and that tunnel needs protocol-level disguise (the `I1` parameter) to survive against modern DPI systems.
+The key insight is that neither a CDN nor a simple reverse proxy is sufficient when DPI throttles both direct and proxied connections to foreign IPs. You need an encrypted, obfuscated tunnel between the in-region proxy and your origin — and that tunnel needs protocol-level disguise (the `I1-I5` CPS parameters from a curated, rotatable list) to survive against modern DPI systems. Expect to rotate the CPS cycle periodically as DPI signature databases catch up.
 
 ## Resources
 
 - [AmneziaVPN Project](https://amnezia.org) — Creators of AmneziaWG
 - [AmneziaWG Protocol Documentation](https://docs.amnezia.org/documentation/amnezia-wg/)
+- [AmneziaWG 2.0 announcement (April 2026)](https://amnezia.org/blog/amneziawg-2-0-available-for-self-hosted)
+- [AmneziaWG 2.0 self-hosted documentation](https://docs.amnezia.org/documentation/instructions/new-amneziawg-selfhosted/)
 - [AmneziaWG Linux Kernel Module](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module)
 - [AmneziaWG Tools](https://github.com/amnezia-vpn/amneziawg-tools)
+- [VoidWaifu/Special-Junk-Packet-List](https://github.com/VoidWaifu/Special-Junk-Packet-List) — Maintained list of CPS (I1-I5) signature cycles. Rotate to a new cycle when DPI catches up.
 - [EDIS Global AmneziaWG Guide](https://docs.edisglobal.com/advanced-setup-guides/install-amneziawg-on-ubuntu-22_04/install-amneziawg-on-ubuntu-2204)
 - [amneziawg-installer](https://github.com/bivlked/amneziawg-installer) — Automated AmneziaWG 2.0 server installer (Ubuntu/Debian, ARM support)
 


### PR DESCRIPTION
## Summary

Updates `tutorials/making-website-accessible-from-restricted-regions/01.en.md` for AmneziaWG 2.0 (released April 2026). The original tutorial (published February 2026) uses the AmneziaWG 1.x config format with a static canonical QUIC `I1` signature, which is now reliably fingerprinted by modern DPI and causes the tunnel to fail within minutes.

## What changed

- **Config templates rewritten for AWG 2.0 format**: ranged `H1-H4`, new `S3`/`S4` padding params, full `I1-I5` CPS (Custom Protocol Signature) cycle.
- **Step 7 split into 7.1 / 7.2**: 7.1 generates a per-deployment-unique `obfuscation.params` file with one cycle from the community-maintained [VoidWaifu/Special-Junk-Packet-List](https://github.com/VoidWaifu/Special-Junk-Packet-List). 7.2 references that file in `awg0.conf`.
- **Step 8 simplified**: copy the same `obfuscation.params` from origin to in-region VPS, guaranteeing the "must match" params are byte-identical between peers.
- **"What is AmneziaWG?" / "Why I1 is Critical" sections updated** to describe AWG 2.0 (per-deployment unique fingerprint) and CPS instead of the deprecated single-QUIC-`I1` approach.
- **"Which Parameters Must Match?"** updated to list S1-S4, H1-H4 ranges, I1-I5.
- **Step 5** now includes a version-check snippet noting `awg --version` reports `v1.0.20210914` (the upstream wireguard-tools fork date) regardless of AWG version — readers should check the Debian package build date.
- **New troubleshooting entry**: "Tunnel worked initially but stopped after hours / days" — explains how to rotate the CPS cycle without rotating keys.
- **Resources section** adds: AWG 2.0 announcement, new self-hosted docs, VoidWaifu list.
- **Diagram and prose** updated: "disguised as QUIC" → "disguised as SIP/TLS" (reflecting the actual CPS shape now used).

## Test plan

- [x] Procedure verified end-to-end on a live tunnel: kernel module loads, `awg show` accepts ranged `H` values, `S3`/`S4`, and all five `I1-I5`; tunnel handshakes and passes real HTTPS traffic.
- [x] No country names, government bodies, or specific DPI systems referenced — wording uses neutral phrases like "restricted regions" and "modern DPI systems."
- [x] `git diff --stat` against `hetzneronline/master`: only `tutorials/making-website-accessible-from-restricted-regions/01.en.md` is touched.