### PR TITLE
Minor fix to update image paths in Ubuntu full-encryption tuturials

### DIFF
--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption-with-clevis-and-tang/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption-with-clevis-and-tang/01.de.md
@@ -86,7 +86,7 @@ HOSTNAME host.example.com
 PART /boot/efi esp 256M
 PART /boot ext4 1G
 PART /     ext4 all crypt
-IMAGE /root/images/Ubuntu-2204-jammy-amd64-base.tar.gz
+IMAGE /root/images/Ubuntu-2204-jammy-amd64-base.tar.zst
 ```
 
 Wenn in Schritt 2 ein SSH-Schlüssel konfiguriert wurde, füge bitte auch die folgende Zeile in `/tmp/setup.conf` ein.

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption-with-clevis-and-tang/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption-with-clevis-and-tang/01.en.md
@@ -86,7 +86,7 @@ HOSTNAME host.example.com
 PART /boot/efi esp 256M
 PART /boot ext4 1G
 PART /     ext4 all crypt
-IMAGE /root/images/Ubuntu-2204-jammy-amd64-base.tar.gz
+IMAGE /root/images/Ubuntu-2204-jammy-amd64-base.tar.zst
 ```
 
 If an SSH-Key has been configured in Step 2, please also add the following line to `/tmp/setup.conf`.

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
@@ -78,7 +78,7 @@ HOSTNAME host.example.com
 PART /boot/efi esp 256M
 PART /boot ext4 1G
 PART /     ext4 all crypt
-IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.gz
+IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.zst
 SSHKEYS_URL /tmp/authorized_keys
 ```
 
@@ -134,7 +134,7 @@ HOSTNAME host.example.com
 PART /boot/efi esp 256M
 PART /boot ext4 1G
 PART /     ext4 all crypt
-IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.gz
+IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.zst
 SSHKEYS_URL /tmp/authorized_keys
 ```
 
@@ -198,7 +198,7 @@ HOSTNAME host.example.com
 PART /boot/efi esp 256M
 PART /boot ext4 1G
 PART /     ext4 all crypt
-IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.gz
+IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.zst
 SSHKEYS_URL /tmp/authorized_keys
 ```
 
@@ -227,7 +227,7 @@ PART /boot ext4 1G
 PART lvm vg0 all crypt
 LV vg0 root / ext4 50G
 LV vg0 home /home ext4 1500G
-IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.gz
+IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.zst
 SSHKEYS_URL /tmp/authorized_keys
 ```
 

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
@@ -77,7 +77,7 @@ HOSTNAME host.example.com
 PART /boot/efi esp 256M
 PART /boot ext4 1G
 PART /     ext4 all crypt
-IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.gz
+IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.zst
 SSHKEYS_URL /tmp/authorized_keys
 ```
 
@@ -133,7 +133,7 @@ HOSTNAME host.example.com
 PART /boot/efi esp 256M
 PART /boot ext4 1G
 PART /     ext4 all crypt
-IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.gz
+IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.zst
 SSHKEYS_URL /tmp/authorized_keys
 ```
 
@@ -197,7 +197,7 @@ HOSTNAME host.example.com
 PART /boot/efi esp 256M
 PART /boot ext4 1G
 PART /     ext4 all crypt
-IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.gz
+IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.zst
 SSHKEYS_URL /tmp/authorized_keys
 ```
 
@@ -226,7 +226,7 @@ PART /boot ext4 1G
 PART lvm vg0 all crypt
 LV vg0 root / ext4 50G
 LV vg0 home /home ext4 1500G
-IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.gz
+IMAGE /root/images/Ubuntu-2404-noble-amd64-base.tar.zst
 SSHKEYS_URL /tmp/authorized_keys
 ```
 


### PR DESCRIPTION
Previous paths aren't working anymore, images in rescue-mode got changed from tar.gz to tar.zst

> I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Ralph Weires