### PR TITLE
Add tutorial: Securing SSH on Ubuntu 22.04 with UFW and Fail2ban

### DIFF
--- a/tutorials/secure-ssh-with-ufw-and-fail2ban-on-ubuntu-22-04/01.en.md
+++ b/tutorials/secure-ssh-with-ufw-and-fail2ban-on-ubuntu-22-04/01.en.md
@@ -1,0 +1,261 @@
+---
+SPDX-License-Identifier: MIT
+path: "/tutorials/secure-ssh-with-ufw-and-fail2ban-on-ubuntu-22-04"
+slug: "secure-ssh-with-ufw-and-fail2ban-on-ubuntu-22-04"
+date: "2026-06-10"
+title: "Securing SSH on Ubuntu 22.04 with UFW and Fail2ban"
+short_description: "Set up a UFW firewall and make Fail2ban enforce its SSH bans through UFW on Ubuntu 22.04, so brute-force attempts get blocked at the firewall."
+tags: ["Ubuntu", "Ubuntu 22.04", "Security", "Firewall", "UFW", "Fail2ban", "SSH"]
+author: "Egemen KEYDAL"
+author_link: "https://github.com/KEYDALTR"
+author_img: "https://avatars.githubusercontent.com/u/274326765"
+author_description: ""
+language: "en"
+available_languages: ["en"]
+header_img: "header-6"
+cta: "dedicated"
+---
+
+## Introduction
+
+Put a server on the internet and the SSH login attempts start almost immediately. The vast majority are automated bots working through common username and password lists. Two tools handle this well on Ubuntu: UFW as a simple firewall, and Fail2ban to watch the auth logs and block whoever keeps failing to log in.
+
+By default these two don't talk to each other. Fail2ban installs its bans as raw `iptables` rules, while your visible firewall is UFW. That works, but your bans then live outside `ufw status`, which is confusing when you later try to audit what is blocked. This tutorial sets both up and, more importantly, tells Fail2ban to apply its bans *through* UFW, so every ban shows up as a normal UFW rule.
+
+**Prerequisites**
+
+* A server running Ubuntu 22.04 (this was tested on a fresh Ubuntu 22.04.5 LTS install).
+* Root access, or a user with `sudo`. The commands below are written for `root`; if you use a sudo user, put `sudo` in front of them.
+* SSH access to the server. If you are new to UFW itself, the tutorial "[Simple Firewall Management with UFW](https://community.hetzner.com/tutorials/simple-firewall-management-with-ufw)" covers the basics of rules.
+
+This tutorial uses the following example values. Replace them with your own:
+
+* IPv4 address of the server: `10.0.0.1`
+* Example attacker address used for the ban test: `198.51.100.23`
+
+## Step 1 - Install Fail2ban
+
+UFW already ships with Ubuntu, so there is nothing to install for the firewall itself. You can confirm it is present:
+
+```bash
+ufw version
+```
+
+On a fresh Ubuntu 22.04 server this returns:
+
+```
+ufw 0.36.1
+Copyright 2008-2021 Canonical Ltd.
+```
+
+Fail2ban is not installed by default. Update the package list and install it:
+
+```bash
+apt update
+apt install fail2ban
+```
+
+One thing to know about Ubuntu 22.04: after the package is installed, the service is left **disabled and stopped**. You can check:
+
+```bash
+systemctl is-enabled fail2ban
+systemctl is-active fail2ban
+```
+
+```
+disabled
+inactive
+```
+
+Leave it stopped for now. If you start it at this point it just loads the default jail with the default `iptables` ban action, which is exactly the behavior we want to change. We start it in Step 3, once the configuration is in place.
+
+## Step 2 - Set up the UFW firewall
+
+Before enabling the firewall, set the default policy to block incoming traffic and allow outgoing traffic:
+
+```bash
+ufw default deny incoming
+ufw default allow outgoing
+```
+
+Now the important part. The default policy blocks everything coming in, **including your SSH session**. If you enable UFW now, you will lock yourself out. Allow SSH first:
+
+```bash
+ufw allow OpenSSH
+```
+
+`OpenSSH` is an application profile that UFW ships with; it opens port 22/tcp. You can see the available profiles with `ufw app list`.
+
+With SSH allowed, enable the firewall:
+
+```bash
+ufw --force enable
+```
+
+The `--force` flag skips the interactive "this may disrupt existing ssh connections" prompt, which is what you want when you are already running over SSH and have allowed it.
+
+Check the result:
+
+```bash
+ufw status verbose
+```
+
+```
+Status: active
+Logging: on (low)
+Default: deny (incoming), allow (outgoing), disabled (routed)
+New profiles: skip
+
+To                         Action      From
+--                         ------      ----
+22/tcp (OpenSSH)           ALLOW IN    Anywhere
+22/tcp (OpenSSH (v6))      ALLOW IN    Anywhere (v6)
+```
+
+The firewall is active, only SSH is open, and your session is still alive.
+
+## Step 3 - Configure Fail2ban to ban through UFW
+
+Never edit `/etc/fail2ban/jail.conf` directly. It gets replaced on package updates. Fail2ban reads `/etc/fail2ban/jail.local` on top of it, so put your settings there.
+
+Create `/etc/fail2ban/jail.local`:
+
+```bash
+nano /etc/fail2ban/jail.local
+```
+
+Add the following:
+
+```ini
+[DEFAULT]
+# Ban for 1 hour after 5 failures within 10 minutes
+bantime  = 1h
+findtime = 10m
+maxretry = 5
+
+# Enforce bans through UFW instead of raw iptables
+banaction = ufw
+
+[sshd]
+enabled = true
+backend  = systemd
+```
+
+Two lines do the real work here:
+
+* `banaction = ufw` tells Fail2ban to use the `ufw` action that ships in `/etc/fail2ban/action.d/ufw.conf`, instead of its default `iptables` action. Bans become UFW rules.
+* `backend = systemd` for the `sshd` jail. On Ubuntu 22.04, OpenSSH logs to the systemd journal, so the journal backend is the reliable way for Fail2ban to read failed logins.
+
+Save the file. Now enable and start the service in one step:
+
+```bash
+systemctl enable --now fail2ban
+```
+
+Confirm the jail is running:
+
+```bash
+fail2ban-client status sshd
+```
+
+```
+Status for the jail: sshd
+|- Filter
+|  |- Currently failed:	0
+|  |- Total failed:	0
+|  `- Journal matches:	_SYSTEMD_UNIT=sshd.service + _COMM=sshd
+`- Actions
+   |- Currently banned:	0
+   |- Total banned:	0
+   `- Banned IP list:
+```
+
+Nothing is banned yet, which is expected. The `Journal matches` line confirms Fail2ban is reading SSH events from the journal.
+
+## Step 4 - Test that bans land in UFW
+
+You don't want to wait for a real attacker to confirm the integration works. You can ban an address by hand and watch it appear in UFW. The address `198.51.100.23` below is a reserved documentation address, so this is safe to run.
+
+Ban it:
+
+```bash
+fail2ban-client set sshd banip 198.51.100.23
+```
+
+The jail now lists it:
+
+```bash
+fail2ban-client status sshd
+```
+
+```
+`- Actions
+   |- Currently banned:	1
+   |- Total banned:	1
+   `- Banned IP list:	198.51.100.23
+```
+
+Now look at UFW:
+
+```bash
+ufw status numbered
+```
+
+```
+[ 1] Anywhere                   REJECT IN   198.51.100.23
+```
+
+This is the point of the whole setup. Fail2ban inserted a `REJECT` rule at position 1, above your allow rules, so the banned address is dropped before it ever reaches SSH. The ban is a normal UFW rule you can see and audit.
+
+Remove the test ban:
+
+```bash
+fail2ban-client set sshd unbanip 198.51.100.23
+```
+
+Check that the rule is gone:
+
+```bash
+ufw status | grep 198.51.100.23
+```
+
+This returns nothing, which means Fail2ban removed the UFW rule when it unbanned the address.
+
+From now on, any address that fails the SSH login five times within ten minutes gets the same treatment automatically, banned for one hour. If you watch `ufw status numbered` on a server that has been online for a while, you will see these rules come and go on their own.
+
+## Conclusion
+
+You now have a UFW firewall that only allows SSH, and a Fail2ban jail that watches the SSH journal and blocks repeated failures by writing real UFW rules. Because the bans live in UFW, `ufw status` shows your full picture of what is blocked, instead of leaving Fail2ban's bans hidden in a separate `iptables` chain.
+
+From here you can open additional ports as you add services (`ufw allow 80/tcp`, `ufw allow 443/tcp`), and add more Fail2ban jails for those services in the same `jail.local` file. Whenever you change `jail.local`, reload Fail2ban with `fail2ban-client reload`.
+
+##### License: MIT
+
+<!--
+
+Contributor's Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it under the license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate license and I have the
+    right under that license to submit that work with modifications,
+    whether created in whole or in part by me, under the same license
+    (unless I am permitted to submit under a different license), as
+    indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are
+    public and that a record of the contribution (including all personal
+    information I submit with it, including my sign-off) is maintained
+    indefinitely and may be redistributed consistent with this project
+    or the license(s) involved.
+
+Signed-off-by: Egemen KEYDAL <egemenkeydaltr@gmail.com>
+
+-->

--- a/tutorials/secure-ssh-with-ufw-and-fail2ban-on-ubuntu-22-04/01.en.md
+++ b/tutorials/secure-ssh-with-ufw-and-fail2ban-on-ubuntu-22-04/01.en.md
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/secure-ssh-with-ufw-and-fail2ban-on-ubuntu-22-04"
 slug: "secure-ssh-with-ufw-and-fail2ban-on-ubuntu-22-04"
-date: "2026-06-10"
+date: "2026-06-17"
 title: "Securing SSH on Ubuntu 22.04 with UFW and Fail2ban"
 short_description: "Set up a UFW firewall and make Fail2ban enforce its SSH bans through UFW on Ubuntu 22.04, so brute-force attempts get blocked at the firewall."
 tags: ["Ubuntu", "Ubuntu 22.04", "Security", "Firewall", "UFW", "Fail2ban", "SSH"]
@@ -24,9 +24,13 @@ By default these two don't talk to each other. Fail2ban installs its bans as raw
 
 **Prerequisites**
 
-* A server running Ubuntu 22.04 (this was tested on a fresh Ubuntu 22.04.5 LTS install).
-* Root access, or a user with `sudo`. The commands below are written for `root`; if you use a sudo user, put `sudo` in front of them.
+* A server running Ubuntu 22.04 / 24.04 / 26.04 (this was tested on a fresh Ubuntu install).
+* Root access, or a user with `sudo`.
 * SSH access to the server. If you are new to UFW itself, the tutorial "[Simple Firewall Management with UFW](https://community.hetzner.com/tutorials/simple-firewall-management-with-ufw)" covers the basics of rules.
+
+<br>
+
+**Example terminology**
 
 This tutorial uses the following example values. Replace them with your own:
 
@@ -41,18 +45,18 @@ UFW already ships with Ubuntu, so there is nothing to install for the firewall i
 ufw version
 ```
 
-On a fresh Ubuntu 22.04 server this returns:
+On a fresh Ubuntu server this returns:
 
-```
-ufw 0.36.1
-Copyright 2008-2021 Canonical Ltd.
+```text
+ufw 0.36.2
+Copyright 2008-2023 Canonical Ltd.
 ```
 
 Fail2ban is not installed by default. Update the package list and install it:
 
 ```bash
-apt update
-apt install fail2ban
+sudo apt update
+sudo apt install fail2ban
 ```
 
 One thing to know about Ubuntu 22.04: after the package is installed, the service is left **disabled and stopped**. You can check:
@@ -62,26 +66,40 @@ systemctl is-enabled fail2ban
 systemctl is-active fail2ban
 ```
 
-```
-disabled
-inactive
-```
+Output:
 
-Leave it stopped for now. If you start it at this point it just loads the default jail with the default `iptables` ban action, which is exactly the behavior we want to change. We start it in Step 3, once the configuration is in place.
+* **Disabled**
+  ```
+  disabled
+  inactive
+  ```
+  Leave it stopped for now. If you start it at this point it just loads the default jail with the default `iptables` ban action, which is exactly the behavior we want to change. We start it in Step 3, once the configuration is in place.
+
+<br>
+
+* **Enabled**
+  ```
+  enabled
+  active
+  ```
+  Stop it for now. We will restart it in Step 3, once the configuration is in place.
+  ```bash
+  sudo systemctl stop fail2ban
+  ```
 
 ## Step 2 - Set up the UFW firewall
 
 Before enabling the firewall, set the default policy to block incoming traffic and allow outgoing traffic:
 
 ```bash
-ufw default deny incoming
-ufw default allow outgoing
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
 ```
 
 Now the important part. The default policy blocks everything coming in, **including your SSH session**. If you enable UFW now, you will lock yourself out. Allow SSH first:
 
 ```bash
-ufw allow OpenSSH
+sudo ufw allow OpenSSH
 ```
 
 `OpenSSH` is an application profile that UFW ships with; it opens port 22/tcp. You can see the available profiles with `ufw app list`.
@@ -89,7 +107,7 @@ ufw allow OpenSSH
 With SSH allowed, enable the firewall:
 
 ```bash
-ufw --force enable
+sudo ufw --force enable
 ```
 
 The `--force` flag skips the interactive "this may disrupt existing ssh connections" prompt, which is what you want when you are already running over SSH and have allowed it.
@@ -97,7 +115,7 @@ The `--force` flag skips the interactive "this may disrupt existing ssh connecti
 Check the result:
 
 ```bash
-ufw status verbose
+sudo ufw status verbose
 ```
 
 ```
@@ -121,7 +139,7 @@ Never edit `/etc/fail2ban/jail.conf` directly. It gets replaced on package updat
 Create `/etc/fail2ban/jail.local`:
 
 ```bash
-nano /etc/fail2ban/jail.local
+sudo nano /etc/fail2ban/jail.local
 ```
 
 Add the following:
@@ -143,22 +161,24 @@ backend  = systemd
 
 Two lines do the real work here:
 
-* `banaction = ufw` tells Fail2ban to use the `ufw` action that ships in `/etc/fail2ban/action.d/ufw.conf`, instead of its default `iptables` action. Bans become UFW rules.
-* `backend = systemd` for the `sshd` jail. On Ubuntu 22.04, OpenSSH logs to the systemd journal, so the journal backend is the reliable way for Fail2ban to read failed logins.
+|                   | Description |
+| ----------------- | ----------- |
+| `banaction = ufw` | tells Fail2ban to use the `ufw` action that ships in `/etc/fail2ban/action.d/ufw.conf`, instead of its default `iptables` action. Bans become UFW rules. |
+| `backend = systemd` | For the `sshd` jail. On Ubuntu 22.04, OpenSSH logs to the systemd journal, so the journal backend is the reliable way for Fail2ban to read failed logins. |
 
 Save the file. Now enable and start the service in one step:
 
 ```bash
-systemctl enable --now fail2ban
+sudo systemctl enable --now fail2ban
 ```
 
 Confirm the jail is running:
 
 ```bash
-fail2ban-client status sshd
+sudo fail2ban-client status sshd
 ```
 
-```
+```shell
 Status for the jail: sshd
 |- Filter
 |  |- Currently failed:	0
@@ -179,13 +199,13 @@ You don't want to wait for a real attacker to confirm the integration works. You
 Ban it:
 
 ```bash
-fail2ban-client set sshd banip 198.51.100.23
+sudo fail2ban-client set sshd banip 198.51.100.23
 ```
 
 The jail now lists it:
 
 ```bash
-fail2ban-client status sshd
+sudo fail2ban-client status sshd
 ```
 
 ```
@@ -198,7 +218,7 @@ fail2ban-client status sshd
 Now look at UFW:
 
 ```bash
-ufw status numbered
+sudo ufw status numbered
 ```
 
 ```
@@ -210,13 +230,13 @@ This is the point of the whole setup. Fail2ban inserted a `REJECT` rule at posit
 Remove the test ban:
 
 ```bash
-fail2ban-client set sshd unbanip 198.51.100.23
+sudo fail2ban-client set sshd unbanip 198.51.100.23
 ```
 
 Check that the rule is gone:
 
 ```bash
-ufw status | grep 198.51.100.23
+sudo ufw status | grep 198.51.100.23
 ```
 
 This returns nothing, which means Fail2ban removed the UFW rule when it unbanned the address.
@@ -227,7 +247,11 @@ From now on, any address that fails the SSH login five times within ten minutes 
 
 You now have a UFW firewall that only allows SSH, and a Fail2ban jail that watches the SSH journal and blocks repeated failures by writing real UFW rules. Because the bans live in UFW, `ufw status` shows your full picture of what is blocked, instead of leaving Fail2ban's bans hidden in a separate `iptables` chain.
 
-From here you can open additional ports as you add services (`ufw allow 80/tcp`, `ufw allow 443/tcp`), and add more Fail2ban jails for those services in the same `jail.local` file. Whenever you change `jail.local`, reload Fail2ban with `fail2ban-client reload`.
+From here you can open additional ports as you add services (`ufw allow 80/tcp`, `ufw allow 443/tcp`), and add more Fail2ban jails for those services in the same `jail.local` file. Whenever you change `jail.local`, reload Fail2ban with:
+
+```bash
+sudo fail2ban-client reload
+```
 
 ##### License: MIT
 

--- a/tutorials/secure-ssh-with-ufw-and-fail2ban-on-ubuntu/01.en.md
+++ b/tutorials/secure-ssh-with-ufw-and-fail2ban-on-ubuntu/01.en.md
@@ -3,9 +3,9 @@ SPDX-License-Identifier: MIT
 path: "/tutorials/secure-ssh-with-ufw-and-fail2ban-on-ubuntu"
 slug: "secure-ssh-with-ufw-and-fail2ban-on-ubuntu"
 date: "2026-06-17"
-title: "Securing SSH on Ubuntu 22.04 with UFW and Fail2ban"
-short_description: "Set up a UFW firewall and make Fail2ban enforce its SSH bans through UFW on Ubuntu 22.04, so brute-force attempts get blocked at the firewall."
-tags: ["Ubuntu", "Ubuntu 22.04", "Security", "Firewall", "UFW", "Fail2ban", "SSH"]
+title: "Securing SSH on Ubuntu with UFW and Fail2ban"
+short_description: "Set up a UFW firewall and make Fail2ban enforce its SSH bans through UFW on Ubuntu, so brute-force attempts get blocked at the firewall."
+tags: ["Ubuntu", "Ubuntu", "Security", "Firewall", "UFW", "Fail2ban", "SSH"]
 author: "Egemen KEYDAL"
 author_link: "https://github.com/KEYDALTR"
 author_img: "https://avatars.githubusercontent.com/u/274326765"

--- a/tutorials/secure-ssh-with-ufw-and-fail2ban-on-ubuntu/01.en.md
+++ b/tutorials/secure-ssh-with-ufw-and-fail2ban-on-ubuntu/01.en.md
@@ -1,7 +1,7 @@
 ---
 SPDX-License-Identifier: MIT
-path: "/tutorials/secure-ssh-with-ufw-and-fail2ban-on-ubuntu-22-04"
-slug: "secure-ssh-with-ufw-and-fail2ban-on-ubuntu-22-04"
+path: "/tutorials/secure-ssh-with-ufw-and-fail2ban-on-ubuntu"
+slug: "secure-ssh-with-ufw-and-fail2ban-on-ubuntu"
 date: "2026-06-17"
 title: "Securing SSH on Ubuntu 22.04 with UFW and Fail2ban"
 short_description: "Set up a UFW firewall and make Fail2ban enforce its SSH bans through UFW on Ubuntu 22.04, so brute-force attempts get blocked at the firewall."


### PR DESCRIPTION
This tutorial sets up a UFW firewall and configures Fail2ban to enforce its SSH bans through UFW (banaction = ufw) on Ubuntu 22.04, so brute-force bans appear as normal UFW rules. Tested end to end on a fresh Ubuntu 22.04.5 LTS server.

I have read and understood the Contributor's Certificate of Origin available at the end of https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md and I hereby certify that I meet the contribution criteria described in it.

Signed-off-by: Egemen KEYDAL <egemenkeydaltr@gmail.com>