### PR TITLE
Make gateway extraction in full-disk-encryption tutorials more robust

### DIFF
--- a/tutorials/install-almalinux-10-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-almalinux-10-with-full-disk-encryption/01.de.md
@@ -254,7 +254,7 @@ add_initramfs_network() {
 
   mainif="$(ip --json a show up | jq -r 'del(.[] | select(.ifname == "lo")) | .[0]')" # main network interface
   ip="$(echo $mainif | jq -r '.addr_info[0].local')" # main IP
-  gw="$(ip --json -4 neigh show nud reachable | jq -r '.[0].dst')" # gateway
+  gw="$(ip --json -4 route show default | jq -r '.[0].gateway')" # gateway
   nn="$(echo $mainif | jq -r '.altnames[0]')" # interface name
 
   echo -e "kernel_cmdline=\"rd.neednet=1 ip=$ip::$gw:255.255.255.255::$nn:none:185.12.64.1:185.12.64.2:213.239.239.164\"\nadd_dracutmodules+=\" network \"" > /etc/dracut.conf.d/90-network.conf

--- a/tutorials/install-almalinux-10-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-almalinux-10-with-full-disk-encryption/01.de.md
@@ -254,7 +254,7 @@ add_initramfs_network() {
 
   mainif="$(ip --json a show up | jq -r 'del(.[] | select(.ifname == "lo")) | .[0]')" # main network interface
   ip="$(echo $mainif | jq -r '.addr_info[0].local')" # main IP
-  gw="$(ip --json n | jq -r '.[0].dst')" # gateway
+  gw="$(ip --json -4 neigh show nud reachable | jq -r '.[0].dst')" # gateway
   nn="$(echo $mainif | jq -r '.altnames[0]')" # interface name
 
   echo -e "kernel_cmdline=\"rd.neednet=1 ip=$ip::$gw:255.255.255.255::$nn:none:185.12.64.1:185.12.64.2:213.239.239.164\"\nadd_dracutmodules+=\" network \"" > /etc/dracut.conf.d/90-network.conf

--- a/tutorials/install-almalinux-10-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-almalinux-10-with-full-disk-encryption/01.en.md
@@ -253,7 +253,7 @@ add_initramfs_network() {
 
   mainif="$(ip --json a show up | jq -r 'del(.[] | select(.ifname == "lo")) | .[0]')" # main network interface
   ip="$(echo $mainif | jq -r '.addr_info[0].local')" # main IP
-  gw="$(ip --json n | jq -r '.[0].dst')" # gateway
+  gw="$(ip --json -4 neigh show nud reachable | jq -r '.[0].dst')" # gateway
   nn="$(echo $mainif | jq -r '.altnames[0]')" # interface name
 
   echo -e "kernel_cmdline=\"rd.neednet=1 ip=$ip::$gw:255.255.255.255::$nn:none:185.12.64.1:185.12.64.2:213.239.239.164\"\nadd_dracutmodules+=\" network \"" > /etc/dracut.conf.d/90-network.conf

--- a/tutorials/install-almalinux-10-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-almalinux-10-with-full-disk-encryption/01.en.md
@@ -253,7 +253,7 @@ add_initramfs_network() {
 
   mainif="$(ip --json a show up | jq -r 'del(.[] | select(.ifname == "lo")) | .[0]')" # main network interface
   ip="$(echo $mainif | jq -r '.addr_info[0].local')" # main IP
-  gw="$(ip --json -4 neigh show nud reachable | jq -r '.[0].dst')" # gateway
+  gw="$(ip --json -4 route show default | jq -r '.[0].gateway')" # gateway
   nn="$(echo $mainif | jq -r '.altnames[0]')" # interface name
 
   echo -e "kernel_cmdline=\"rd.neednet=1 ip=$ip::$gw:255.255.255.255::$nn:none:185.12.64.1:185.12.64.2:213.239.239.164\"\nadd_dracutmodules+=\" network \"" > /etc/dracut.conf.d/90-network.conf

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
@@ -252,7 +252,7 @@ add_initramfs_network() {
 
   mainif="$(ip --json a show up | jq -r 'del(.[] | select(.ifname == "lo")) | .[0]')" # main network interface
   ip="$(echo $mainif | jq -r '.addr_info[0].local')" # main IP
-  gw="$(ip --json -4 neigh show nud reachable | jq -r '.[0].dst')" # gateway
+  gw="$(ip --json -4 route show default | jq -r '.[0].gateway')" # gateway
   nn="$(echo $mainif | jq -r '.altnames[0]')" # name of interface
 
   echo "IP=$ip::$gw:255.255.255.255::$nn:none:185.12.64.1:185.12.64.2:213.239.239.164" >> /etc/initramfs-tools/initramfs.conf
@@ -309,7 +309,7 @@ add_initramfs_network() {
 
   mainif="$(ip --json a show up | jq -r 'del(.[] | select(.ifname == "lo")) | .[0]')" # main network interface
   ip="$(echo $mainif | jq -r '.addr_info[0].local')" # main IP
-  gw="$(ip --json -4 neigh show nud reachable | jq -r '.[0].dst')" # gateway
+  gw="$(ip --json -4 route show default | jq -r '.[0].gateway')" # gateway
   nn="$(echo $mainif | jq -r '.altnames[0]')" # interface name
 
   echo "IP=$ip::$gw:255.255.255.255::$nn:none:185.12.64.1:185.12.64.2:213.239.239.164" >> /etc/initramfs-tools/initramfs.conf

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.de.md
@@ -252,7 +252,7 @@ add_initramfs_network() {
 
   mainif="$(ip --json a show up | jq -r 'del(.[] | select(.ifname == "lo")) | .[0]')" # main network interface
   ip="$(echo $mainif | jq -r '.addr_info[0].local')" # main IP
-  gw="$(ip --json n | jq -r '.[0].dst')" # gateway
+  gw="$(ip --json -4 neigh show nud reachable | jq -r '.[0].dst')" # gateway
   nn="$(echo $mainif | jq -r '.altnames[0]')" # name of interface
 
   echo "IP=$ip::$gw:255.255.255.255::$nn:none:185.12.64.1:185.12.64.2:213.239.239.164" >> /etc/initramfs-tools/initramfs.conf
@@ -309,7 +309,7 @@ add_initramfs_network() {
 
   mainif="$(ip --json a show up | jq -r 'del(.[] | select(.ifname == "lo")) | .[0]')" # main network interface
   ip="$(echo $mainif | jq -r '.addr_info[0].local')" # main IP
-  gw="$(ip --json n | jq -r '.[0].dst')" # gateway
+  gw="$(ip --json -4 neigh show nud reachable | jq -r '.[0].dst')" # gateway
   nn="$(echo $mainif | jq -r '.altnames[0]')" # interface name
 
   echo "IP=$ip::$gw:255.255.255.255::$nn:none:185.12.64.1:185.12.64.2:213.239.239.164" >> /etc/initramfs-tools/initramfs.conf

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
@@ -251,7 +251,7 @@ add_initramfs_network() {
 
   mainif="$(ip --json a show up | jq -r 'del(.[] | select(.ifname == "lo")) | .[0]')" # main network interface
   ip="$(echo $mainif | jq -r '.addr_info[0].local')" # main IP
-  gw="$(ip --json n | jq -r '.[0].dst')" # gateway
+  gw="$(ip --json -4 neigh show nud reachable | jq -r '.[0].dst')" # gateway
   nn="$(echo $mainif | jq -r '.altnames[0]')" # interface name
 
   echo "IP=$ip::$gw:255.255.255.255::$nn:none:185.12.64.1:185.12.64.2:213.239.239.164" >> /etc/initramfs-tools/initramfs.conf
@@ -308,7 +308,7 @@ add_initramfs_network() {
 
   mainif="$(ip --json a show up | jq -r 'del(.[] | select(.ifname == "lo")) | .[0]')" # main network interface
   ip="$(echo $mainif | jq -r '.addr_info[0].local')" # main IP
-  gw="$(ip --json n | jq -r '.[0].dst')" # gateway
+  gw="$(ip --json -4 neigh show nud reachable | jq -r '.[0].dst')" # gateway
   nn="$(echo $mainif | jq -r '.altnames[0]')" # interface name
 
   echo "IP=$ip::$gw:255.255.255.255::$nn:none:185.12.64.1:185.12.64.2:213.239.239.164" >> /etc/initramfs-tools/initramfs.conf

--- a/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
+++ b/tutorials/install-ubuntu-2004-with-full-disk-encryption/01.en.md
@@ -251,7 +251,7 @@ add_initramfs_network() {
 
   mainif="$(ip --json a show up | jq -r 'del(.[] | select(.ifname == "lo")) | .[0]')" # main network interface
   ip="$(echo $mainif | jq -r '.addr_info[0].local')" # main IP
-  gw="$(ip --json -4 neigh show nud reachable | jq -r '.[0].dst')" # gateway
+  gw="$(ip --json -4 route show default | jq -r '.[0].gateway')" # gateway
   nn="$(echo $mainif | jq -r '.altnames[0]')" # interface name
 
   echo "IP=$ip::$gw:255.255.255.255::$nn:none:185.12.64.1:185.12.64.2:213.239.239.164" >> /etc/initramfs-tools/initramfs.conf
@@ -308,7 +308,7 @@ add_initramfs_network() {
 
   mainif="$(ip --json a show up | jq -r 'del(.[] | select(.ifname == "lo")) | .[0]')" # main network interface
   ip="$(echo $mainif | jq -r '.addr_info[0].local')" # main IP
-  gw="$(ip --json -4 neigh show nud reachable | jq -r '.[0].dst')" # gateway
+  gw="$(ip --json -4 route show default | jq -r '.[0].gateway')" # gateway
   nn="$(echo $mainif | jq -r '.altnames[0]')" # interface name
 
   echo "IP=$ip::$gw:255.255.255.255::$nn:none:185.12.64.1:185.12.64.2:213.239.239.164" >> /etc/initramfs-tools/initramfs.conf


### PR DESCRIPTION
Fix for #1487

Filter only on `reachable` and IPv4 neighbor entries.

> I have read and understood the Contributor's Certificate of Origin available at the end of
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Ralph Weires

Edit: Changed things a bit more to use `ip route` right away, which seems better for gateway extraction.