### PR TITLE
New tutorial: Install and Configure Pi-hole with Docker on Debian and Ubuntu

### DIFF
--- a/tutorials/how-to-install-pihole/01.en.md
+++ b/tutorials/how-to-install-pihole/01.en.md
@@ -1,0 +1,375 @@
+---
+SPDX-License-Identifier: MIT
+path: "/tutorials/how-to-install-pihole"
+slug: "how-to-install-pihole"
+date: "2026-06-07"
+title: "How to Install Pi-hole with Docker on Debian and Ubuntu"
+short_description: "Learn how to install Docker and deploy Pi-hole using Docker Compose on Debian and Ubuntu servers."
+tags: ["Networking", "Docker", "Pi-hole", "Ubuntu", "Debian"]
+author: "Miroslav Minárik"
+author_link: "https://github.com/miominarik"
+author_img: "https://avatars.githubusercontent.com/u/60823521"
+author_description: "Web Developer who enjoys working with Linux"
+language: "en"
+available_languages: ["en"]
+header_img: "header-4"
+cta: "cloud"
+---
+
+## Introduction
+
+Pi-hole is a network-wide DNS filtering solution that blocks advertisements, trackers, and malicious domains before they reach your devices.
+
+In this tutorial, you will install Docker, Docker Compose, and deploy Pi-hole inside a Docker container on a Debian or Ubuntu server. At the end of this guide, you will have a fully functional Pi-hole instance accessible through a web interface and ready to serve DNS requests for your network.
+
+**Prerequisites**
+
+* A Debian 12/13 or Ubuntu 24.04/26.04 server
+* Root or sudo access
+* A static IP address
+* Open ports `53/tcp`, `53/udp`, and `80/tcp`
+
+**Example terminology**
+
+Throughout this tutorial, the following placeholders are used:
+
+* Hostname: `<your_host>`
+* Server IP: `<10.0.0.1>`
+* Password: `<your_password>`
+
+## Step 1 - Install Docker
+
+Update the system packages:
+
+```bash
+sudo apt update
+sudo apt upgrade -y
+```
+
+Install required packages:
+
+```bash
+sudo apt install -y \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+```
+
+Create the Docker keyring directory:
+
+```bash
+sudo install -m 0755 -d /etc/apt/keyrings
+```
+
+Download Docker's GPG key:
+
+```bash
+curl -fsSL https://download.docker.com/linux/$(. /etc/os-release && echo "$ID")/gpg | \
+sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+```
+
+Set permissions:
+
+```bash
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+```
+
+Add the Docker repository:
+
+```bash
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+  https://download.docker.com/linux/$(. /etc/os-release && echo "$ID") \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+```
+
+Update repositories:
+
+```bash
+sudo apt update
+```
+
+Install Docker Engine and Docker Compose:
+
+```bash
+sudo apt install -y \
+    docker-ce \
+    docker-ce-cli \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin
+```
+
+Verify the installation:
+
+```bash
+docker --version
+docker compose version
+```
+
+Expected output:
+
+```text
+Docker version 28.x.x
+Docker Compose version v2.x.x
+```
+
+## Step 2 - Create the Pi-hole Directory Structure
+
+Create a directory for Pi-hole:
+
+```bash
+mkdir -p ~/pihole
+cd ~/pihole
+```
+
+Create persistent storage directories:
+
+```bash
+mkdir -p etc-pihole
+mkdir -p etc-dnsmasq.d
+```
+
+Your structure should look like:
+
+```text
+~/pihole
+├── docker-compose.yml
+├── etc-pihole
+└── etc-dnsmasq.d
+```
+
+## Step 3 - Create the Docker Compose Configuration
+
+Create the compose file:
+
+```bash
+nano docker-compose.yml
+```
+
+Insert the following configuration:
+
+```yaml
+services:
+  pihole:
+    container_name: pihole
+    image: pihole/pihole:latest
+
+    environment:
+      TZ: Europe/Bratislava
+      FTLCONF_webserver_api_password: "ChangeMe123!"
+
+    ports:
+      - "53:53/tcp"
+      - "53:53/udp"
+      - "80:80/tcp"
+
+    volumes:
+      - ./etc-pihole:/etc/pihole
+      - ./etc-dnsmasq.d:/etc/dnsmasq.d
+
+    restart: unless-stopped
+```
+
+Save and close the file.
+
+## Step 4 - Start Pi-hole
+
+Start the container:
+
+```bash
+docker compose up -d
+```
+
+Verify that the container is running:
+
+```bash
+docker ps
+```
+
+Expected output:
+
+```text
+CONTAINER ID   IMAGE                  STATUS
+xxxxxxxxxxxx   pihole/pihole:latest   Up
+```
+
+View the logs:
+
+```bash
+docker compose logs -f
+```
+
+Press `CTRL+C` to exit.
+
+## Step 5 - Access the Web Interface
+
+Open your browser and navigate to:
+
+```text
+http://<10.0.0.1>/admin
+```
+
+Replace `<10.0.0.1>` with the IP address of your server.
+
+Log in using the password configured in:
+
+```yaml
+FTLCONF_webserver_api_password: "ChangeMe123!"
+```
+
+After logging in, you should see the Pi-hole dashboard.
+
+## Step 6 - Configure DNS Clients
+
+To use Pi-hole, configure your devices or router to use the Pi-hole server as their DNS server.
+
+Example:
+
+```text
+Primary DNS: <10.0.0.1>
+Secondary DNS: (leave empty)
+```
+
+For best results, configure DNS directly on your router so all devices automatically use Pi-hole.
+
+## Step 7 - Update Pi-hole
+
+Pull the latest image:
+
+```bash
+cd ~/pihole
+docker compose pull
+```
+
+Restart the container:
+
+```bash
+docker compose up -d
+```
+
+Verify the running version:
+
+```bash
+docker ps
+```
+
+## Step 8 - Useful Commands
+
+View logs:
+
+```bash
+docker compose logs -f
+```
+
+Restart Pi-hole:
+
+```bash
+docker compose restart
+```
+
+Stop Pi-hole:
+
+```bash
+docker compose down
+```
+
+Start Pi-hole:
+
+```bash
+docker compose up -d
+```
+
+Check container status:
+
+```bash
+docker ps
+```
+
+## Step 9 - Troubleshooting - Port 53 Already in Use
+
+When starting the Pi-hole container, you may encounter an error similar to:
+
+```text
+failed to bind host port 0.0.0.0:53/tcp: address already in use
+```
+
+This means another service is already listening on DNS port `53`.
+
+Check which service is using the port:
+
+```bash
+sudo ss -tulpn | grep ':53'
+```
+
+### Ubuntu - systemd-resolved
+
+Some Ubuntu installations use `systemd-resolved` which occupies port `53`.
+
+Stop and disable the service:
+
+```bash
+sudo systemctl stop systemd-resolved
+sudo systemctl disable systemd-resolved
+```
+
+Create a new DNS configuration:
+
+```bash
+cat <<EOF | sudo tee /etc/resolv.conf
+nameserver 1.1.1.1
+nameserver 8.8.8.8
+EOF
+```
+
+Verify DNS resolution:
+
+```bash
+ping -c 4 google.com
+```
+
+### Debian - dnsmasq
+
+Some Debian installations may have `dnsmasq` installed.
+
+Check its status:
+
+```bash
+sudo systemctl status dnsmasq
+```
+
+If it is running and you do not need it, stop and disable it:
+
+```bash
+sudo systemctl stop dnsmasq
+sudo systemctl disable dnsmasq
+```
+
+### Verify Port Availability
+
+Ensure that nothing is listening on port `53`:
+
+```bash
+sudo ss -tulpn | grep ':53'
+```
+
+If no output is returned, start Pi-hole again:
+
+```bash
+cd ~/pihole
+docker compose up -d
+```
+
+Verify the container status:
+
+```bash
+docker ps
+```
+
+## Conclusion
+
+You have successfully installed Docker and deployed Pi-hole using Docker Compose on Debian or Ubuntu. Your server is now capable of providing network-wide DNS filtering and blocking advertisements, trackers, and malicious domains for all devices that use it as their DNS server.
+
+##### License: MIT

--- a/tutorials/how-to-install-pihole/01.en.md
+++ b/tutorials/how-to-install-pihole/01.en.md
@@ -373,3 +373,32 @@ docker ps
 You have successfully installed Docker and deployed Pi-hole using Docker Compose on Debian or Ubuntu. Your server is now capable of providing network-wide DNS filtering and blocking advertisements, trackers, and malicious domains for all devices that use it as their DNS server.
 
 ##### License: MIT
+
+<!--
+
+Contributor's Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it under the license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate license and I have the
+    right under that license to submit that work with modifications,
+    whether created in whole or in part by me, under the same license
+    (unless I am permitted to submit under a different license), as
+    indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are
+    public and that a record of the contribution (including all personal
+    information I submit with it, including my sign-off) is maintained
+    indefinitely and may be redistributed consistent with this project
+    or the license(s) involved.
+
+Signed-off-by: Miroslav Minárik miroslav.minarik@miomail.sk
+
+-->

--- a/tutorials/how-to-install-pihole/01.en.md
+++ b/tutorials/how-to-install-pihole/01.en.md
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/how-to-install-pihole"
 slug: "how-to-install-pihole"
-date: "2026-06-07"
+date: "2026-06-17"
 title: "How to Install Pi-hole with Docker on Debian and Ubuntu"
 short_description: "Learn how to install Docker and deploy Pi-hole using Docker Compose on Debian and Ubuntu servers."
 tags: ["Networking", "Docker", "Pi-hole", "Ubuntu", "Debian"]
@@ -24,10 +24,12 @@ In this tutorial, you will install Docker, Docker Compose, and deploy Pi-hole in
 
 **Prerequisites**
 
-* A Debian 12/13 or Ubuntu 24.04/26.04 server
-* Root or sudo access
-* A static IP address
-* Open ports `53/tcp`, `53/udp`, and `80/tcp`
+* A server
+  * Debian 12/13 or Ubuntu 24.04/26.04
+  * Root or sudo access
+  * A static IP address
+  * Open ports `53/tcp`, `53/udp`, and `80/tcp`
+  * Docker already installed 
 
 **Example terminology**
 
@@ -39,81 +41,15 @@ Throughout this tutorial, the following placeholders are used:
 
 ## Step 1 - Install Docker
 
-Update the system packages:
+If you haven't already, install Docker now as explained in the official Docker documentation:
+
+* [Debain](https://docs.docker.com/engine/install/debian/#install-using-the-repository)
+* [Ubuntu](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository)
+
+Remember to add your user to the `docker` group:
 
 ```bash
-sudo apt update
-sudo apt upgrade -y
-```
-
-Install required packages:
-
-```bash
-sudo apt install -y \
-    ca-certificates \
-    curl \
-    gnupg \
-    lsb-release
-```
-
-Create the Docker keyring directory:
-
-```bash
-sudo install -m 0755 -d /etc/apt/keyrings
-```
-
-Download Docker's GPG key:
-
-```bash
-curl -fsSL https://download.docker.com/linux/$(. /etc/os-release && echo "$ID")/gpg | \
-sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-```
-
-Set permissions:
-
-```bash
-sudo chmod a+r /etc/apt/keyrings/docker.gpg
-```
-
-Add the Docker repository:
-
-```bash
-echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
-  https://download.docker.com/linux/$(. /etc/os-release && echo "$ID") \
-  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-```
-
-Update repositories:
-
-```bash
-sudo apt update
-```
-
-Install Docker Engine and Docker Compose:
-
-```bash
-sudo apt install -y \
-    docker-ce \
-    docker-ce-cli \
-    containerd.io \
-    docker-buildx-plugin \
-    docker-compose-plugin
-```
-
-Verify the installation:
-
-```bash
-docker --version
-docker compose version
-```
-
-Expected output:
-
-```text
-Docker version 28.x.x
-Docker Compose version v2.x.x
+sudo usermod -aG docker your-user-name
 ```
 
 ## Step 2 - Create the Pi-hole Directory Structure
@@ -128,8 +64,9 @@ cd ~/pihole
 Create persistent storage directories:
 
 ```bash
-mkdir -p etc-pihole
-mkdir -p etc-dnsmasq.d
+mkdir -p ~/pihole/etc-pihole
+mkdir -p ~/pihole/etc-dnsmasq.d
+touch ~/pihole/docker-compose.yml
 ```
 
 Your structure should look like:
@@ -149,7 +86,7 @@ Create the compose file:
 nano docker-compose.yml
 ```
 
-Insert the following configuration:
+Insert the following configuration which uses the Docker image [`pihole/pihole`](https://hub.docker.com/r/pihole/pihole):
 
 ```yaml
 services:
@@ -183,6 +120,8 @@ Start the container:
 docker compose up -d
 ```
 
+If you get an error message like `Error response from daemon: failed to set up container networking`, go to [Step 9 - Troubleshooting: Port 53 Already in Use](#step-9---troubleshooting-port-53-already-in-use).
+
 Verify that the container is running:
 
 ```bash
@@ -192,9 +131,30 @@ docker ps
 Expected output:
 
 ```text
-CONTAINER ID   IMAGE                  STATUS
-xxxxxxxxxxxx   pihole/pihole:latest   Up
+CONTAINER ID   IMAGE                  STATUS         PORTS                     NAMES
+xxxxxxxxxxxx   pihole/pihole:latest   Up (healthy)   0.0.0.0:53->53/tcp, ...   pihole
 ```
+
+<blockquote>
+<details>
+<summary>Click here if the ports section is empty</summary>
+
+The ports section should look like this:
+
+```text
+0.0.0.0:53->53/tcp, [::]:53->53/tcp, 67/udp, 0.0.0.0:80->80/tcp, 0.0.0.0:53->53/udp, [::]:80->80/tcp, [::]:53->53/udp, 123/udp, 443/tcp
+```
+
+If this section is empty for you, stop and remove the container are restart it:
+
+```bash
+docker stop pihole && docker rm pihole
+docker compose up -d
+docker ps
+```
+
+</details>
+</blockquote>
 
 View the logs:
 
@@ -214,7 +174,7 @@ http://<10.0.0.1>/admin
 
 Replace `<10.0.0.1>` with the IP address of your server.
 
-Log in using the password configured in:
+Log in using the password configured in `docker-compose.yml`:
 
 ```yaml
 FTLCONF_webserver_api_password: "ChangeMe123!"
@@ -233,62 +193,89 @@ Primary DNS: <10.0.0.1>
 Secondary DNS: (leave empty)
 ```
 
-For best results, configure DNS directly on your router so all devices automatically use Pi-hole.
+For best results, configure DNS directly on your router so all devices automatically use Pi-hole. Learn more, in the official Pi-hole documentation:
+
+* [Making your network take advantage of Pi-hole](https://docs.pi-hole.net/main/post-install/#making-your-network-take-advantage-of-pi-hole)
+* [Configure your router to have DHCP clients use Pi-hole as their DNS server](https://discourse.pi-hole.net/t/how-do-i-configure-my-devices-to-use-pi-hole-as-their-dns-server/245)
+* [Use Pi-hole's built-in DHCP server](https://discourse.pi-hole.net/t/how-do-i-use-pi-holes-built-in-dhcp-server-and-why-would-i-want-to/3026)
 
 ## Step 7 - Update Pi-hole
 
-Pull the latest image:
+<table>
+<tr><td>Pull the latest image</td>
+<td>
 
 ```bash
 cd ~/pihole
 docker compose pull
 ```
 
-Restart the container:
+</td></tr>
+<tr><td>Restart the container</td>
+<td>
 
 ```bash
 docker compose up -d
 ```
 
-Verify the running version:
+</td></tr>
+<tr><td>Verify the running version</td>
+<td>
 
 ```bash
+docker exec pihole pihole -v
 docker ps
 ```
 
+</td></tr>
+</table>
+
 ## Step 8 - Useful Commands
 
-View logs:
+<table>
+<tr><td>View logs</td>
+<td>
 
 ```bash
 docker compose logs -f
 ```
 
-Restart Pi-hole:
+</td></tr>
+<tr><td>Restart Pi-hole</td>
+<td>
 
 ```bash
 docker compose restart
 ```
 
-Stop Pi-hole:
+</td></tr>
+<tr><td>Stop Pi-hole</td>
+<td>
 
 ```bash
 docker compose down
 ```
 
-Start Pi-hole:
+</td></tr>
+<tr><td>Start Pi-hole</td>
+<td>
 
 ```bash
 docker compose up -d
 ```
 
-Check container status:
+</td></tr>
+<tr><td>Check container status</td>
+<td>
 
 ```bash
 docker ps
 ```
 
-## Step 9 - Troubleshooting - Port 53 Already in Use
+</td></tr>
+</table>
+
+## Step 9 - Troubleshooting: Port 53 Already in Use
 
 When starting the Pi-hole container, you may encounter an error similar to:
 
@@ -304,69 +291,75 @@ Check which service is using the port:
 sudo ss -tulpn | grep ':53'
 ```
 
-### Ubuntu - systemd-resolved
+-----
 
-Some Ubuntu installations use `systemd-resolved` which occupies port `53`.
+* **Ubuntu - `systemd-resolved`**
+  
+  Some Ubuntu installations use `systemd-resolved` which occupies port `53`.
+  
+  Stop and disable the service:
+  
+  ```bash
+  sudo systemctl stop systemd-resolved
+  sudo systemctl disable systemd-resolved
+  ```
+  
+  Create a new DNS configuration:
+  
+  ```bash
+  cat <<EOF | sudo tee /etc/resolv.conf
+  nameserver 1.1.1.1
+  nameserver 8.8.8.8
+  EOF
+  ```
+  
+  Verify DNS resolution:
+  
+  ```bash
+  ping -c 4 google.com
+  ```
 
-Stop and disable the service:
+<br>
 
-```bash
-sudo systemctl stop systemd-resolved
-sudo systemctl disable systemd-resolved
-```
+* **Debian - `dnsmasq`**
+  
+  Some Debian installations may have `dnsmasq` installed.
+  
+  Check its status:
+  
+  ```bash
+  sudo systemctl status dnsmasq
+  ```
+  
+  If it is running and you do not need it, stop and disable it:
+  
+  ```bash
+  sudo systemctl stop dnsmasq
+  sudo systemctl disable dnsmasq
+  ```
 
-Create a new DNS configuration:
+<br>
 
-```bash
-cat <<EOF | sudo tee /etc/resolv.conf
-nameserver 1.1.1.1
-nameserver 8.8.8.8
-EOF
-```
-
-Verify DNS resolution:
-
-```bash
-ping -c 4 google.com
-```
-
-### Debian - dnsmasq
-
-Some Debian installations may have `dnsmasq` installed.
-
-Check its status:
-
-```bash
-sudo systemctl status dnsmasq
-```
-
-If it is running and you do not need it, stop and disable it:
-
-```bash
-sudo systemctl stop dnsmasq
-sudo systemctl disable dnsmasq
-```
-
-### Verify Port Availability
-
-Ensure that nothing is listening on port `53`:
-
-```bash
-sudo ss -tulpn | grep ':53'
-```
-
-If no output is returned, start Pi-hole again:
-
-```bash
-cd ~/pihole
-docker compose up -d
-```
-
-Verify the container status:
-
-```bash
-docker ps
-```
+* **Verify Port Availability**
+  
+  Ensure that nothing is listening on port `53`:
+  
+  ```bash
+  sudo ss -tulpn | grep ':53'
+  ```
+  
+  If no output is returned, start Pi-hole again:
+  
+  ```bash
+  cd ~/pihole
+  docker compose up -d
+  ```
+  
+  Verify the container status:
+  
+  ```bash
+  docker ps
+  ```
 
 ## Conclusion
 

--- a/tutorials/pihole-install/01.en.md
+++ b/tutorials/pihole-install/01.en.md
@@ -1,7 +1,7 @@
 ---
 SPDX-License-Identifier: MIT
-path: "/tutorials/how-to-install-pihole"
-slug: "how-to-install-pihole"
+path: "/tutorials/pihole-install"
+slug: "pihole-install"
 date: "2026-06-17"
 title: "How to Install Pi-hole with Docker on Debian and Ubuntu"
 short_description: "Learn how to install Docker and deploy Pi-hole using Docker Compose on Debian and Ubuntu servers."


### PR DESCRIPTION
# Description

This tutorial explains how to install Pi-hole using Docker and Docker Compose on Debian and Ubuntu servers.

It covers:

* Installing Docker Engine and Docker Compose from the official Docker repository
* Creating a persistent Pi-hole deployment using Docker Compose
* Configuring persistent storage for Pi-hole data and DNS settings
* Deploying and managing the Pi-hole container
* Accessing and securing the Pi-hole web interface
* Configuring clients and routers to use Pi-hole as their DNS server
* Updating and maintaining a Pi-hole installation
* Troubleshooting port 53 conflicts on both Debian and Ubuntu systems

The tutorial is intended for users who want to deploy a network-wide DNS filtering solution

# Checklist

* [x] Written in English
* [x] Original content, not published elsewhere
* [x] All tools used are free and open source
* [x] Tested and validated on Debian and Ubuntu
* [x] Previewed in the Hetzner Markdown test suite
* [x] License block included at the bottom
* [x] No sensitive data in the tutorial

I have read and understood the Contributor's Certificate of Origin available at the end of

https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md

and I hereby certify that I meet the contribution criteria described in it.

Signed-off-by: Miroslav Minárik miroslav.minarik@miomail.sk
