### PR TITLE
hetzner-ddns-bridge: update for Hetzner Console API only (legacy DNS API shutdown)

### DIFF
--- a/tutorials/hetzner-ddns-bridge/01.de.md
+++ b/tutorials/hetzner-ddns-bridge/01.de.md
@@ -2,9 +2,9 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/hetzner-ddns-bridge/de"
 slug: "hetzner-ddns-bridge"
-date: "2026-02-03"
-title: "Hetzner DynDNS Bridge: Hetzner Console API und DNS Console API"
-short_description: "Ein PHP-/SQLite-Skript, das Hetzner-DNS-Zonen über die APIs der DNS Console (Legacy) und der Hetzner Console synchron hält."
+date: "2026-08-05"
+title: "Hetzner DynDNS Bridge für die Hetzner Console API"
+short_description: "Ein PHP-/SQLite-Skript, das einen DynDNS-Endpunkt bereitstellt und Hetzner-DNS-Zonen über die Hetzner Console API synchron hält."
 tags: ["Hetzner DNS", "Hetzner Console", "Automation", "PHP"]
 author: "woehrl"
 author_link: "https://github.com/woehrl"
@@ -18,14 +18,17 @@ cta: "cloud"
 
 ## Einführung
 
-Deine IPv4/IPv6 soll folgen wie ein treuer Hund, ohne dass du DNS von Hand pflegen musst? Dieses kleine PHP-Skript spielt DynDNS-Server, spricht sowohl die [Hetzner Console](https://console.hetzner.com/) API als auch die Legacy [DNS Console](https://dns.hetzner.com/) API und versteht sich mit Routern wie einer Fritz!Box. Zuerst kommt die Schritt-für-Schritt-Anleitung für Einsteiger, danach die Nerd-Ecke mit den Details. Neue Zonen lassen sich seit 10. November 2025 nicht mehr in der DNS Console anlegen; plane die Migration in die Hetzner Console ein und halte DNS Console nur während des Umzugs aktiv.
+Deine IPv4/IPv6 soll folgen wie ein treuer Hund, ohne dass du DNS von Hand pflegen musst? Dieses kleine PHP-Skript spielt DynDNS-Server, spricht die [Hetzner Console](https://console.hetzner.com/) API und versteht sich mit Routern wie einer Fritz!Box. Zuerst kommt die Schritt-für-Schritt-Anleitung für Einsteiger, danach die Nerd-Ecke mit den Details.
+
+> **Update August 2026:** Hetzner hat die alte DNS Console (`dns.hetzner.com`) samt Legacy-API im Mai 2026 abgeschaltet; verbliebene Zonen wurden automatisch in die Hetzner Console migriert. Dieses Tutorial und das Skript wurden entsprechend aktualisiert und nutzen ausschließlich die Hetzner Console API. Außerdem neu: Unterstützung für IPv6-only-Anschlüsse (DS-Lite), dedizierte `myip6`-/`myipv6`-Parameter und protokollkonforme `nochg`-Antworten. Wer noch eine ältere Version des Skripts einsetzt, findet Migrationshinweise in der Nerd-Ecke.
 
 **Voraussetzungen**
 
-- Ein Hetzner-Account mit mindestens einer DNS-Zone (Hetzner Console oder DNS Console während der Migration).
+- Ein Hetzner-Account mit mindestens einer DNS-Zone in der [Hetzner Console](https://console.hetzner.com/).
 - PHP mit den Erweiterungen `curl` und `SQLite3` (Webspace oder kleine VM reicht).
 - Einen Ort für das PHP-Skript und einen Cronjob alle paar Minuten.
 - Einen Client, der eine DynDNS-URL aufrufen kann (Router, NAS oder ein einfacher curl-Aufruf).
+- Die A-/AAAA-Records, die aktualisiert werden sollen, müssen in der Zone bereits existieren — das Skript ändert nur Werte und legt bewusst keine neuen Records an.
 
 ## Schritt 0 - Beispiel-Setup auf Debian/Ubuntu
 
@@ -72,7 +75,7 @@ Falls du von einem blanken Debian/Ubuntu startest, bringen dich diese Befehle zu
 
 Nutze die zu diesem Tutorial gebündelten Dateien in `tutorials/hetzner-ddns-bridge/scripts`:
 
-> <small>Gespiegelt von https://github.com/woehrl/hetzner-dyndns, Commit `11582e6`. Kopiere sie auf deinen Webspace oder eine kleine VM.</small>
+> <small>Gespiegelt von https://github.com/woehrl/hetzner-dyndns, Commit `fbb3728`. Kopiere sie auf deinen Webspace oder eine kleine VM.</small>
 
 * [GitHub » tutorials/hetzner-ddns-bridge/scripts](https://github.com/hetzneronline/community-content/tree/master/tutorials/hetzner-ddns-bridge/scripts)
 
@@ -123,12 +126,13 @@ Bearbeite `hetzner_dyndns.config.php`:
 | -- | ------------ |
 | <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">auth_user</kbd> | Optional: Username für HTTP Basic Auth. Wenn leer, wird <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">update</kbd> verwendet. |
 | <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">auth_password</kbd> | Bestimme ein starkes, geteiltes Passwort. Dein Router nutzt es. |
-| <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">api_order</kbd> | Lege fest, welche API zuerst probiert wird: Verwende <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">['console', 'dns']</kbd> für Migration oder <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">['console']</kbd>, wenn alle Zonen auf der neuen API liegen. |
-| <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">console_token</kbd><br><kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">dns_token</kbd> | Tokens hinzufügen:<ul><li><b>Hetzner Console:</b> Erstelle ein API-Token in der Hetzner Console und trage es bei <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">console_token</kbd> ein.</li><li><b>DNS Console</b> (legacy): Erstelle ein DNS-Token in der DNS Console und trage es bei <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">dns_token</kbd> ein (nur wenn du dort noch Zonen hast).</li></ul> |
+| <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">console_token</kbd> | Erstelle in der Hetzner Console ein Projekt-API-Token mit Lese-/Schreibrechten für DNS und trage es hier ein. Pflichtfeld pro Realm. |
 | <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">zone_name</kbd> | Wenn die IP-Adresse für eine Subdomain (z.B. `sub.example.com`) aktualisiert werden soll, muss hier die Hauptdomain (z.B. `example.com`) angegeben werden. |
 | <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">auth_realm</kbd> | Optional: Wähle ein Label  (z. B. "dynbridge"). |
 | <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">history_db</kbd> | Optional: Zeige auf einen beschreibbaren Pfad (z. B.<br><kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">__DIR__ . '/hetzner_dyndns.sqlite3'</kbd>). |
 | TTL | Optional: Passe die TTL pro Realm an, wenn es schneller oder langsamer propagieren soll. |
+
+> **Hinweis für Bestandsinstallationen:** Die früheren Einstellungen `dns_token`, `dns_endpoint` und `api_order` gehörten zur abgeschalteten Legacy-API und werden ignoriert. Es genügt, pro Realm ein `console_token` zu ergänzen — der Rest der Config kann bleiben.
 
 ## Schritt 3 - Sicher ins Netz stellen
 
@@ -152,6 +156,7 @@ Bearbeite `hetzner_dyndns.config.php`:
     "https://dein-ddns-host.example.com/nic/update?hostname=myhost.example.com&myip=$(curl -s ifconfig.me)"
   ```
 - Erfolgreiche Antworten sind `good <ip>` (aktualisiert) oder `nochg <ip>` (nichts zu tun). Alles andere: ins Debug-Log schauen.
+- Kommt „No matching rrset found", existiert der A-/AAAA-Record noch nicht: einmalig in der Hetzner Console anlegen, dann klappt das Update.
 
 ## Schritt 5 - Automatisieren
 
@@ -159,50 +164,47 @@ Bearbeite `hetzner_dyndns.config.php`:
   ```bash
   */5 * * * * php /path/to/hetzner_dyndns.php --cron --realm=default
   ```
-- Richte deinen Router oder dein NAS auf dieselbe `nic/update`-URL mit dem gesetzten Passwort ein. IPv6 klappt, wenn der Client `myipv6` mitsendet.
+- Richte deinen Router oder dein NAS auf dieselbe `nic/update`-URL mit dem gesetzten Passwort ein.
+- IPv4 und IPv6 zusammen: entweder kommagetrennt über `myip=<IPv4>,<IPv6>` oder über einen dedizierten Parameter `myip6=<IPv6>` bzw. `myipv6=<IPv6>` (Fritz!Box: `myip=<ipaddr>&myip6=<ip6addr>` in der Update-URL).
+- IPv6-only/DS-Lite: einfach nur die IPv6 senden (`myip6=...` ohne `myip`) — das Skript aktualisiert dann ausschließlich den AAAA-Record und schreibt bewusst keine Carrier-IPv4 in den A-Record.
 - Legacy-Clients dürfen weiterhin `X-Authentication: <passwort>` oder `?p=<passwort>` (nur Passwort) senden, empfohlen ist Basic Auth.
 
 ## Schritt 6 - Kurzer Troubleshooting-Spickzettel
 
 - 401 oder Auth-Prompt: Passwort stimmt nicht oder `.htaccess` greift nicht.
-- `not_found`: falsche Zone oder Hostname, oder fehlende Token-Rechte.
+- `Zone not found on console API`: falscher `zone_name`, Zone liegt in einem anderen Console-Projekt oder das Token gehört zum falschen Projekt.
+- `No matching rrset found`: den A-/AAAA-Record einmalig in der Zone anlegen — das Skript legt bewusst keine Records an.
 - SQLite-Schreibfehler: Dateirechte anpassen oder DB in einen beschreibbaren Pfad verschieben.
-- Nichts ändert sich: `api_order` prüfen und das richtige Token pro Realm setzen.
+- Nichts ändert sich: `console_token` pro Realm prüfen (DNS-Schreibrechte!) und mit `debug` das Log ansehen.
 
 ## Nerd-Ecke (so funktioniert es wirklich)
 
 * **Architektur im Überblick**
   - Ein PHP-Skript, eine Config, eine SQLite-DB. DynDNS-Aufrufe (`/nic/update` oder `/v3/update`) werden via `.htaccess` auf `hetzner_dyndns.php` umgeschrieben.
-  - Das Skript authentifiziert mit Benutzername/Passwort, parst Hostname und optionales `realm`, cached bekannte Records in SQLite und antwortet sofort mit `good`, wenn sich nichts geändert hat.
+  - Das Skript authentifiziert mit Benutzername/Passwort, parst Hostname und optionales `realm`, cached den letzten IP-Stand und die Zonen-ID in SQLite und antwortet sofort mit `nochg`, wenn sich nichts geändert hat — ganz ohne API-Call.
 
 <br>
 
 * **Konfig-Details**
   - Gemeinsame Einstellungen: `auth_user`, `auth_password`, `auth_realm`, `history_db` sowie optional `debug`/`debug_log`.
   - Benachrichtigungen: `notifications.enabled` aktivieren, `php` oder `smtp` wählen, Empfänger setzen und entscheiden, ob bei Erfolg, Fehler oder beidem gemailt wird.
-  - Realms: pro Realm `ttl`, `api_order`, `zone_name`, `console_token` und `dns_token`. Setze `zone_name`, wenn der DynDNS-Endpunkt auf einer Subdomain liegt, du aber die Hauptzone aktualisierst.
+  - Realms: pro Realm `ttl`, `zone_name` und `console_token`. Setze `zone_name`, wenn der DynDNS-Endpunkt auf einer Subdomain liegt, du aber die Hauptzone aktualisierst.
 
 <br>
 
-* **"Hetzner Console"-API-Ablauf** (aktuell)
-  1. Zone über `/zones?name=<zone>` mit dem Hetzner Console API-Token finden.
+* **API-Ablauf (Hetzner Console)**
+  1. Zone über `/zones?name=<zone>` mit dem Hetzner Console API-Token finden — die Zonen-ID wird danach in SQLite gecacht, gealterte IDs heilen sich per erneutem Lookup selbst.
   2. RRsets über `/zones/{id}/rrsets` (A und AAAA) holen.
-  3. RRset-Namen mit dem Host abgleichen (inkl. `@` am Apex).
-  4. `set_records` aufrufen, um die IPs zu ersetzen. Erfolgreich = Action-Response; Fehler melden `not_found` oder fehlende Rechte.
+  3. Den RRset-Namen **exakt** mit dem Host abgleichen (inkl. `@` am Apex). Es wird nur der exakt passende Record aktualisiert; Fallbacks auf Eltern-Records gibt es absichtlich nicht.
+  4. `set_records` aufrufen, um die IPs zu ersetzen — und zwar nur für die Adressfamilien, die der Client tatsächlich geliefert hat (IPv4-only, Dual-Stack oder IPv6-only).
+  5. Fehler bleiben als `needs_sync` markiert und werden vom Cron erneut versucht.
 
 <br>
 
-* **"DNS Console"-API-Ablauf** (Legacy)
-  1. Zonen-ID mit `/zones?name=<zone>` über `dns_token` holen.
-  2. A/AAAA-Record-IDs finden, in SQLite cachen und per `PUT /records/{id}` aktualisieren.
-  3. Fehler bleiben als `needs_sync` für Cron-Retries markiert.
-
-<br>
-
-* **Wechsel zwischen den APIs**
-  - Nutze `['console', 'dns']` während der Migration. Wenn Hetzner Console `not_found` sagt, fällt das Skript auf DNS Console zurück.
-  - Wenn eine Zone komplett auf Hetzner Console läuft, `dns_token` entfernen oder auf `['console']` umstellen, um Legacy-Calls zu sparen und dem DNS-Console-Abschaltplan voraus zu sein.
-  - Nach Config-Änderungen `php hetzner_dyndns.php --cron` ausführen, um offene Jobs abzuarbeiten und beide APIs zu testen.
+* **Migration von älteren Skript-Versionen**
+  - Die Legacy-API (`dns.hetzner.com/api/v1`) wurde von Hetzner im Mai 2026 abgeschaltet; der zugehörige Code-Pfad ist entfernt. Die Config-Schlüssel `dns_token`, `dns_endpoint` und `api_order` werden ignoriert (bei aktivem `debug` mit Hinweis im Log).
+  - Pro Realm ist jetzt ein `console_token` Pflicht; die SQLite-DB bleibt kompatibel und muss nicht angefasst werden.
+  - Nach dem Update einmal `php hetzner_dyndns.php --cron` ausführen, um offene Jobs abzuarbeiten — der Cron-Aufruf über die Kommandozeile benötigt (und akzeptiert) keine HTTP-Zugangsdaten.
 
 <br>
 
@@ -215,20 +217,21 @@ Bearbeite `hetzner_dyndns.config.php`:
 
 * **Benachrichtigungen und Observability**
   - E-Mails zu Erfolgen und Fehlern über PHP `mail()` oder SMTP.
-  - `debug` und `debug_log` zeichnen Requests und Responses beider APIs plus Benachrichtigungsstatus auf.
-  - Cron-Summen listen Gesamtzahl, Erfolge, Fehler und welche API jeden Host bearbeitet hat.
+  - `debug` und `debug_log` zeichnen alle API-Requests und -Responses plus Benachrichtigungsstatus auf.
+  - Cron-Summen listen Gesamtzahl, Erfolge und Fehler pro Host.
 
 <br>
 
 * **Sicherheit und Deployment**
   - `.htaccess` blockiert direkte Zugriffe auf PHP und SQLite und lässt nur die DynDNS-Endpunkte durch.
   - Tokens nur auf DNS scopen und regelmäßig rotieren.
+  - Passwortvergleiche laufen timing-sicher über `hash_equals()`.
   - SQLite-DB und Debug-Log müssen für den PHP-User schreibbar sein; nach Möglichkeit außerhalb öffentlicher Webroots ablegen.
-  - DynDNS-Endpunkt per HTTPS bereitstellen. Reines HTTP würde dein Passwort verraten.
+  - DynDNS-Endpunkt per HTTPS bereitstellen. Reines HTTP würde dein Passwort verraten. `?p=<passwort>` landet zudem in Server-Logs — wenn dein Client Basic Auth kann, nutze Basic Auth.
 
 ## Ergebnis
 
-Die Bridge liefert dir einen freundlichen DynDNS-Endpunkt, der Hetzners API-Umstellung überlebt. Starte mit dem Schnellstart, damit Updates laufen, und wirf dann einen Blick in die Nerd-Ecke, wenn du Realms, Benachrichtigungen oder das Verhältnis zwischen Hetzner Console und DNS Console feintunen willst.
+Die Bridge liefert dir einen freundlichen DynDNS-Endpunkt auf Basis der Hetzner Console API — inklusive IPv6-only-Support, Retry-Logik und sauberem DynDNS2-Protokoll. Starte mit dem Schnellstart, damit Updates laufen, und wirf dann einen Blick in die Nerd-Ecke, wenn du Realms, Benachrichtigungen oder die Migration von einer älteren Skript-Version feintunen willst.
 
 ##### License: MIT
 

--- a/tutorials/hetzner-ddns-bridge/01.de.md
+++ b/tutorials/hetzner-ddns-bridge/01.de.md
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/hetzner-ddns-bridge/de"
 slug: "hetzner-ddns-bridge"
-date: "2026-08-05"
+date: "2026-08-07"
 title: "Hetzner DynDNS Bridge für die Hetzner Console API"
 short_description: "Ein PHP-/SQLite-Skript, das einen DynDNS-Endpunkt bereitstellt und Hetzner-DNS-Zonen über die Hetzner Console API synchron hält."
 tags: ["Hetzner DNS", "Hetzner Console", "Automation", "PHP"]
@@ -153,7 +153,7 @@ Bearbeite `hetzner_dyndns.config.php`:
 - Nutze HTTP Basic Auth mit `auth_user`/`auth_password` (User defaultet auf `update`, wenn leer). DynDNS-Clients senden meist irgendeinen Usernamen plus das Passwort; per `curl` geht es so:
   ```bash
   curl -u user:deinPasswort \
-    "https://dein-ddns-host.example.com/nic/update?hostname=myhost.example.com&myip=$(curl -s ifconfig.me)"
+    "https://dein-ddns-host.example.com/nic/update?hostname=myhost.example.com&myip=$(curl -4 https://ip.hetzner.com)"
   ```
 - Erfolgreiche Antworten sind `good <ip>` (aktualisiert) oder `nochg <ip>` (nichts zu tun). Alles andere: ins Debug-Log schauen.
 - Kommt „No matching rrset found", existiert der A-/AAAA-Record noch nicht: einmalig in der Hetzner Console anlegen, dann klappt das Update.

--- a/tutorials/hetzner-ddns-bridge/01.en.md
+++ b/tutorials/hetzner-ddns-bridge/01.en.md
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/hetzner-ddns-bridge"
 slug: "hetzner-ddns-bridge"
-date: "2026-08-05"
+date: "2026-08-07"
 title: "Hetzner DynDNS Bridge for the Hetzner Console API"
 short_description: "How to use a PHP/SQLite-based bridge that provides a DynDNS endpoint and keeps Hetzner DNS zones in sync via the Hetzner Console API."
 tags: ["Hetzner DNS", "Hetzner Console", "Automation", "PHP"]
@@ -150,7 +150,7 @@ Edit `hetzner_dyndns.config.php`:
 - Use HTTP Basic Auth with your `auth_user`/`auth_password` (user defaults to `update` if empty). Most DynDNS clients send any username plus the password, and you can also `curl` it:
   ```bash
   curl -u update:yourSecret \
-    "https://your-ddns-host.example.com/nic/update?hostname=myhost.example.com&myip=$(curl -s ifconfig.me)"
+    "https://your-ddns-host.example.com/nic/update?hostname=myhost.example.com&myip=$(curl -4 https://ip.hetzner.com)"
   ```
 - A happy response is `good <ip>` (updated) or `nochg <ip>` (nothing to do). Anything else means check the debug log.
 - If you get "No matching rrset found", the A/AAAA record does not exist yet: create it once in the Hetzner Console, then the update will succeed.

--- a/tutorials/hetzner-ddns-bridge/01.en.md
+++ b/tutorials/hetzner-ddns-bridge/01.en.md
@@ -2,9 +2,9 @@
 SPDX-License-Identifier: MIT
 path: "/tutorials/hetzner-ddns-bridge"
 slug: "hetzner-ddns-bridge"
-date: "2026-02-03"
-title: "Hetzner DynDNS Bridge: Hetzner Console + DNS Console API Support"
-short_description: "How to use a PHP/SQLite-based bridge that keeps Hetzner DNS zones in sync via the APIs of DNS Console API (legacy) and Hetzner Console API."
+date: "2026-08-05"
+title: "Hetzner DynDNS Bridge for the Hetzner Console API"
+short_description: "How to use a PHP/SQLite-based bridge that provides a DynDNS endpoint and keeps Hetzner DNS zones in sync via the Hetzner Console API."
 tags: ["Hetzner DNS", "Hetzner Console", "Automation", "PHP"]
 author: "woehrl"
 author_link: "https://github.com/woehrl"
@@ -18,14 +18,17 @@ cta: "cloud"
 
 ## Introduction
 
-Need your IPv4/IPv6 address to follow you around the internet without babysitting your DNS? This tutorial walks you through a small PHP script that pretends to be a DynDNS server, speaks to both [Hetzner Console](https://console.hetzner.com/) API and the legacy [DNS Console](https://dns.hetzner.com/) API, and plays nice with routers like a Fritz!Box. The first half is a hand-holding setup guide. The second half is the nerd zone with all the gory details. New DNS zones can no longer be created in DNS Console (as of 10 Nov 2025); plan to migrate every zone to Hetzner Console and only keep DNS Console enabled while you finish that move.
+Need your IPv4/IPv6 address to follow you around the internet without babysitting your DNS? This tutorial walks you through a small PHP script that pretends to be a DynDNS server, talks to the [Hetzner Console](https://console.hetzner.com/) API, and plays nice with routers like a Fritz!Box. The first half is a hand-holding setup guide. The second half is the nerd zone with all the gory details.
+
+> **Update August 2026:** Hetzner shut down the old DNS Console (`dns.hetzner.com`) and its legacy API in May 2026; remaining zones were migrated to the Hetzner Console automatically. This tutorial and the script have been updated accordingly and now use the Hetzner Console API exclusively. Also new: support for IPv6-only connections (DS-Lite), dedicated `myip6`/`myipv6` parameters, and protocol-compliant `nochg` responses. If you still run an older version of the script, see the migration notes in the nerd corner.
 
 **Prerequisites**
 
-- A Hetzner account with at least one DNS zone (Hetzner Console or DNS Console during migration).
+- A Hetzner account with at least one DNS zone in the [Hetzner Console](https://console.hetzner.com/).
 - PHP with the `curl` and `SQLite3` extensions (typical web hosting or a small VM works fine).
 - Somewhere to drop a PHP file and run cron every few minutes.
 - A client that can call a DynDNS-style URL (router, NAS, or a simple curl command).
+- The A/AAAA records you want to update must already exist in the zone — the script only changes values and deliberately never creates records.
 
 ## Step 0 - Minimalistic example setup on Debian/Ubuntu
 
@@ -72,7 +75,7 @@ If you start from a fresh minimal Debian/Ubuntu host, this gets you to a working
 
 Use the files bundled with this tutorial in `tutorials/hetzner-ddns-bridge/scripts`:
 
-> <small>Mirrored from https://github.com/woehrl/hetzner-dyndns, commit `11582e6`</small>
+> <small>Mirrored from https://github.com/woehrl/hetzner-dyndns, commit `fbb3728`</small>
 
 * [GitHub » tutorials/hetzner-ddns-bridge/scripts](https://github.com/hetzneronline/community-content/tree/master/tutorials/hetzner-ddns-bridge/scripts)
 
@@ -120,12 +123,13 @@ Edit `hetzner_dyndns.config.php`:
 | -- | ----------- |
 | <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">auth_user</kbd> | Optional: Username for HTTP Basic Auth. If empty, it defaults to <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">update</kbd>. |
 | <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">auth_password</kbd> | Set a strong shared password. Your router will use this. |
-| <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">api_order</kbd> | Decide which API to try first: set to <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">['console', 'dns']</kbd> for a smooth migration or <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">['console']</kbd> once every zone is on the new API. |
-| <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">console_token</kbd><br><kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">dns_token</kbd> | Add tokens:<ul><li><b>Hetzner Console:</b> create a API token in the Hetzner Console and paste it into <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">console_token</kbd>.</li><li><b>DNS Console</b> (legacy): create a DNS token in DNS Console and paste it into <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">dns_token</kbd> (only if you still host zones there).</li></ul> |
+| <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">console_token</kbd> | Create a project API token with DNS read/write permissions in the Hetzner Console and paste it here. Required per realm. |
 | <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">zone_name</kbd> | If you want to update the IP address of a subdomain (e.g. `sub.example.com`), specify the parent domain (e.g. `example.com`) here. |
 | <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">auth_realm</kbd> | Optionally: Pick a label (anything friendly like "dynbridge"). |
 | <kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">history_db</kbd> | Optionally: Point to a writable path (for example<br><kbd style="background-color:#e2e2e2!important;color:#000;border-radius:6px;">__DIR__ . '/hetzner_dyndns.sqlite3'</kbd>). |
 | TTL | Optionally: Adjust TTL per realm if you want faster or slower propagation. |
+
+> **Note for existing installations:** The former settings `dns_token`, `dns_endpoint`, and `api_order` belonged to the shut-down legacy API and are now ignored. Simply add a `console_token` per realm — the rest of your config can stay as it is.
 
 ## Step 3 - Put it on the internet (safely)
 
@@ -148,7 +152,8 @@ Edit `hetzner_dyndns.config.php`:
   curl -u update:yourSecret \
     "https://your-ddns-host.example.com/nic/update?hostname=myhost.example.com&myip=$(curl -s ifconfig.me)"
   ```
-- A happy response is `good <ip>` (already updated) or `nochg <ip>` (nothing to do). Anything else means check the debug log.
+- A happy response is `good <ip>` (updated) or `nochg <ip>` (nothing to do). Anything else means check the debug log.
+- If you get "No matching rrset found", the A/AAAA record does not exist yet: create it once in the Hetzner Console, then the update will succeed.
 
 ## Step 5 - Make it automatic
 
@@ -156,50 +161,47 @@ Edit `hetzner_dyndns.config.php`:
   ```bash
   */5 * * * * php /path/to/hetzner_dyndns.php --cron --realm=default
   ```
-- Point your router or NAS DynDNS profile to the same `nic/update` URL with the password you set. IPv6 works too when the client sends `myipv6`.
+- Point your router or NAS DynDNS profile to the same `nic/update` URL with the password you set.
+- IPv4 and IPv6 together: either comma-separated via `myip=<IPv4>,<IPv6>` or via a dedicated parameter `myip6=<IPv6>` / `myipv6=<IPv6>` (Fritz!Box: use `myip=<ipaddr>&myip6=<ip6addr>` in the update URL).
+- IPv6-only/DS-Lite: just send the IPv6 address (`myip6=...` without `myip`) — the script then updates only the AAAA record and deliberately never writes a carrier-grade IPv4 into the A record.
 - Legacy clients can still send `X-Authentication: <password>` or `?p=<password>` (password-only), but Basic Auth is recommended.
 
 ## Step 6 - Quick troubleshooting checklist
 
 - 401 or prompt for auth: password mismatch or `.htaccess` not applied.
-- `not_found`: wrong zone or hostname, or missing token permissions.
+- `Zone not found on console API`: wrong `zone_name`, the zone lives in a different Console project, or the token belongs to the wrong project.
+- `No matching rrset found`: create the A/AAAA record in the zone once — the script deliberately never creates records.
 - SQLite write errors: fix file permissions or move the DB to a writable folder.
-- Nothing changes: check `api_order` and make sure you set the right token for the realm.
+- Nothing changes: verify the `console_token` per realm (DNS write permissions!) and check the log with `debug` enabled.
 
 ## Nerd corner (how it actually works)
 
 * **Architecture at a glance**
   - One PHP file, one config file, one SQLite database. Incoming DynDNS calls (`/nic/update` or `/v3/update`) are rewritten to `hetzner_dyndns.php`.
-  - The script authenticates with your shared username/password, parses the hostname and optional `realm` override, caches known records in SQLite, and returns `good` immediately when nothing changed.
+  - The script authenticates with your shared username/password, parses the hostname and optional `realm` override, caches the last known IPs and the zone ID in SQLite, and returns `nochg` immediately when nothing changed — without any API call.
 
 <br>
 
 * **Configuration deep dive**
   - Shared settings: `auth_user`, `auth_password`, `auth_realm`, `history_db`, and optional `debug`/`debug_log`.
   - Notifications: enable `notifications.enabled`, pick `php` or `smtp`, set recipients, and decide if you want messages on success, failure, or both.
-  - Realms: each realm holds `ttl`, `api_order`, `zone_name`, `console_token`, and `dns_token`. Override `zone_name` if your DynDNS endpoint lives on a subdomain but you update the parent zone.
+  - Realms: each realm holds `ttl`, `zone_name`, and `console_token`. Override `zone_name` if your DynDNS endpoint lives on a subdomain but you update the parent zone.
 
 <br>
 
-* **Hetzner Console API flow** (current API)
-  1. Resolve the zone via `/zones?name=<zone>` using the Hetzner Console API token.
+* **API flow (Hetzner Console)**
+  1. Resolve the zone via `/zones?name=<zone>` using the Hetzner Console API token — the zone ID is then cached in SQLite, and stale IDs heal themselves with a fresh lookup.
   2. Fetch RRsets via `/zones/{id}/rrsets` (A and AAAA).
-  3. Match the RRset name to your host (handles `@` at the apex).
-  4. Call `set_records` to replace the records with the new IPs. Successful calls return an action; failures log `not_found` or permission errors.
+  3. Match the RRset name to your host **exactly** (handles `@` at the apex). Only the exactly matching record is updated; there are intentionally no fallbacks to parent records.
+  4. Call `set_records` to replace the records with the new IPs — only for the address families the client actually supplied (IPv4-only, dual-stack, or IPv6-only).
+  5. Failures stay marked `needs_sync` and are retried by cron.
 
 <br>
 
-* **DNS Console API flow** (legacy)
-  1. Look up the zone ID with `/zones?name=<zone>` using `dns_token`.
-  2. Find A/AAAA record IDs, cache them in SQLite, and update via `PUT /records/{id}`.
-  3. Failures stay marked `needs_sync` for cron retries.
-
-<br>
-
-* **Transitioning between APIs**
-  - Use `['console', 'dns']` while migrating. If Hetzner Console says `not_found`, the script falls back to DNS Console.
-  - When a zone is fully on Console, drop `dns_token` or switch to `['console']` to avoid legacy calls and to get ahead of the DNS Console shutdown timeline.
-  - Run `php hetzner_dyndns.php --cron` after config changes to flush pending work and confirm both APIs behave.
+* **Migrating from older script versions**
+  - The legacy API (`dns.hetzner.com/api/v1`) was shut down by Hetzner in May 2026; the corresponding code path has been removed. The config keys `dns_token`, `dns_endpoint`, and `api_order` are ignored (with a hint in the log when `debug` is enabled).
+  - A `console_token` is now required per realm; the SQLite database remains compatible and needs no changes.
+  - After updating, run `php hetzner_dyndns.php --cron` once to flush pending work — the CLI cron invocation neither needs nor accepts HTTP credentials.
 
 <br>
 
@@ -212,20 +214,21 @@ Edit `hetzner_dyndns.config.php`:
 
 * **Notifications and observability**
   - Email notifications report successes and failures using PHP `mail()` or SMTP.
-  - `debug` and `debug_log` capture request and response pairs for both APIs plus notification status.
-  - Cron summaries print totals, successes, failures, and which API handled each host.
+  - `debug` and `debug_log` capture all API request and response pairs plus notification status.
+  - Cron summaries print totals, successes, and failures per host.
 
 <br>
 
 * **Security and deployment notes**
   - `.htaccess` blocks direct hits to the PHP and SQLite files and only exposes the DynDNS endpoints.
   - Keep tokens scoped to DNS and rotate them periodically.
+  - Password comparisons are timing-safe via `hash_equals()`.
   - Ensure the SQLite DB and debug log are writable by the PHP user; keep them out of public web roots when possible.
-  - Use HTTPS on your DynDNS endpoint. Plain HTTP would leak your shared password.
+  - Use HTTPS on your DynDNS endpoint. Plain HTTP would leak your shared password. Also note that `?p=<password>` ends up in server logs — prefer Basic Auth whenever your client supports it.
 
 ## Conclusion
 
-The bridge gives you a friendly DynDNS endpoint that survives Hetzner's API migration. Start with the quickstart steps to get updates flowing, then dip into the nerd corner when you want to tune realms, notifications, or the Hetzner Console / DNS Console split.
+The bridge gives you a friendly DynDNS endpoint built on the Hetzner Console API — including IPv6-only support, retry logic, and clean dyndns2 protocol behavior. Start with the quickstart steps to get updates flowing, then dip into the nerd corner when you want to tune realms, notifications, or migrate from an older version of the script.
 
 ##### License: MIT
 

--- a/tutorials/hetzner-ddns-bridge/scripts/hetzner_dyndns.config.php.dist
+++ b/tutorials/hetzner-ddns-bridge/scripts/hetzner_dyndns.config.php.dist
@@ -2,9 +2,9 @@
 /**
  * Hetzner DNS Dynamic DNS configuration.
  *
- * Adjust the realms array below to match your zones, tokens, and preferences.
- * Each realm can define its own TTL, API endpoint tokens, and preferred order
- * of DNS providers (classic KonsoleH/dns plus the new Hetzner Console API).
+ * Adjust the realms array below to match your zones and tokens. Updates are
+ * performed via the Hetzner Console API (api.hetzner.cloud); the legacy DNS
+ * API (dns.hetzner.com) was shut down by Hetzner in May 2026.
  *
  * Copy this file to hetzner_dyndns.config.php, fill in the real tokens and passwords,
  * and keep it out of version control.
@@ -60,13 +60,11 @@ return [
         'default' => [
             'name' => 'default',
             'ttl' => 60,
-            'dns_endpoint' => 'https://dns.hetzner.com/api/v1',
+            // Hetzner Console API (project API token with DNS read/write permissions).
             'console_endpoint' => 'https://api.hetzner.cloud/v1',
-            'dns_token' => 'your-dns-api-token',
             'console_token' => 'your-console-api-token',
-            // Optional override if the zone uses a subdomain (e.g. sub.example.com).
-            'zone_name' => 'example.com',
-            'api_order' => ['dns', 'console'],
+            // Optional override if the zone uses a subdomain (e.g. ddns.example.com).
+            'zone_name' => 'ddns.example.com',
         ],
     ],
 ];

--- a/tutorials/hetzner-ddns-bridge/scripts/hetzner_dyndns.php
+++ b/tutorials/hetzner-ddns-bridge/scripts/hetzner_dyndns.php
@@ -3,8 +3,9 @@
  * Hetzner DNS Dynamic DNS Script (enhanced)
  *
  * Maintains per-realm configuration in a separate file, retries failed API calls,
- * and supports both the legacy DNS API and the newer Hetzner Console API so updates
- * are never silently dropped.
+ * and talks to the Hetzner Console API (api.hetzner.cloud) so updates are never
+ * silently dropped. The legacy DNS API (dns.hetzner.com) was shut down by Hetzner
+ * in May 2026 and its support has been removed from this script.
  *
  * `.htaccess` rewrites `/nic/update` and `/v3/update` into this file while blocking
  * direct requests, so the DynDNS-style paths remain viable long term.
@@ -56,10 +57,19 @@ if (!valid_hostname($hostname)) {
     exit('Invalid domain name');
 }
 
-$ipSource = $_GET['myip'] ?? resolve_client_ip();
+// Some routers send IPv6 via a dedicated parameter (FRITZ!Box: myip6, other
+// clients: myipv6) instead of a combined comma-separated myip list. When such
+// a parameter is present without myip, deliberately skip the remote-address
+// fallback: behind DS-Lite/CGNAT it would write a wrong carrier IPv4.
+$ipv6Param = $_GET['myipv6'] ?? $_GET['myip6'] ?? null;
+$ipSource = $_GET['myip'] ?? ($ipv6Param !== null ? null : resolve_client_ip());
 $ips = parse_ip_list($ipSource);
-if (!$ips['ipv4']) {
-    exit('No valid IPv4 address provided');
+$ipv6Extra = parse_ip_list($ipv6Param);
+if (!$ips['ipv6'] && $ipv6Extra['ipv6']) {
+    $ips['ipv6'] = $ipv6Extra['ipv6'];
+}
+if (!$ips['ipv4'] && !$ips['ipv6']) {
+    exit('No valid IP address provided');
 }
 
 $split = split_hostname($hostname);
@@ -84,14 +94,15 @@ if (should_skip_update($historyRow, $ips)) {
         $storedIpv4,
         $storedIpv6
     ));
-    echo 'good ' . $ips['ipv4'];
+    // dyndns2 protocol: "nochg" signals that the IP was already up to date.
+    echo 'nochg ' . ($ips['ipv4'] ?? $ips['ipv6']);
     exit;
 }
 
-$result = sync_host($db, $config, $realmKey, $realmConfig, $hostname, $domain, $zoneLookupName, $hostnameName, $ips, $historyRow);
+$result = sync_host($db, $config, $realmKey, $realmConfig, $hostname, $zoneLookupName, $hostnameName, $ips, $historyRow);
 send_notification($config['notifications'] ?? [], $realmKey, $hostname, $ips, $result);
 if ($result['success']) {
-    echo 'good ' . $ips['ipv4'];
+    echo 'good ' . ($ips['ipv4'] ?? $ips['ipv6']);
     exit;
 }
 
@@ -141,11 +152,13 @@ function get_realm_config(array $config, string $realmKey): array
         throw new RuntimeException('Realm not defined: ' . $realmKey);
     }
 
-    $realm['dns_endpoint'] = rtrim($realm['dns_endpoint'] ?? 'https://dns.hetzner.com/api/v1', '/');
     $realm['console_endpoint'] = rtrim($realm['console_endpoint'] ?? 'https://api.hetzner.cloud/v1', '/');
     $realm['ttl'] = $realm['ttl'] ?? 60;
-    $realm['api_order'] = array_values(array_filter($realm['api_order'] ?? ['dns', 'console']));
     $realm['zone_name'] = trim($realm['zone_name'] ?? '');
+
+    if (!empty($realm['dns_token']) || !empty($realm['dns_endpoint']) || !empty($realm['api_order'])) {
+        log_debug('Legacy DNS API settings (dns_token/dns_endpoint/api_order) are ignored; the legacy API was shut down by Hetzner in May 2026.');
+    }
 
     return $realm;
 }
@@ -175,6 +188,13 @@ function get_cron_context(): array
  */
 function authenticate(array $config): void
 {
+    // CLI invocations (cron) cannot carry HTTP credentials; having shell access
+    // to the host implies authorization. Without this, `--cron` always failed
+    // with "Unauthorized".
+    if (PHP_SAPI === 'cli') {
+        return;
+    }
+
     $realmLabel = $config['auth_realm'] ?? 'My Dynamic DNS service';
     $user = trim((string) ($config['auth_user'] ?? ''));
     if ($user === '') {
@@ -189,42 +209,43 @@ function authenticate(array $config): void
     }
     $authValue = $_SERVER['HTTP_X_AUTHENTICATION'] ?? null;
 
-    if (isset($_SERVER['PHP_AUTH_DIGEST'])) {
-        $digest = $_SERVER['PHP_AUTH_DIGEST'];
-        $expected = md5($user . ':' . $passwords[0]);
-        if (strpos($digest, 'username="' . $user . '"') === false || strpos($digest, 'response="' . $expected . '"') === false) {
-            send_auth_headers($realmLabel);
-        }
-        return;
-    }
-
     if (isset($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'])) {
         foreach ($passwords as $password) {
-            if ($_SERVER['PHP_AUTH_USER'] === $user && $_SERVER['PHP_AUTH_PW'] === $password) {
+            if (hash_equals($user, (string) $_SERVER['PHP_AUTH_USER']) && hash_equals($password, (string) $_SERVER['PHP_AUTH_PW'])) {
                 return;
             }
         }
         send_auth_headers($realmLabel);
     }
 
-    if ($authValue !== null && in_array($authValue, $passwords, true)) {
+    if ($authValue !== null && password_in_list($authValue, $passwords)) {
         return;
     }
 
     if (isset($_SERVER['HTTP_AUTHORIZATION']) && strpos($_SERVER['HTTP_AUTHORIZATION'], 'Basic ') === 0) {
         [$basicUser, $basicPass] = array_pad(explode(':', base64_decode(substr($_SERVER['HTTP_AUTHORIZATION'], 6)), 2), 2, '');
         foreach ($passwords as $password) {
-            if ($basicUser === $user && $basicPass === $password) {
+            if (hash_equals($user, $basicUser) && hash_equals($password, $basicPass)) {
                 return;
             }
         }
     }
 
-    if (isset($_GET['p']) && in_array($_GET['p'], $passwords, true)) {
+    if (isset($_GET['p']) && password_in_list((string) $_GET['p'], $passwords)) {
         return;
     }
 
     send_auth_headers($realmLabel);
+}
+
+function password_in_list(string $candidate, array $passwords): bool
+{
+    foreach ($passwords as $password) {
+        if (hash_equals($password, $candidate)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 function send_auth_headers(string $realm): void
@@ -272,7 +293,13 @@ function parse_ip_list(?string $ip): array
 
 function valid_hostname(string $hostname): bool
 {
-    return (bool) preg_match('/^([a-z0-9](-*[a-z0-9])*)+(\.[a-z]{2,})+$/i', $hostname);
+    // At least two labels are required so split_hostname() can derive a zone;
+    // filter_var alone would also accept single-label names like "example".
+    if (strpos($hostname, '.') === false) {
+        return false;
+    }
+
+    return filter_var($hostname, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) !== false;
 }
 
 function split_hostname(string $hostname): array
@@ -377,10 +404,9 @@ function should_skip_update(?array $row, array $ips): bool
 /**
  * Coordinate the update attempt, record the results, and mark rows for cron retries when needed.
  */
-function sync_host(SQLite3 $db, array $config, string $realmKey, array $realmConfig, string $hostname, string $domain, string $zoneName, string $hostnameName, array $ips, ?array $historyRow): array
+function sync_host(SQLite3 $db, array $config, string $realmKey, array $realmConfig, string $hostname, string $zoneName, string $hostnameName, array $ips, ?array $historyRow): array
 {
-    // Attempt to update DNS records by iterating over all configured APIs until one succeeds.
-    $attempt = try_update($realmConfig, $domain, $zoneName, $hostnameName, $ips, $historyRow);
+    $attempt = try_update($realmConfig, $zoneName, $hostnameName, $ips, $historyRow);
     $needsSync = !$attempt['success'];
     $retryCount = $needsSync ? min(($historyRow['retry_count'] ?? 0) + 1, $config['max_retry_attempts'] ?? 5) : 0;
     $pendingSince = $needsSync ? ($historyRow['pending_since'] ?? time()) : null;
@@ -389,9 +415,9 @@ function sync_host(SQLite3 $db, array $config, string $realmKey, array $realmCon
         $hostname,
         $realmKey,
         $ips,
-        $attempt['zone_id'],
-        $attempt['recordA_id'],
-        $attempt['recordAAAA_id'],
+        $attempt['zone_id'] ?? null,
+        null,
+        null,
         $needsSync,
         $retryCount,
         $attempt['message'],
@@ -402,135 +428,28 @@ function sync_host(SQLite3 $db, array $config, string $realmKey, array $realmCon
 }
 
 /**
- * Attempt each configured API in order, carrying over the latest zone/record IDs.
+ * Run the update against the Hetzner Console API, reusing the cached zone ID
+ * when available and falling back to a fresh zone lookup if that fails.
  */
-function try_update(array $realmConfig, string $domain, string $zoneName, string $hostnameName, array $ips, ?array $historyRow): array
+function try_update(array $realmConfig, string $zoneName, string $hostnameName, array $ips, ?array $historyRow): array
 {
-    $zoneId = $historyRow['zone_id'] ?? null;
-    $recordAId = $historyRow['recordA_id'] ?? null;
-    $recordAAAAId = $historyRow['recordAAAA_id'] ?? null;
-    $errors = [];
-
-    foreach ($realmConfig['api_order'] as $api) {
-        if ($api === 'dns') {
-            if (empty($realmConfig['dns_token'])) {
-                continue;
-            }
-            $response = update_via_dns_api($realmConfig, $domain, $zoneName, $hostnameName, $ips, $zoneId, $recordAId, $recordAAAAId);
-        } elseif ($api === 'console') {
-            if (empty($realmConfig['console_token'])) {
-                continue;
-            }
-            $response = update_via_console_api($realmConfig, $zoneName, $hostnameName, $ips, null);
-        } else {
-            continue;
-        }
-
-        $zoneId = $response['zone_id'] ?? $zoneId;
-        $recordAId = $response['recordA_id'] ?? $recordAId;
-        $recordAAAAId = $response['recordAAAA_id'] ?? $recordAAAAId;
-
-        if ($response['success']) {
-            return array_merge($response, [
-                'zone_id' => $zoneId,
-                'recordA_id' => $recordAId,
-                'recordAAAA_id' => $recordAAAAId,
-                'api_used' => $api,
-            ]);
-        }
-
-        $errors[] = sprintf('%s API error: %s', strtoupper($api), $response['message']);
-    }
-
-    return [
-        'success' => false,
-        'message' => implode(' | ', $errors) ?: 'No API configured',
-        'zone_id' => $zoneId,
-        'recordA_id' => $recordAId,
-        'recordAAAA_id' => $recordAAAAId,
-    ];
-}
-
-/**
- * Update the legacy Hetzner DNS zone/records, looking up record IDs when missing.
- */
-function update_via_dns_api(array $realmConfig, string $domain, string $zoneName, string $hostnameName, array $ips, ?string $zoneId, ?string $recordAId, ?string $recordAAAAId): array
-{
-    $ttl = $realmConfig['ttl'];
-    $endpoint = $realmConfig['dns_endpoint'];
-    $token = $realmConfig['dns_token'];
-    log_debug(sprintf('DNS API update prepared for %s (%s) in zone "%s" via %s', $hostnameName, $domain, $zoneName, $endpoint));
-
-    if (!$zoneId) {
-        $zoneId = fetch_zone_id($endpoint, $token, $zoneName);
-        if (!$zoneId) {
-            log_debug(sprintf('DNS API zone lookup failed for "%s" (derived "%s")', $zoneName, $domain));
-            return ['success' => false, 'message' => 'Zone not found', 'zone_id' => null];
-        }
-        log_debug(sprintf('DNS API resolved zone "%s" to id %s', $zoneName, $zoneId));
-    }
-
-    if (!$recordAId || !$recordAAAAId) {
-        $records = fetch_records($endpoint, $token, $zoneId, $hostnameName);
-        $recordAId = $recordAId ?: $records['A'] ?? null;
-        $recordAAAAId = $recordAAAAId ?: $records['AAAA'] ?? null;
-    }
-
-    if (!$recordAId) {
-        return ['success' => false, 'message' => 'Missing A record ID', 'zone_id' => $zoneId];
-    }
-
-    $payload = [
-        'value' => $ips['ipv4'],
-        'ttl' => $ttl,
-        'type' => 'A',
-        'name' => $hostnameName,
-        'zone_id' => $zoneId,
-    ];
-
-    $response = http_request('PUT', $endpoint . '/records/' . $recordAId, [
-        'Content-Type: application/json',
-        'Auth-API-Token: ' . $token,
-    ], $payload);
-
-        log_debug(sprintf('DNS API AAAA-record update returned %s', $response['success'] ? 'success' : 'failure'));
-        if (!$response['success']) {
-            return [
+    if (empty($realmConfig['console_token'])) {
+        return [
             'success' => false,
-            'message' => $response['error'] ?? 'Failed to update A record',
-            'zone_id' => $zoneId,
+            'message' => 'No console_token configured for this realm (the legacy DNS API was shut down in May 2026)',
+            'zone_id' => $historyRow['zone_id'] ?? null,
         ];
     }
 
-    if ($ips['ipv6'] && $recordAAAAId) {
-        $payload = [
-            'value' => $ips['ipv6'],
-            'ttl' => $ttl,
-            'type' => 'AAAA',
-            'name' => $hostnameName,
-            'zone_id' => $zoneId,
-        ];
-        $response = http_request('PUT', $endpoint . '/records/' . $recordAAAAId, [
-            'Content-Type: application/json',
-            'Auth-API-Token: ' . $token,
-        ], $payload);
-        if (!$response['success']) {
-            return [
-                'success' => false,
-                'message' => $response['error'] ?? 'Failed to update AAAA record',
-                'zone_id' => $zoneId,
-                'recordA_id' => $recordAId,
-            ];
-        }
+    $cachedZoneId = $historyRow['zone_id'] ?? null;
+    $response = update_via_console_api($realmConfig, $zoneName, $hostnameName, $ips, $cachedZoneId);
+    if (!$response['success'] && $cachedZoneId) {
+        log_debug('Update with cached zone id failed; retrying with a fresh zone lookup');
+        $response = update_via_console_api($realmConfig, $zoneName, $hostnameName, $ips, null);
     }
 
-    return [
-        'success' => true,
-        'message' => 'DNS record updated via classic API',
-        'zone_id' => $zoneId,
-        'recordA_id' => $recordAId,
-        'recordAAAA_id' => $recordAAAAId,
-    ];
+    $response['api_used'] = 'console';
+    return $response;
 }
 
 /**
@@ -552,7 +471,6 @@ function update_via_console_api(array $realmConfig, string $zoneName, string $ho
         log_debug(sprintf('Console API resolved zone "%s" to id %s', $zoneName, $zoneId));
     }
 
-    $ttl = $realmConfig['ttl'];
     $nameCandidates = build_rrset_candidates($hostnameName);
     $updates = [
         'A' => $ips['ipv4'],
@@ -594,7 +512,7 @@ function update_via_console_api(array $realmConfig, string $zoneName, string $ho
     if ($hadMissing) {
         return [
             'success' => false,
-            'message' => 'Console rrset names missing',
+            'message' => 'No matching rrset found for the host; create the A/AAAA record in the zone first',
             'zone_id' => $zoneId,
         ];
     }
@@ -604,38 +522,6 @@ function update_via_console_api(array $realmConfig, string $zoneName, string $ho
         'message' => 'Records updated via Hetzner Console API',
         'zone_id' => $zoneId,
     ];
-}
-
-function fetch_zone_id(string $endpoint, string $token, string $zoneName): ?string
-{
-    $response = http_request('GET', $endpoint . '/zones?name=' . urlencode($zoneName), [
-        'Content-Type: application/json',
-        'Auth-API-Token: ' . $token,
-    ]);
-
-    $zones = $response['data']['zones'] ?? [];
-    if (!empty($zones)) {
-        return $zones[0]['id'] ?? null;
-    }
-
-    return null;
-}
-
-function fetch_records(string $endpoint, string $token, string $zoneId, string $hostnameName): array
-{
-    $response = http_request('GET', $endpoint . '/records?zone_id=' . urlencode($zoneId), [
-        'Content-Type: application/json',
-        'Auth-API-Token: ' . $token,
-    ]);
-
-    $result = ['A' => null, 'AAAA' => null];
-    foreach ($response['data']['records'] ?? [] as $record) {
-        if ($record['name'] === $hostnameName && in_array($record['type'], ['A', 'AAAA'], true)) {
-            $result[$record['type']] = $record['id'];
-        }
-    }
-
-    return $result;
 }
 
 function fetch_console_zone_id(string $endpoint, string $token, string $zoneName): ?string
@@ -690,14 +576,10 @@ function build_rrset_candidates(string $hostnameName): array
         return ['@'];
     }
 
-    $parts = explode('.', $hostnameName);
-    $candidates = [];
-    for ($i = 0, $len = count($parts); $i < $len; $i++) {
-        $candidates[] = implode('.', array_slice($parts, 0, $len - $i));
-    }
-    $candidates[] = '@';
-
-    return array_filter(array_unique($candidates));
+    // Only the exact rrset name may be updated. Falling back to parent labels
+    // or the zone apex (as earlier versions did) silently rewrote unrelated
+    // records when the requested host had no rrset of its own.
+    return [$hostnameName];
 }
 
 /**
@@ -1077,13 +959,16 @@ function process_pending_updates(SQLite3 $db, array $config, ?string $realmFilte
             $hostnameName = $overriddenHostnameName === '' ? '@' : $overriddenHostnameName;
         }
         $ips = ['ipv4' => $row['ip'], 'ipv6' => $row['ip6']];
-        $result = sync_host($db, $config, $realmKey, $realmConfig, $row['hostname'], $domain, $zoneLookupName, $hostnameName, $ips, $row);
-        if ($result['success']) {
+        // Note: do NOT reuse $result here - it still holds the SQLite3Result the
+        // while loop iterates over; overwriting it crashed the cron after the
+        // first pending row.
+        $attempt = sync_host($db, $config, $realmKey, $realmConfig, $row['hostname'], $zoneLookupName, $hostnameName, $ips, $row);
+        if ($attempt['success']) {
             $summary['success']++;
-            $summary['details'][$row['hostname']] = ['status' => 'success', 'api' => $result['api_used'] ?? $result['api'] ?? 'unknown'];
+            $summary['details'][$row['hostname']] = ['status' => 'success', 'api' => $attempt['api_used'] ?? 'unknown'];
         } else {
             $summary['failed']++;
-            $summary['details'][$row['hostname']] = ['status' => 'failed', 'message' => $result['message']];
+            $summary['details'][$row['hostname']] = ['status' => 'failed', 'message' => $attempt['message']];
         }
     }
 


### PR DESCRIPTION
Update of my tutorial [hetzner-ddns-bridge](https://community.hetzner.com/tutorials/hetzner-ddns-bridge) (both language versions) plus the mirrored scripts.

**Why:** The legacy DNS API (`dns.hetzner.com/api/v1`) was shut down in May 2026 (the endpoint now redirects to console.hetzner.com), so the previous instructions covering the DNS-Console-to-Console migration and the `api_order`/`dns_token` settings are obsolete.

**Changes:**
- Tutorial (de + en): rewritten for the Hetzner Console API only; added an update note, migration hints for existing installations of the script, refreshed config table, troubleshooting entries, and security notes. Titles/short descriptions adjusted accordingly.
- `scripts/`: synced from [woehrl/hetzner-dyndns](https://github.com/woehrl/hetzner-dyndns) commit `fbb3728`. Highlights since the previously mirrored commit `11582e6`:
  - legacy DNS API code path removed
  - IPv6-only (DS-Lite) connections supported; dedicated `myip6`/`myipv6` parameters accepted (FRITZ!Box-friendly)
  - dyndns2-compliant `nochg` responses
  - bug fixes: hostname validation for subdomains, cron retry processing, CLI cron authentication, strict rrset matching (no accidental apex updates), timing-safe password checks
- `date` fields bumped to the revision date; author, license and Contributor's Certificate of Origin unchanged.

All changes were tested end-to-end against a mocked Console API (update, IPv6-only, apex, missing rrset, cron retry paths).

---

I have read and understood the Contributor's Certificate of Origin available at the end of 
https://raw.githubusercontent.com/hetzneronline/community-content/master/tutorial-template.md
and I hereby certify that I meet the contribution criteria described in it.
Signed-off-by: Florian Woehrl <fw@woehrl.biz>