### PR TITLE
Update Shopware 6 tutorial to PHP 8.5 and Ubuntu 26.04

### DIFF
--- a/tutorials/install-shopware-6/01.en.md
+++ b/tutorials/install-shopware-6/01.en.md
@@ -18,7 +18,7 @@ cta: "cloud"
 
 ## Introduction
 
-Shopware is a trendsetting ecommerce platform to power your online business. It offers a combination of beauty & brains needed to build and customize a fully responsive online store. In this tutorial, we will learn how to install and configure Shopware 6 with Nginx on Ubuntu 24.04.
+Shopware is a trendsetting ecommerce platform to power your online business. It offers a combination of beauty & brains needed to build and customize a fully responsive online store. In this tutorial, we will learn how to install and configure Shopware 6 with Nginx on Ubuntu 26.04.
 
 **Prerequisites**
 
@@ -35,7 +35,7 @@ Shopware is a trendsetting ecommerce platform to power your online business. It 
 We install Nginx, MariaDB and PHP-FPM with the following command:
 
 ```bash
-sudo apt install unzip nginx php8.3-fpm php8.3-mysql php8.3-curl php8.3-gd php8.3-xml php8.3-zip php8.3-opcache php8.3-mbstring php8.3-intl php8.3-cli mariadb-server
+sudo apt install unzip nginx php8.5-fpm php8.5-mysql php8.5-curl php8.5-gd php8.5-xml php8.5-zip php8.5-opcache php8.5-mbstring php8.5-intl php8.5-cli mariadb-server
 ```
 
 To confirm the installation, press enter and then all related packages will be installed.
@@ -64,10 +64,10 @@ We can end the MariaDB session by entering `exit`.
 
 ## Step 3 - Configuring PHP/PHP-FPM
 
-To match the requirements of Shopware 6, we will need to adjust some `php.ini` settings. The `php.ini` used by PHP-FPM can be found under `/etc/php/8.3/fpm/php.ini`. We can open it with an editor like `nano`:
+To match the requirements of Shopware 6, we will need to adjust some `php.ini` settings. The `php.ini` used by PHP-FPM can be found under `/etc/php/8.5/fpm/php.ini`. We can open it with an editor like `nano`:
 
 ```bash
-sudo nano /etc/php/8.3/fpm/php.ini
+sudo nano /etc/php/8.5/fpm/php.ini
 ```
 
 We then search with `CTRL` + `W` for `memory_limit =` and set the value from 128 to 512.
@@ -79,13 +79,13 @@ This will allow us to upload larger files to the media manager. We can save the 
 After configuring, we can restart the PHP-FPM server using the command:
 
 ```bash
-sudo systemctl restart php8.3-fpm
+sudo systemctl restart php8.5-fpm
 ```
 
 It should be also marked to start on boot:
 
 ```bash
-sudo systemctl enable php8.3-fpm
+sudo systemctl enable php8.5-fpm
 ```
 
 ## Step 4 - Configuring Nginx
@@ -138,7 +138,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_read_timeout 300s;
         client_body_buffer_size 128k;
-        fastcgi_pass unix:/run/php/php8.3-fpm.sock;
+        fastcgi_pass unix:/run/php/php8.5-fpm.sock;
     }
 }
 ```


### PR DESCRIPTION
Updated to use newest Ubuntu LTS + PHP 8.5 to be more future proof