### PR TITLE
Add tutorial: Hosting a WordPress Site on Ubuntu 24.04 with Panelica

### DIFF
--- a/tutorials/host-a-wordpress-site-on-ubuntu-with-panelica/01.en.md
+++ b/tutorials/host-a-wordpress-site-on-ubuntu-with-panelica/01.en.md
@@ -1,0 +1,215 @@
+---
+SPDX-License-Identifier: MIT
+path: "/tutorials/host-a-wordpress-site-on-ubuntu-with-panelica"
+slug: "host-a-wordpress-site-on-ubuntu-with-panelica"
+date: "2026-07-14"
+title: "Hosting a WordPress Site on Ubuntu 24.04 with Panelica"
+short_description: "Set up a server from scratch and host a WordPress site with the free version of the Panelica control panel: firewall, DNS, one-click install, and SSL."
+tags: ["WordPress", "Ubuntu", "Panelica"]
+author: "Panelica"
+author_link: "https://github.com/Panelica"
+author_img: "https://avatars.githubusercontent.com/u/261654611?v=4"
+author_description: "Maintainers of the Panelica server management panel."
+language: "en"
+available_languages: ["en"]
+header_img: "header-6"
+cta: "cloud"
+---
+
+## Introduction
+
+This tutorial walks through hosting a [WordPress](https://wordpress.org/) website on a fresh Ubuntu 24.04 server, using the free version of the open-core control panel [Panelica](https://panelica.com/) to handle the web server, DNS, and SSL certificate for you.
+
+WordPress powers a large share of the web, but running it in production means more than copying files: you need a web server, a database, correct DNS records, a valid TLS certificate, and a firewall. Doing each of those by hand is a good learning exercise; doing them for several sites quickly becomes repetitive. A control panel automates the repetitive parts while leaving you in full control of your own server.
+
+By the end you will have:
+
+- A hardened Ubuntu 24.04 server with a non-root user and a firewall
+- Panelica installed and running on its free plan
+- A domain pointed at your server
+- A WordPress site served over HTTPS with an automatically issued and renewed certificate
+
+The steps for server preparation, DNS, and firewalling are useful on their own — they apply to any application you host, not just WordPress.
+
+**Panelica editions:** Panelica offers a free plan ("Free forever", up to 3 domains) alongside paid plans. This tutorial only uses features available on the free plan. The panel software is installed directly on your own server; nothing about your sites is hosted elsewhere.
+
+**Prerequisites:**
+
+- One server running Ubuntu 24.04 (a small instance with 2 GB of RAM is enough to start)
+- A registered domain name that you can edit DNS records for
+- Basic familiarity with connecting to a server over SSH
+- Root or sudo access to the server
+
+**Example terminology used in this tutorial:**
+
+- Username: `holu`
+- Server IPv4 address: `<203.0.113.1>`
+- Domain: `<example.com>`
+
+Replace these with your own values wherever they appear.
+
+## Step 1 - Prepare the server
+
+Connect to your new server as `root`:
+
+```bash
+ssh root@<203.0.113.1>
+```
+
+Update the system packages first:
+
+```bash
+apt update && apt upgrade -y
+```
+
+Create a non-root user for day-to-day administration and give it sudo rights:
+
+```bash
+adduser holu
+usermod -aG sudo holu
+```
+
+Copy your SSH key to the new user so you can log in without a password. From your local machine:
+
+```bash
+ssh-copy-id holu@<203.0.113.1>
+```
+
+Confirm you can log in as the new user, then use `sudo` for administrative commands from now on. Installing the panel itself requires root privileges, which `sudo` provides.
+
+## Step 2 - Configure a firewall
+
+A WordPress host needs a small, well-defined set of open ports. At minimum:
+
+| Port | Protocol | Purpose |
+| ---- | -------- | ------- |
+| 22   | TCP      | SSH administration |
+| 80   | TCP      | HTTP (needed for certificate issuance and redirects) |
+| 443  | TCP      | HTTPS (your website) |
+| 8443 | TCP      | Panelica web interface |
+
+If you manage the firewall on the server itself, `ufw` is a straightforward option:
+
+```bash
+sudo ufw allow 22/tcp
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw allow 8443/tcp
+sudo ufw enable
+```
+
+Restrict SSH and the panel port (`22` and `8443`) to your own IP address where possible, so administration interfaces are not exposed to the whole internet.
+
+## Step 3 - Point your domain at the server
+
+For the certificate and the site to work, your domain must resolve to the server's IP address. In your domain registrar's DNS settings, create an `A` record:
+
+| Type | Name | Value |
+| ---- | ---- | ----- |
+| A    | @    | `<203.0.113.1>` |
+| A    | www  | `<203.0.113.1>` |
+
+DNS changes can take anywhere from a few minutes to a few hours to propagate. You can check progress with:
+
+```bash
+dig +short <example.com>
+```
+
+When the command returns your server's IP address, DNS is ready. Do not issue the SSL certificate until this resolves correctly, because certificate validation relies on it.
+
+## Step 4 - Install Panelica
+
+Log in to the server (as your sudo user) and run the installer:
+
+```bash
+curl -sSL https://latest.panelica.com/install.sh | sudo bash
+```
+
+The installer sets up the web server, database, and supporting services under a self-contained directory and configures them to start automatically. This takes a few minutes. When it finishes, it prints the URL of the panel and the initial administrator credentials — note these down.
+
+Open the panel in your browser:
+
+```
+https://<203.0.113.1>:8443
+```
+
+Your browser will warn about the certificate on first access, because the panel is initially reachable by IP address before you have a domain and certificate for it. This is expected; proceed to the login page and sign in with the administrator credentials from the installer output. Change the administrator password immediately after logging in.
+
+## Step 5 - Complete the setup wizard
+
+On first login, the panel opens a short setup wizard. To start on the free plan, enter your email address in the field provided and start the free plan from the wizard — no payment is required, and the email is only used for your panel account. The free plan lets you host up to three domains, which is enough for this tutorial and for a small personal setup.
+
+Once the wizard finishes, you land on the dashboard, which shows the status of the server's services. Confirm that the core services (web server, database, DNS) are running before continuing.
+
+## Step 6 - Add your domain
+
+In the panel, open the **Domains** section and add `<example.com>`. Panelica provisions the domain automatically: it creates the web server configuration, the document root where your site files live, and a DNS zone.
+
+After adding the domain, verify that it loads over plain HTTP in your browser (`http://<example.com>`). You should see a default placeholder page served from your server. If you do, DNS and the web server are wired up correctly and you are ready to install WordPress.
+
+## Step 7 - Install WordPress
+
+Panelica can install WordPress for you rather than requiring a manual download, database creation, and `wp-config.php` edit.
+
+1. Open the **WordPress** section of the panel.
+2. Choose to install a new WordPress site and select `<example.com>` as the target domain.
+3. Provide the site title and an administrator account (username, password, and email) for WordPress itself. Keep these separate from your panel and server credentials.
+4. Start the installation.
+
+The panel creates a dedicated database, generates the WordPress configuration, downloads the latest WordPress release into the domain's document root, and completes the setup. When it finishes, visit `http://<example.com>/wp-admin` and log in with the WordPress administrator account you just created.
+
+## Step 8 - Secure the site with HTTPS
+
+Serving a site over plain HTTP is no longer acceptable for production; browsers flag it and logins are sent in the clear. Panelica can obtain a free certificate from Let's Encrypt and renew it automatically.
+
+1. Open the **SSL** section for `<example.com>`.
+2. Request a certificate. Because your domain already resolves to the server (Step 3) and port 80 is open (Step 2), the validation succeeds automatically.
+3. Enable the option to force HTTPS, so visitors on `http://` are redirected to `https://`.
+
+After the certificate is issued, update WordPress to use the HTTPS address. In **Settings > General** inside `wp-admin`, set both the *WordPress Address* and *Site Address* to `https://<example.com>`. Reload the site; it should now load over HTTPS with a valid certificate, and the certificate will renew on its own before it expires.
+
+## Step 9 - Basic hardening
+
+A few final steps protect the panel and the site:
+
+- **Enable two-factor authentication** on your panel administrator account. Panelica supports time-based one-time passwords (TOTP), which stops a leaked password alone from granting access.
+- **Keep WordPress updated.** Log in to `wp-admin` regularly and apply core, theme, and plugin updates, or enable automatic updates for minor releases.
+- **Restrict administrative ports.** As noted in Step 2, limit SSH (`22`) and the panel (`8443`) to trusted IP addresses.
+- **Use strong, unique passwords** for the server user, the panel administrator, and the WordPress administrator — three separate accounts, three separate passwords.
+
+## Conclusion
+
+You now have a WordPress site running on your own Ubuntu 24.04 server, served over HTTPS with an automatically renewing certificate, behind a firewall, and managed through a control panel on its free plan. The same server can host up to three domains on the free plan, and the preparation steps — user setup, firewall, DNS, and SSL — transfer directly to any other web application you choose to host.
+
+From here, sensible next steps are configuring scheduled backups of your site and database, and adding the remaining domains you want to host.
+
+##### License: MIT
+
+<!--
+
+Contributor's Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+    the right to submit it under the license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate license and I have the
+    right under that license to submit that work with modifications,
+    whether created in whole or in part by me, under the same license
+    (unless I am permitted to submit under a different license), as
+    indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person
+    who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are
+    public and that a record of the contribution (including all personal
+    information I submit with it, including my sign-off) is maintained
+    indefinitely and may be redistributed consistent with this project
+    or the license(s) involved.
+
+Signed-off-by: Panelica info@panelica.com
+
+-->


### PR DESCRIPTION
This pull request adds a new tutorial: **Hosting a WordPress Site on Ubuntu 24.04 with Panelica**.

It walks a reader through hosting a WordPress site on a fresh Ubuntu 24.04 server using the free plan of the Panelica control panel: server preparation and a non-root user, firewall configuration, pointing a domain via DNS, installing the panel, the setup wizard, adding the domain, a one-click WordPress install, issuing a Let's Encrypt certificate, and basic hardening.

- New tutorial, no existing tutorial covers this topic.
- Focuses on a concrete use-case (hosting WordPress), not on the product itself. The server-preparation, DNS, firewall, and SSL steps are generally useful.
- Uses only features available on the free plan.
- No references to any competitors.
- Licensed MIT with the Contributor's Certificate of Origin sign-off included.
